### PR TITLE
upgrade lager version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
        , {jsx,    "2.9.0"}
        , {cowlib, "2.3.0"}
        , {redbug, "1.2.1"}
-       , {lager,  "3.6.3"}
+       , {lager,  "3.6.8"}
        ]
 }.
 {relx, [ { release

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.3.0">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.9.0">>},0},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.6.3">>},0},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.8">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.5.0">>},0},
  {<<"redbug">>,{pkg,<<"redbug">>,<<"1.2.1">>},0}]}.
 [
@@ -10,7 +10,7 @@
  {<<"cowlib">>, <<"BBD58EF537904E4F7C1DD62E6AA8BC831C8183CE4EFA9BD1150164FE15BE4CAA">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
  {<<"jsx">>, <<"D2F6E5F069C00266CAD52FB15D87C428579EA4D7D73A33669E12679E203329DD">>},
- {<<"lager">>, <<"FE78951D174616273F87F0DBC3374D1430B1952E5EFC4E1C995592D30A207294">>},
+ {<<"lager">>, <<"897EFC7679BB82383448646C96768CDC4E747464DD18B999C7AACA485686B0DA">>},
  {<<"ranch">>, <<"F04166F456790FEE2AC1AA05A02745CC75783C2BFB26D39FAF6AEFC9A3D3A58A">>},
  {<<"redbug">>, <<"9153EE50E42C39CE3F6EFA65EE746F4A52896DA66862CFB59E7C0F838B7B8414">>}]}
 ].


### PR DESCRIPTION
Hello 

I cannnot compile this project, Because lager version is old.
```
rebar3 shell
===> Verifying dependencies...
===> Compiling lager
/Users/takuya.hirata/erlang_ls/_build/default/lib/lager/src/lager_util.erl: redefining predefined macro 'FUNCTION_NAME'
===> Compiling _build/default/lib/lager/src/lager_util.erl failed
_build/default/lib/lager/src/lager_util.erl:none: redefining predefined macro 'FUNCTION_NAME'
```

So upgrade lager version.

please checkout.

thank you.