### PR TITLE
Avoid exceptions when analyzing the syntax tree

### DIFF
--- a/src/erlang_ls_code_navigation.erl
+++ b/src/erlang_ls_code_navigation.erl
@@ -54,7 +54,7 @@ goto_definition( _Filename
 %% TODO: Eventually search everywhere and suggest a code lens to include a file
 goto_definition(Filename, #{ info := {macro, _Define} = Info }, Path) ->
   search(filename:basename(Filename), Path, definition(Info));
-goto_definition(Filename, #{ info := {record_access, {_Record, _Var}} = Info }, Path) ->
+goto_definition(Filename, #{ info := {record_access, {_Record, _Field}} = Info }, Path) ->
   search(filename:basename(Filename), Path, definition(Info));
 goto_definition(Filename, #{ info := {record_expr, _Record} = Info }, Path) ->
   search(filename:basename(Filename), Path, definition(Info));
@@ -111,7 +111,7 @@ definition({import_entry, {_M, F, A}}) ->
   {function, {F, A}};
 definition({macro, Define}) ->
   {define, Define};
-definition({record_access, {Record, _Variable}}) ->
+definition({record_access, {Record, _Field}}) ->
   {record, Record};
 definition({record_expr, Record}) ->
   {record, Record};

--- a/src/erlang_ls_poi.erl
+++ b/src/erlang_ls_poi.erl
@@ -129,8 +129,8 @@ get_range({Line, Column}, {module, _}, _Extra) ->
   From = {Line, Column},
   To = From,
   #{ from => From, to => To };
-get_range(Pos, {record_access, {Record, Var}}, _Extra) ->
-  #{ from => minus(Pos, Var), to => plus(Pos, Record) };
+get_range(Pos, {record_access, {Record, Field}}, _Extra) ->
+  #{ from => minus(Pos, "#"), to => plus(Pos, Record ++ "." ++ Field) };
 get_range({Line, Column}, {record_expr, Record}, _Extra) ->
   From = {Line, Column - 1},
   To = {Line, Column + length(Record) - 1},

--- a/src/erlang_ls_tree.erl
+++ b/src/erlang_ls_tree.erl
@@ -97,53 +97,75 @@ points_of_interest(Tree) ->
 %% @edoc Return the list of points of interest for a given `Tree`.
 -spec points_of_interest(tree(), extra()) -> [erlang_ls_poi:poi()].
 points_of_interest(Tree, Extra) ->
-  Type = erl_syntax:type(Tree),
-  try points_of_interest(Tree, Type, Extra)
+  try
+    case erl_syntax:type(Tree) of
+      application   -> application(Tree, Extra);
+      attribute     -> attribute(Tree, Extra);
+      function      -> function(Tree, Extra);
+      implicit_fun  -> implicit_fun(Tree, Extra);
+      macro         -> macro(Tree, Extra);
+      record_access -> record_access(Tree, Extra);
+      record_expr   -> record_expr(Tree, Extra);
+      _             -> []
+    end
   catch
     Class:Reason:Stacktrace ->
-      lager:warning( "Could not analyze tree: ~p:~p ~p"
-                   , [Class, Reason, Stacktrace]),
+      Position = erl_syntax:get_pos(Tree),
+      lager:warning( "Could not analyze tree - error=~p:~p pos=~p "
+                     "stacktrace=~p"
+                   , [Class, Reason, Position, Stacktrace]),
       []
   end.
 
-%% @edoc Return the list of points of interest of a specific `Type`
-%% for a given `Tree`.
--spec points_of_interest(tree(), any(), [[erlang_ls_poi:pos()]]) -> [erlang_ls_poi:poi()].
-points_of_interest(Tree, application, Extra) ->
-  case erl_syntax_lib:analyze_application(Tree) of
-    {M, {F, A}} ->
-      %% Remote call
-      [erlang_ls_poi:poi(Tree, {application, {M, F, A}}, Extra)];
-    {F, A} ->
-      case lists:member({F, A}, erlang:module_info(exports)) of
-        true ->
-          %% Call to a function from the `erlang` module
-          [erlang_ls_poi:poi(Tree, {application, {erlang, F, A}}, Extra)];
-        false ->
-          %% Local call
-          [erlang_ls_poi:poi(Tree, {application, {F, A}}, Extra)]
+-spec application(tree(), extra()) -> [erlang_ls_poi:poi()].
+application(Tree, Extra) ->
+  MFA = case erl_syntax_lib:analyze_application(Tree) of
+          %% Remote call
+          {M, {F, A}} -> {M, F, A};
+          {F, A} ->
+            case lists:member({F, A}, erlang:module_info(exports)) of
+              %% Call to a function from the `erlang` module
+              true -> {erlang, F, A};
+              %% Local call
+              false -> {F, A}
+            end;
+          A when is_integer(A) ->
+            %% If the function is not explicitly named (e.g. a variable is
+            %% used as the module qualifier or the function name), only the
+            %% arity A is returned.
+            %% In the special case where the macro `?MODULE` is used as the
+            %% module qualifier, we can consider it as a local call.
+            Operator = erl_syntax:application_operator(Tree),
+            case erl_syntax:type(Operator) of
+              module_qualifier -> application_with_variable(Operator, A);
+              _                -> undefined
+            end
+        end,
+  case MFA of
+    undefined -> [];
+    _ -> [erlang_ls_poi:poi(Tree, {application, MFA}, Extra)]
+  end.
+
+-spec application_with_variable(tree(), arity()) ->
+  {atom(), arity()} | undefined.
+application_with_variable(Operator, A) ->
+  Module   = erl_syntax:module_qualifier_argument(Operator),
+  Function = erl_syntax:module_qualifier_body(Operator),
+  case {erl_syntax:type(Module), erl_syntax:type(Function)} of
+    %% Only in the case of ?MODULE:foo we return something
+    {macro, atom} ->
+      ModuleName   = node_name(Module),
+      FunctionName = node_name(Function),
+      case {ModuleName, FunctionName} of
+        {'MODULE', F} -> {F, A};
+        _ -> undefined
       end;
-    A when is_integer(A) ->
-      %% If the function is not explicitly named (e.g. a variable is
-      %% used as the module qualifier or the function name), only the
-      %% arity A is returned.
-      %% In the special case where the macro `?MODULE` is used as the
-      %% module qualifier, we can consider it as a local call.
-      Operator = erl_syntax:application_operator(Tree),
-      try { erl_syntax:variable_name(
-              erl_syntax:macro_name(
-                erl_syntax:module_qualifier_argument(Operator)))
-          , erl_syntax:atom_value(
-              erl_syntax:module_qualifier_body(Operator))
-          } of
-          {'MODULE', F} ->
-          [erlang_ls_poi:poi(Tree, {application, {'MODULE', F, A}}, Extra)]
-      catch _:_ ->
-          []
-      end
-  end;
-points_of_interest(Tree, attribute, Extra) ->
-  case erl_syntax_lib:analyze_attribute(Tree) of
+    _ -> undefined
+  end.
+
+-spec attribute(tree(), extra()) -> [erlang_ls_poi:poi()].
+attribute(Tree, Extra) ->
+  try erl_syntax_lib:analyze_attribute(Tree) of
     %% Yes, Erlang allows both British and American spellings for
     %% keywords.
     {behavior, {behavior, Behaviour}} ->
@@ -180,55 +202,90 @@ points_of_interest(Tree, attribute, Extra) ->
       [erlang_ls_poi:poi(Tree, {record, atom_to_list(Record)}, Extra)];
     {spec, {spec, {{F, A}, _}}} ->
       SpecLocations = maps:get(spec_locations, Extra, []),
-      Locations = proplists:get_value({F, A}, SpecLocations),
-      [erlang_ls_poi:poi(Tree, {type_application, {T, L}}, Extra) || {T, L} <- Locations];
+      case proplists:get_value({F, A}, SpecLocations) of
+        undefined ->
+          lager:warning("Spec location not found for ~p/~p", [F, A]),
+          [];
+        Locations ->
+          [erlang_ls_poi:poi(Tree, {type_application, {T, L}}, Extra) || {T, L} <- Locations]
+      end;
     {type, {type, Type}} ->
       %% TODO: Support type usages in type definitions
       TypeName = element(1, Type),
       [erlang_ls_poi:poi(Tree, {type_definition, TypeName}, Extra)];
     _ ->
       []
-  end;
-points_of_interest(Tree, function, Extra) ->
+  catch throw:syntax_error ->
+      []
+  end.
+
+-spec function(tree(), extra()) -> [erlang_ls_poi:poi()].
+function(Tree, Extra) ->
   {F, A} = erl_syntax_lib:analyze_function(Tree),
-  [erlang_ls_poi:poi(Tree, {function, {F, A}}, Extra)];
-points_of_interest(Tree, implicit_fun, Extra) ->
-  FunSpec = case erl_syntax_lib:analyze_implicit_fun(Tree) of
+  [erlang_ls_poi:poi(Tree, {function, {F, A}}, Extra)].
+
+-spec implicit_fun(tree(), extra()) -> [erlang_ls_poi:poi()].
+implicit_fun(Tree, Extra) ->
+  FunSpec = try erl_syntax_lib:analyze_implicit_fun(Tree) of
               {M, {F, A}} -> {M, F, A};
               {F, A} -> {F, A}
+            catch throw:syntax_error ->
+                undefined
             end,
-  [erlang_ls_poi:poi(Tree, {implicit_fun, FunSpec}, Extra)];
-points_of_interest(Tree, macro, Extra) ->
-  Name = erl_syntax:macro_name(Tree),
-  [erlang_ls_poi:poi(Tree, {macro, macro_name(Name)}, Extra)];
-points_of_interest(Tree, record_access, Extra) ->
-  Record = erl_syntax:atom_name(erl_syntax:record_access_type(Tree)),
-  Var = erl_syntax:variable_literal(
-          erl_syntax:record_access_argument(Tree)),
-  [erlang_ls_poi:poi(Tree, {record_access, {Record, Var}}, Extra)];
-points_of_interest(Tree, record_expr, Extra) ->
-  Record = erl_syntax:atom_name(erl_syntax:record_expr_type(Tree)),
-  [erlang_ls_poi:poi(Tree, {record_expr, Record}, Extra)];
-points_of_interest(_Tree, _Type, _Extra) ->
-  [].
+  case FunSpec of
+    undefined -> [];
+    _ -> [erlang_ls_poi:poi(Tree, {implicit_fun, FunSpec}, Extra)]
+  end.
+
+-spec macro(tree(), extra()) -> [erlang_ls_poi:poi()].
+macro(Tree, Extra) ->
+  case erl_syntax:get_pos(Tree) of
+    0 -> [];
+    _ -> [erlang_ls_poi:poi(Tree, {macro, node_name(Tree)}, Extra)]
+  end.
+
+-spec record_access(tree(), extra()) -> [erlang_ls_poi:poi()].
+record_access(Tree, Extra) ->
+  RecordNode = erl_syntax:record_access_type(Tree),
+  case erl_syntax:type(RecordNode) of
+    atom ->
+      Record = erl_syntax:atom_name(RecordNode),
+      Field = erl_syntax:atom_name(erl_syntax:record_access_field(Tree)),
+      [erlang_ls_poi:poi(Tree, {record_access, {Record, Field}}, Extra)];
+    _ ->
+      []
+  end.
+
+-spec record_expr(tree(), extra()) -> [erlang_ls_poi:poi()].
+record_expr(Tree, Extra) ->
+  RecordNode = erl_syntax:record_expr_type(Tree),
+  case erl_syntax:type(RecordNode) of
+    atom ->
+      Record = erl_syntax:atom_name(RecordNode),
+      [erlang_ls_poi:poi(Tree, {record_expr, Record}, Extra)];
+    _ ->
+      []
+  end.
 
 -spec define_name(tree()) -> atom().
 define_name(Tree) ->
   case erl_syntax:type(Tree) of
     application ->
       Operator = erl_syntax:application_operator(Tree),
-      macro_name(Operator);
+      node_name(Operator);
     variable ->
       erl_syntax:variable_name(Tree);
     atom ->
       erl_syntax:atom_value(Tree)
   end.
 
--spec macro_name(tree()) -> atom().
-macro_name(Tree) ->
+-spec node_name(tree()) -> atom().
+node_name(Tree) ->
   case erl_syntax:type(Tree) of
     atom ->
       erl_syntax:atom_value(Tree);
     variable ->
-      erl_syntax:variable_name(Tree)
+      erl_syntax:variable_name(Tree);
+    macro ->
+      node_name(erl_syntax:macro_name(Tree))
   end.


### PR DESCRIPTION
I tried indexing all of OTP with the changes in this branch and the only mesages printed are related to the missing spec locations. 