### PR TITLE
[Fixes #116] Allow non-whitespace chars just before module qualifier …

### DIFF
--- a/test/erlang_ls_completion_SUITE.erl
+++ b/test/erlang_ls_completion_SUITE.erl
@@ -73,4 +73,9 @@ exported_functions(Config) ->
                           }
                        ],
   ?assertEqual(Completion, ExpectedCompletion),
+
+  #{result := Completion} =
+    erlang_ls_client:completion(Uri, 52, 34, 2, <<":">>),
+  ?assertEqual(Completion, ExpectedCompletion),
+
   ok.


### PR DESCRIPTION
…(i.e. '(', '[', '{', ',' and ';') and also enything before that.

#116 