### PR TITLE
[#116] Refactor extraction of last token from text

### DIFF
--- a/src/erlang_ls_completion_provider.erl
+++ b/src/erlang_ls_completion_provider.erl
@@ -39,7 +39,8 @@ handle_request({completion, Params}, State) ->
    , <<"textDocument">> := #{<<"uri">> := Uri
                             }
    } = Params,
-  {ok, #{text := Text}} = erlang_ls_db:find(documents, Uri),
+  {ok, Document} = erlang_ls_db:find(documents, Uri),
+  Text = erlang_ls_document:text(Document),
   case maps:find(<<"context">>, Params) of
     {ok, Context} ->
       TriggerKind = maps:get(<<"triggerKind">>, Context),

--- a/src/erlang_ls_completion_provider.erl
+++ b/src/erlang_ls_completion_provider.erl
@@ -61,7 +61,7 @@ handle_request({completion, Params}, State) ->
    any().
 find_completion(Prefix, ?TRIGGER_CHARACTER, <<":">>) ->
   Token = erlang_ls_text:last_token(Prefix),
-  case erl_syntax:type(Token) of
+  try erl_syntax:type(Token) of
     atom ->
       Module = erl_syntax:atom_value(Token),
       case erlang_ls_completion_index:find(Module) of
@@ -77,7 +77,9 @@ find_completion(Prefix, ?TRIGGER_CHARACTER, <<":">>) ->
         not_found ->
           null
       end;
-    _ -> null
+      _ -> null
+  catch error:{badarg, _} ->
+      null
   end;
 find_completion(_Prefix, _TriggerKind, _TriggerCharacter) ->
   null.

--- a/src/erlang_ls_document.erl
+++ b/src/erlang_ls_document.erl
@@ -11,7 +11,6 @@
 -export([ create/2
         , uri/1
         , text/1
-        , text_line/2
         , tree/1
         , points_of_interest/1
           %% TODO: Implement points_of_interest/2 which takes a list of types
@@ -52,11 +51,6 @@ uri(#{uri := Uri}) ->
 -spec text(document()) -> binary().
 text(#{text := Text}) ->
   Text.
-
--spec text_line(document(), non_neg_integer()) -> binary().
-text_line(#{text := Text}, Line) ->
-  Lines = binary:split(Text, <<"\n">>, [global]),
-  lists:nth(Line + 1, Lines).
 
 -spec tree(document()) -> erlang_ls_tree:tree().
 tree(#{tree := Tree}) ->

--- a/src/erlang_ls_text.erl
+++ b/src/erlang_ls_text.erl
@@ -1,0 +1,33 @@
+%%==============================================================================
+%% Text Manipulation Functions
+%%==============================================================================
+-module(erlang_ls_text).
+
+-export([ last_token/1
+        , line/2
+        , line/3
+        ]).
+
+-type text()       :: binary().
+-type line_num()   :: non_neg_integer().
+-type column_num() :: non_neg_integer().
+-type token()      :: erl_scan:token().
+
+%% Extract the N-th line from a text.
+-spec line(text(), line_num()) -> text().
+line(Text, LineNum) ->
+  Lines = binary:split(Text, <<"\n">>, [global]),
+  lists:nth(LineNum + 1, Lines).
+
+%% Extract the N-th line from a text, up to the given column number.
+-spec line(text(), line_num(), column_num()) -> text().
+line(Text, LineNum, ColumnNum) ->
+  Line = line(Text, LineNum),
+  binary:part(Line, {0, ColumnNum}).
+
+%% Extract the last token from the given text.
+-spec last_token(text()) -> token().
+last_token(Text) ->
+  {ok, Tokens, _} = erl_scan:string(binary_to_list(Text)),
+  [Token | _]     = lists:reverse(Tokens),
+  Token.


### PR DESCRIPTION
### Description

* Move text manipulation functions to a separate module
* Use OTP library functions instead of custom pattern matching.

Fixes #116 .
