### PR TITLE
[Fixes #120] Handle more than one clause in the function spec

### DIFF
--- a/src/erlang_ls_parser.erl
+++ b/src/erlang_ls_parser.erl
@@ -87,9 +87,10 @@ extra(Form, Tokens, Extra, attribute) ->
                                  , lists:zip(Imports, Locations)
                                  ),
       maps:put(import_locations, NewLocations, Extra);
-    {spec, {spec, {{F, A}, [FT]}}} ->
-      OldLocations = maps:get(spec_locations, Extra, []),
-      NewLocations = [{{F, A}, spec_locations(FT)}|OldLocations],
+    {spec, {spec, {{F, A}, FTs}}} ->
+      SpecLocations = [spec_locations(FT) || FT <- FTs],
+      OldLocations  = maps:get(spec_locations, Extra, []),
+      NewLocations  = [{{F, A}, lists:append(SpecLocations)} | OldLocations],
       maps:put(spec_locations, NewLocations, Extra);
     _ ->
       Extra
@@ -97,8 +98,7 @@ extra(Form, Tokens, Extra, attribute) ->
 extra(_Form, _Tokens, Extra, _Type) ->
   Extra.
 
-%% TODO: Refine any() type
--spec spec_locations(any()) -> [{atom(), erl_anno:location()}].
+-spec spec_locations(erl_syntax:syntaxTree()) -> [{atom(), erl_anno:location()}].
 spec_locations(FT) ->
   case erl_syntax:type(FT) of
     function_type ->

--- a/src/erlang_ls_tree.erl
+++ b/src/erlang_ls_tree.erl
@@ -208,13 +208,8 @@ attribute(Tree, Extra) ->
       [erlang_ls_poi:poi(Tree, {record, atom_to_list(Record)}, Extra)];
     {spec, {spec, {{F, A}, _}}} ->
       SpecLocations = maps:get(spec_locations, Extra, []),
-      case proplists:get_value({F, A}, SpecLocations) of
-        undefined ->
-          lager:warning("Spec location not found for ~p/~p", [F, A]),
-          [];
-        Locations ->
-          [erlang_ls_poi:poi(Tree, {type_application, {T, L}}, Extra) || {T, L} <- Locations]
-      end;
+      Locations     = proplists:get_value({F, A}, SpecLocations),
+      [erlang_ls_poi:poi(Tree, {type_application, {T, L}}, Extra) || {T, L} <- Locations];
     {type, {type, Type}} ->
       %% TODO: Support type usages in type definitions
       TypeName = element(1, Type),

--- a/test/erlang_ls_parser_SUITE.erl
+++ b/test/erlang_ls_parser_SUITE.erl
@@ -1,0 +1,47 @@
+-module(erlang_ls_parser_SUITE).
+
+%% CT Callbacks
+-export([ all/0
+        , init_per_suite/1
+        , end_per_suite/1
+        ]).
+
+%% Test cases
+-export([ specs_location/1
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) -> Config.
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(_Config) -> ok.
+
+-spec all() -> [atom()].
+all() -> erlang_ls_test_utils:all(?MODULE).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+%% Issue #120
+-spec specs_location(config()) -> ok.
+specs_location(_Config) ->
+  Text = "-spec foo(integer()) -> any(); (atom()) -> pid().",
+  {ok, _Tree, Extra} = erlang_ls_parser:parse(Text),
+  SpecLocations = maps:get(spec_locations, Extra, []),
+  Locations     = proplists:get_value({foo, 1}, SpecLocations),
+  ?assertEqual(4, length(Locations)),
+  ok.


### PR DESCRIPTION
### Description

Handle the case where a function spec has more than one clause and a test to avoid regression.

Fixes #120 
