### PR TITLE
[#123] Add support for textDocument/documentSymbol

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -226,9 +226,6 @@
 -define(COMPLETION_ITEM_KIND_TEXT, 1).
 -type completion_item_kind() :: ?COMPLETION_ITEM_KIND_TEXT.
 
--define(SYMBOL_KIND_FILE, 1).
--type symbol_kind() :: ?SYMBOL_KIND_FILE.
-
 -define(CODE_ACTION_KIND_QUICKFIX, 1).
 -type code_action_kind() :: ?CODE_ACTION_KIND_QUICKFIX.
 
@@ -400,6 +397,64 @@
                            | ?MESSAGE_TYPE_LOG.
 
 %%------------------------------------------------------------------------------
+%% Symbol Kinds
+%%------------------------------------------------------------------------------
+
+-define(SYMBOLKIND_FILE           , 1).
+-define(SYMBOLKIND_MODULE         , 2).
+-define(SYMBOLKIND_NAMESPACE      , 3).
+-define(SYMBOLKIND_PACKAGE        , 4).
+-define(SYMBOLKIND_CLASS          , 5).
+-define(SYMBOLKIND_METHOD         , 6).
+-define(SYMBOLKIND_PROPERTY       , 7).
+-define(SYMBOLKIND_FIELD          , 8).
+-define(SYMBOLKIND_CONSTRUCTOR    , 9).
+-define(SYMBOLKIND_ENUM           , 10).
+-define(SYMBOLKIND_INTERFACE      , 11).
+-define(SYMBOLKIND_FUNCTION       , 12).
+-define(SYMBOLKIND_VARIABLE       , 13).
+-define(SYMBOLKIND_CONSTANT       , 14).
+-define(SYMBOLKIND_STRING         , 15).
+-define(SYMBOLKIND_NUMBER         , 16).
+-define(SYMBOLKIND_BOOLEAN        , 17).
+-define(SYMBOLKIND_ARRAY          , 18).
+-define(SYMBOLKIND_OBJECT         , 19).
+-define(SYMBOLKIND_KEY            , 20).
+-define(SYMBOLKIND_NULL           , 21).
+-define(SYMBOLKIND_ENUM_MEMBER    , 22).
+-define(SYMBOLKIND_STRUCT         , 23).
+-define(SYMBOLKIND_EVENT          , 24).
+-define(SYMBOLKIND_OPERATOR       , 25).
+-define(SYMBOLKIND_TYPE_PARAMETER , 26).
+
+-type symbol_kind() :: ?SYMBOLKIND_FILE
+                     | ?SYMBOLKIND_MODULE
+                     | ?SYMBOLKIND_NAMESPACE
+                     | ?SYMBOLKIND_PACKAGE
+                     | ?SYMBOLKIND_CLASS
+                     | ?SYMBOLKIND_METHOD
+                     | ?SYMBOLKIND_PROPERTY
+                     | ?SYMBOLKIND_FIELD
+                     | ?SYMBOLKIND_CONSTRUCTOR
+                     | ?SYMBOLKIND_ENUM
+                     | ?SYMBOLKIND_INTERFACE
+                     | ?SYMBOLKIND_FUNCTION
+                     | ?SYMBOLKIND_VARIABLE
+                     | ?SYMBOLKIND_CONSTANT
+                     | ?SYMBOLKIND_STRING
+                     | ?SYMBOLKIND_NUMBER
+                     | ?SYMBOLKIND_BOOLEAN
+                     | ?SYMBOLKIND_ARRAY
+                     | ?SYMBOLKIND_OBJECT
+                     | ?SYMBOLKIND_KEY
+                     | ?SYMBOLKIND_NULL
+                     | ?SYMBOLKIND_ENUM_MEMBER
+                     | ?SYMBOLKIND_STRUCT
+                     | ?SYMBOLKIND_EVENT
+                     | ?SYMBOLKIND_OPERATOR
+                     | ?SYMBOLKIND_TYPE_PARAMETER.
+
+%%------------------------------------------------------------------------------
 %% Internals
-%%-----------------------------------------------------------------------------
+%%------------------------------------------------------------------------------
 -type pos() :: {integer(), integer()}.

--- a/src/erlang_ls_document_symbol_provider.erl
+++ b/src/erlang_ls_document_symbol_provider.erl
@@ -1,0 +1,47 @@
+-module(erlang_ls_document_symbol_provider).
+
+-behaviour(erlang_ls_provider).
+
+-export([ handle_request/2
+        , is_enabled/0
+        , setup/1
+        , teardown/0
+        ]).
+
+-include("erlang_ls.hrl").
+
+%%==============================================================================
+%% erlang_ls_provider functions
+%%==============================================================================
+
+-spec is_enabled() -> boolean().
+is_enabled() ->
+  true.
+
+-spec setup(map()) -> erlang_ls_provider:state().
+setup(_Config) ->
+  #{}.
+
+-spec handle_request(any(), erlang_ls_provider:state()) ->
+  {any(), erlang_ls_provider:state()}.
+handle_request({document_symbol, Params}, State) ->
+  #{ <<"textDocument">> := #{ <<"uri">> := Uri}} = Params,
+  {ok, Document} = erlang_ls_db:find(documents, Uri),
+  POIs = erlang_ls_document:points_of_interest(Document),
+  case POIs of
+    [] -> {null, State};
+    _ ->
+      {[ #{ name => list_to_binary(io_lib:format("~p/~p", [F, A]))
+          , kind => ?SYMBOLKIND_FUNCTION
+          , location => #{ uri   => Uri
+                         , range => erlang_ls_protocol:range(Range)
+                         }
+          }
+         || #{ info := {function, {F, A}}
+             , range := Range
+             } <- POIs ], State}
+  end.
+
+-spec teardown() -> ok.
+teardown() ->
+  ok.

--- a/src/erlang_ls_protocol_impl.erl
+++ b/src/erlang_ls_protocol_impl.erl
@@ -13,6 +13,7 @@
         , textdocument_didchange/1
         , textdocument_didsave/1
         , textdocument_didclose/1
+        , textdocument_documentsymbol/1
         , textdocument_hover/1
         , textdocument_definition/1
         , textdocument_references/1
@@ -48,6 +49,8 @@ initialize(Params) ->
                }
           , definitionProvider => erlang_ls_definition_provider:is_enabled()
           , referencesProvider => erlang_ls_references_provider:is_enabled()
+          , documentSymbolProvider =>
+              erlang_ls_document_symbol_provider:is_enabled()
           }
      },
   {response, Result}.
@@ -126,6 +129,17 @@ textdocument_didsave(Params) ->
 textdocument_didclose(Params) ->
   ok = erlang_ls_text_synchronization:did_close(Params),
   {}.
+
+%%==============================================================================
+%% textdocument/documentSymbol
+%%==============================================================================
+
+-spec textdocument_documentsymbol(map()) -> {response, map()}.
+textdocument_documentsymbol(Params) ->
+  Provider = erlang_ls_document_symbol_provider,
+  Request  = {document_symbol, Params},
+  Response = erlang_ls_provider:handle_request(Provider, Request),
+  {response, Response}.
 
 %%==============================================================================
 %% textdocument_hover

--- a/src/erlang_ls_provider.erl
+++ b/src/erlang_ls_provider.erl
@@ -22,6 +22,7 @@
 -type config()   :: any().
 -type provider() :: erlang_ls_completion_provider
                   | erlang_ls_definition_provider
+                  | erlang_ls_document_symbol_provider
                   | erlang_ls_references_provider.
 -type request()  :: {atom(), map()}.
 -type state()    :: any().
@@ -88,6 +89,7 @@ start_provider(Provider, Config) ->
 providers() ->
   [ erlang_ls_completion_provider
   , erlang_ls_definition_provider
+  , erlang_ls_document_symbol_provider
   , erlang_ls_references_provider
   ].
 

--- a/test/erlang_ls_document_symbol_SUITE.erl
+++ b/test/erlang_ls_document_symbol_SUITE.erl
@@ -1,0 +1,94 @@
+-module(erlang_ls_document_symbol_SUITE).
+
+%% CT Callbacks
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , all/0
+        ]).
+
+%% Test cases
+-export([ functions/1
+        ]).
+
+
+-include("erlang_ls.hrl").
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+  [{timetrap, {seconds, 30}}].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  {ok, Started} = application:ensure_all_started(erlang_ls),
+  [{started, Started}|Config].
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  [application:stop(App) || App <- ?config(started, Config)],
+  ok.
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(TestCase, Config) ->
+  erlang_ls_test_utils:init_per_testcase(TestCase, Config).
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(_TestCase, _Config) ->
+  ok.
+
+-spec all() -> [atom()].
+all() ->
+  erlang_ls_test_utils:all(?MODULE).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec functions(config()) -> ok.
+functions(Config) ->
+  Uri = ?config(code_navigation_uri, Config),
+  #{result := Symbols} = erlang_ls_client:document_symbol(Uri),
+  Expected = [ #{ kind => ?SYMBOLKIND_FUNCTION,
+                  location =>
+                    #{ range =>
+                         #{ 'end' => #{character => ToC, line => ToL},
+                            start => #{character => FromC, line => FromL}
+                          },
+                       uri => Uri
+                     },
+                  name => Name
+                } || {Name, {FromL, FromC}, {ToL, ToC}} <- functions()],
+  ?assertEqual(lists:sort(Expected), lists:sort(Symbols)),
+  ok.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+functions() ->
+  [ {<<"callback_a/0">>, {27, 0}, {27, 10}}
+  , {<<"function_a/0">>, {20, 0}, {20, 10}}
+  , {<<"function_b/0">>, {24, 0}, {24, 10}}
+  , {<<"function_c/0">>, {30, 0}, {30, 10}}
+  , {<<"function_d/0">>, {38, 0}, {38, 10}}
+  , {<<"function_e/0">>, {41, 0}, {41, 10}}
+  , {<<"function_f/0">>, {46, 0}, {46, 10}}
+  , {<<"function_g/1">>, {49, 0}, {49, 10}}
+  , {<<"function_h/0">>, {55, 0}, {55, 10}}
+  , {<<"function_i/0">>, {59, 0}, {59, 10}}
+  , {<<"function_i/0">>, {61, 0}, {61, 10}}
+  ].

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -89,8 +89,9 @@ initialize_post(_S, _Args, Res) ->
                         , change    => ?TEXT_DOCUMENT_SYNC_KIND_FULL
                         , save      => true
                         }
-                   , definitionProvider => true
-                   , referencesProvider => true
+                   , definitionProvider     => true
+                   , referencesProvider     => true
+                   , documentSymbolProvider => true
                    }
               },
   ?assertEqual(Expected, maps:get(result, Res)),


### PR DESCRIPTION
### Description

Add support for the document symbol provider. This makes it possible, in Emacs, to use the `imenu` command to navigate to functions.

Fixes #123 .
