### PR TITLE
[#125] Cleanup the POI data structure, add points_of_interest/2 API.

### DIFF
--- a/src/erlang_ls_completion_provider.erl
+++ b/src/erlang_ls_completion_provider.erl
@@ -67,12 +67,12 @@ find_completion(Prefix, ?TRIGGER_CHARACTER, <<":">>) ->
       case erlang_ls_completion_index:find(Module) of
         {ok, Uri} ->
           {ok, Document} = erlang_ls_db:find(documents, Uri),
-          POIs = erlang_ls_document:points_of_interest(Document),
+          POIs = erlang_ls_document:points_of_interest(Document, [exports_entry]),
           [ #{ label            => list_to_binary(io_lib:format("~p/~p", [F, A]))
              , insertText       => snippet_function_call(F, A)
              , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
              }
-            || #{info := {exports_entry, {F, A}}} <- POIs
+            || #{info := {_, {F, A}}} <- POIs
           ];
         not_found ->
           null

--- a/src/erlang_ls_completion_provider.erl
+++ b/src/erlang_ls_completion_provider.erl
@@ -72,7 +72,7 @@ find_completion(Prefix, ?TRIGGER_CHARACTER, <<":">>) ->
              , insertText       => snippet_function_call(F, A)
              , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
              }
-            || #{info := {_, {F, A}}} <- POIs
+            || #{data := {F, A}} <- POIs
           ];
         not_found ->
           null

--- a/src/erlang_ls_document.erl
+++ b/src/erlang_ls_document.erl
@@ -13,7 +13,7 @@
         , text/1
         , tree/1
         , points_of_interest/1
-          %% TODO: Implement points_of_interest/2 which takes a list of types
+        , points_of_interest/2
         , get_element_at_pos/3
         ]).
 
@@ -59,6 +59,10 @@ tree(#{tree := Tree}) ->
 -spec points_of_interest(document()) -> [erlang_ls_poi:poi()].
 points_of_interest(#{pois := POIs}) ->
   POIs.
+
+-spec points_of_interest(document(), [erlang_ls_poi:kind()]) -> [erlang_ls_poi:poi()].
+points_of_interest(#{pois := POIs}, Kinds) ->
+  [POI || #{ info := {Kind, _} } = POI <- POIs, lists:member(Kind, Kinds)].
 
 -spec get_element_at_pos(document(), non_neg_integer(), non_neg_integer()) ->
   [any()].

--- a/src/erlang_ls_document.erl
+++ b/src/erlang_ls_document.erl
@@ -62,7 +62,7 @@ points_of_interest(#{pois := POIs}) ->
 
 -spec points_of_interest(document(), [erlang_ls_poi:kind()]) -> [erlang_ls_poi:poi()].
 points_of_interest(#{pois := POIs}, Kinds) ->
-  [POI || #{ info := {Kind, _} } = POI <- POIs, lists:member(Kind, Kinds)].
+  [POI || #{ kind := Kind } = POI <- POIs, lists:member(Kind, Kinds)].
 
 -spec get_element_at_pos(document(), non_neg_integer(), non_neg_integer()) ->
   [any()].

--- a/src/erlang_ls_document_symbol_provider.erl
+++ b/src/erlang_ls_document_symbol_provider.erl
@@ -27,7 +27,7 @@ setup(_Config) ->
 handle_request({document_symbol, Params}, State) ->
   #{ <<"textDocument">> := #{ <<"uri">> := Uri}} = Params,
   {ok, Document} = erlang_ls_db:find(documents, Uri),
-  POIs = erlang_ls_document:points_of_interest(Document),
+  POIs = erlang_ls_document:points_of_interest(Document, [function]),
   case POIs of
     [] -> {null, State};
     _ ->
@@ -37,7 +37,7 @@ handle_request({document_symbol, Params}, State) ->
                          , range => erlang_ls_protocol:range(Range)
                          }
           }
-         || #{ info := {function, {F, A}}
+         || #{ info := {_, {F, A}}
              , range := Range
              } <- POIs ], State}
   end.

--- a/src/erlang_ls_document_symbol_provider.erl
+++ b/src/erlang_ls_document_symbol_provider.erl
@@ -37,7 +37,7 @@ handle_request({document_symbol, Params}, State) ->
                          , range => erlang_ls_protocol:range(Range)
                          }
           }
-         || #{ info := {_, {F, A}}
+         || #{ data := {F, A}
              , range := Range
              } <- POIs ], State}
   end.

--- a/src/erlang_ls_poi.erl
+++ b/src/erlang_ls_poi.erl
@@ -23,8 +23,9 @@
                 | record_expr
                 | type_application
                 | type_definition.
--type poi()    :: #{ type => poi
-                   , info => {kind(), any()}
+-type poi()    :: #{ type  => poi
+                   , kind  => kind()
+                   , data  => any()
                    , range := range()
                    }.
 
@@ -33,11 +34,11 @@
              , range/0
              ]).
 
--export([ poi/3 ]).
+-export([ poi/4 ]).
 
 -export([ list/1
         , match/2
-        , match_key/2
+        , match_kind/2
         , match_pos/2
         , first/1
         ]).
@@ -47,12 +48,13 @@
 %%==============================================================================
 
 %% @edoc Constructor for a Point of Interest.
--spec poi(erlang_ls_tree:tree(), any(), erlang_ls_tree:extra()) -> poi().
-poi(Tree, Info, Extra) ->
+-spec poi(erlang_ls_tree:tree(), kind(), any(), erlang_ls_tree:extra()) -> poi().
+poi(Tree, Kind, Data, Extra) ->
   Pos = erl_syntax:get_pos(Tree),
-  Range = get_range(Pos, Info, Extra),
-  #{ type  => poi
-   , info  => Info
+  Range = get_range(Pos, Kind, Data, Extra),
+  #{ type  => 'poi'
+   , kind  => Kind
+   , data  => Data
    , range => Range
    }.
 
@@ -68,13 +70,15 @@ list(Tree) ->
       end,
   erl_syntax_lib:fold(F, [], Tree).
 
--spec match(erlang_ls_tree:tree(), any()) -> [poi()].
-match(Tree, Info0) ->
-  [POI || #{info := Info} = POI <- list(Tree), Info0 =:= Info].
+-spec match(erlang_ls_tree:tree(), {kind(), any()}) -> [poi()].
+match(Tree, {Kind0, Data0}) ->
+  [POI || #{kind := Kind, data := Data} = POI <- list(Tree)
+            , Kind0 =:= Kind
+            , Data0 =:= Data].
 
--spec match_key(erlang_ls_tree:tree(), atom()) -> [poi()].
-match_key(Tree, Key0) ->
-  [POI || #{info := {Key, _}} = POI <- list(Tree), Key0 =:= Key].
+-spec match_kind(erlang_ls_tree:tree(), atom()) -> [poi()].
+match_kind(Tree, Kind0) ->
+  [POI || #{kind := Kind} = POI <- list(Tree), Kind0 =:= Kind].
 
 -spec match_pos(erlang_ls_tree:tree(), pos()) -> [poi()].
 match_pos(Tree, Pos) ->
@@ -91,79 +95,79 @@ first(POIs) ->
 %% Internal Functions
 %%==============================================================================
 
--spec get_range(pos(), {atom(), any()}, erlang_ls_tree:extra()) -> range().
-get_range({Line, Column}, {application, {M, F, _A}}, _Extra) ->
+-spec get_range(pos(), kind(), any(), erlang_ls_tree:extra()) -> range().
+get_range({Line, Column}, application, {M, F, _A}, _Extra) ->
   CFrom = Column - length(atom_to_list(M)),
   From = {Line, CFrom},
   CTo = Column + length(atom_to_list(F)),
   To = {Line, CTo},
   #{ from => From, to => To };
-get_range({Line, Column}, {application, {F, _A}}, _Extra) ->
+get_range({Line, Column}, application, {F, _A}, _Extra) ->
   From = {Line, Column},
   To = {Line, Column + length(atom_to_list(F))},
   #{ from => From, to => To };
-get_range({Line, Column}, {implicit_fun, {M, F, A}}, _Extra) ->
+get_range({Line, Column}, implicit_fun, {M, F, A}, _Extra) ->
   From = {Line, Column},
   %% Assumes "fun M:F/A"
   Length = 6 + length(atom_to_list(M) ++ atom_to_list(F) ++ integer_to_list(A)),
   To = {Line, Column + Length},
   #{ from => From, to => To };
-get_range({Line, Column}, {implicit_fun, {F, A}}, _Extra) ->
+get_range({Line, Column}, implicit_fun, {F, A}, _Extra) ->
   From = {Line, Column},
   %% Assumes "fun F/A"
   Length = 5 + length(atom_to_list(F) ++ integer_to_list(A)),
   To = {Line, Column + Length},
   #{ from => From, to => To };
-get_range({Line, Column}, {behaviour, Behaviour}, _Extra) ->
+get_range({Line, Column}, behaviour, Behaviour, _Extra) ->
   From = {Line, Column - 1},
   To = {Line, Column + length("behaviour") + length(atom_to_list(Behaviour))},
   #{ from => From, to => To };
-get_range({_Line, _Column}, {exports_entry, {F, A}}, Extra) ->
+get_range({_Line, _Column}, exports_entry, {F, A}, Extra) ->
   get_entry_range(exports_locations, F, A, Extra);
-get_range({_Line, _Column}, {import_entry, {_M, F, A}}, Extra) ->
+get_range({_Line, _Column}, import_entry, {_M, F, A}, Extra) ->
   get_entry_range(import_locations, F, A, Extra);
-get_range({Line, Column}, {function, {F, _A}}, _Extra) ->
+get_range({Line, Column}, function, {F, _A}, _Extra) ->
   From = {Line, Column},
   To = {Line, Column + length(atom_to_list(F))},
   #{ from => From, to => To };
-get_range({Line, _Column}, {define, _Define}, _Extra) ->
+get_range({Line, _Column}, define, _Define, _Extra) ->
   From = {Line, 1},
   To = From,
   #{ from => From, to => To };
-get_range({Line, Column}, {include, Include}, _Extra) ->
+get_range({Line, Column}, include, Include, _Extra) ->
   From = {Line, Column},
   To = {Line, Column + length("include") + length(Include)},
   #{ from => From, to => To };
-get_range({Line, Column}, {include_lib, Include}, _Extra) ->
+get_range({Line, Column}, include_lib, Include, _Extra) ->
   From = {Line, Column},
   To = {Line, Column + length("include_lib") + length(Include)},
   #{ from => From, to => To };
-get_range({Line, Column}, {macro, Macro}, _Extra) when is_atom(Macro) ->
+get_range({Line, Column}, macro, Macro, _Extra) when is_atom(Macro) ->
   From = {Line, Column},
   To = {Line, Column + length(atom_to_list(Macro))},
   #{ from => From, to => To };
-get_range({Line, Column}, {module, _}, _Extra) ->
+get_range({Line, Column}, module, _, _Extra) ->
   From = {Line, Column},
   To = From,
   #{ from => From, to => To };
-get_range(Pos, {record_access, {Record, Field}}, _Extra) ->
+get_range(Pos, record_access, {Record, Field}, _Extra) ->
   #{ from => minus(Pos, "#"), to => plus(Pos, Record ++ "." ++ Field) };
-get_range({Line, Column}, {record_expr, Record}, _Extra) ->
+get_range({Line, Column}, record_expr, Record, _Extra) ->
   From = {Line, Column - 1},
   To = {Line, Column + length(Record) - 1},
   #{ from => From, to => To };
 %% TODO: Distinguish between usage poi and definition poi
-get_range({Line, _Column}, {record, _Record}, _Extra) ->
+get_range({Line, _Column}, record, _Record, _Extra) ->
   From = {Line, 1},
   To = From,
   #{ from => From, to => To };
 %% TODO: Do we really need the StartLocation there?
-get_range({_Line, _Column}, {type_application, {Type, StartLocation}}, _Extra) ->
+get_range({_Line, _Column}, type_application, {Type, StartLocation}, _Extra) ->
   {FromLine, FromColumn} = From = StartLocation,
   Length = length(atom_to_list(Type)),
   To = {FromLine, FromColumn + Length - 1},
   #{ from => From, to => To };
-get_range({Line, Column}, {type_definition, _Type}, _Extra) ->
+get_range({Line, Column}, type_definition, _Type, _Extra) ->
   From = {Line, Column},
   To = From,
   #{ from => From, to => To }.

--- a/src/erlang_ls_poi.erl
+++ b/src/erlang_ls_poi.erl
@@ -7,12 +7,29 @@
 -type column() :: non_neg_integer().
 -type pos()    :: {line(), column()}.
 -type range()  :: #{ from := pos(), to := pos() }.
--type poi()    :: #{ type := atom()
-                   , info => any()
+-type kind()   :: application
+                | behaviour
+                | define
+                | exports_entry
+                | function
+                | implicit_fun
+                | import_entry
+                | include
+                | include_lib
+                | macro
+                | module
+                | record
+                | record_access
+                | record_expr
+                | type_application
+                | type_definition.
+-type poi()    :: #{ type => poi
+                   , info => {kind(), any()}
                    , range := range()
                    }.
 
--export_type([ poi/0
+-export_type([ kind/0
+             , poi/0
              , range/0
              ]).
 

--- a/src/erlang_ls_poi.erl
+++ b/src/erlang_ls_poi.erl
@@ -23,8 +23,7 @@
                 | record_expr
                 | type_application
                 | type_definition.
--type poi()    :: #{ type  => poi
-                   , kind  => kind()
+-type poi()    :: #{ kind  => kind()
                    , data  => any()
                    , range := range()
                    }.
@@ -52,8 +51,7 @@
 poi(Tree, Kind, Data, Extra) ->
   Pos = erl_syntax:get_pos(Tree),
   Range = get_range(Pos, Kind, Data, Extra),
-  #{ type  => 'poi'
-   , kind  => Kind
+  #{ kind  => Kind
    , data  => Data
    , range => Range
    }.
@@ -62,8 +60,7 @@ poi(Tree, Kind, Data, Extra) ->
 -spec list(erlang_ls_tree:tree()) -> [poi()].
 list(Tree) ->
   F = fun(T, Acc) ->
-          Annotations = erl_syntax:get_ann(T),
-          case [POI || #{ type := poi } = POI <- Annotations] of
+          case erl_syntax:get_ann(T) of
             [] -> Acc;
             L -> L ++ Acc
           end

--- a/src/erlang_ls_references_index.erl
+++ b/src/erlang_ls_references_index.erl
@@ -36,7 +36,7 @@ index(Document) ->
 %%==============================================================================
 
 -spec get(erlang_ls_uri:uri(), erlang_ls_poi:poi()) -> [ref()].
-get(Uri, #{info := {Kind, MFA}})
+get(Uri, #{kind := Kind, data := MFA})
   when Kind =:= application; Kind =:= implicit_fun; Kind =:= function ->
   Key = key(Uri, MFA),
   ordsets:to_list(get(Key));
@@ -48,7 +48,7 @@ get(_, _) ->
 %%==============================================================================
 
 -spec register_usage(erlang_ls_uri:uri(), erlang_ls_poi:poi()) -> ok.
-register_usage(Uri, #{info := {_Kind, MFA}, range := Range}) ->
+register_usage(Uri, #{data := MFA, range := Range}) ->
   Key = key(Uri, MFA),
   Ref = #{uri => Uri, range => Range},
   add(Key, Ref),

--- a/src/erlang_ls_references_index.erl
+++ b/src/erlang_ls_references_index.erl
@@ -25,8 +25,9 @@ setup() ->
 
 -spec index(erlang_ls_document:document()) -> ok.
 index(Document) ->
-  Uri  = erlang_ls_document:uri(Document),
-  POIs = erlang_ls_document:points_of_interest(Document),
+  Uri   = erlang_ls_document:uri(Document),
+  Kinds = [application, implicit_fun],
+  POIs  = erlang_ls_document:points_of_interest(Document, Kinds),
   [register_usage(Uri, POI) || POI <- POIs],
   ok.
 
@@ -35,8 +36,8 @@ index(Document) ->
 %%==============================================================================
 
 -spec get(erlang_ls_uri:uri(), erlang_ls_poi:poi()) -> [ref()].
-get(Uri, #{info := {Type, MFA}})
-  when Type =:= application; Type =:= implicit_fun; Type =:= function ->
+get(Uri, #{info := {Kind, MFA}})
+  when Kind =:= application; Kind =:= implicit_fun; Kind =:= function ->
   Key = key(Uri, MFA),
   ordsets:to_list(get(Key));
 get(_, _) ->
@@ -47,13 +48,10 @@ get(_, _) ->
 %%==============================================================================
 
 -spec register_usage(erlang_ls_uri:uri(), erlang_ls_poi:poi()) -> ok.
-register_usage(Uri, #{info := {Type, MFA}, range := Range})
-  when Type =:= application; Type =:= implicit_fun ->
+register_usage(Uri, #{info := {_Kind, MFA}, range := Range}) ->
   Key = key(Uri, MFA),
   Ref = #{uri => Uri, range => Range},
   add(Key, Ref),
-  ok;
-register_usage(_File, _POI) ->
   ok.
 
 -spec get(key()) -> ordsets:ordset(ref()).

--- a/src/erlang_ls_tree.erl
+++ b/src/erlang_ls_tree.erl
@@ -121,7 +121,7 @@ points_of_interest(Tree, Extra) ->
 application(Tree, Extra) ->
   case application_mfa(Tree) of
     undefined -> [];
-    MFA -> [erlang_ls_poi:poi(Tree, {application, MFA}, Extra)]
+    MFA -> [erlang_ls_poi:poi(Tree, application, MFA, Extra)]
   end.
 
 -spec application_mfa(tree()) ->
@@ -175,45 +175,48 @@ attribute(Tree, Extra) ->
     %% Yes, Erlang allows both British and American spellings for
     %% keywords.
     {behavior, {behavior, Behaviour}} ->
-      [erlang_ls_poi:poi(Tree, {behaviour, Behaviour}, Extra)];
+      [erlang_ls_poi:poi(Tree, behaviour, Behaviour, Extra)];
     {behaviour, {behaviour, Behaviour}} ->
-      [erlang_ls_poi:poi(Tree, {behaviour, Behaviour}, Extra)];
+      [erlang_ls_poi:poi(Tree, behaviour, Behaviour, Extra)];
     {export, Exports} ->
-      [erlang_ls_poi:poi(Tree, {exports_entry, {F, A}}, Extra) || {F, A} <- Exports];
+      [erlang_ls_poi:poi(Tree, exports_entry, {F, A}, Extra) || {F, A} <- Exports];
     {import, {M, Imports}} ->
-      [erlang_ls_poi:poi(Tree, {import_entry, {M, F, A}}, Extra) || {F, A} <- Imports];
+      [erlang_ls_poi:poi(Tree, import_entry, {M, F, A}, Extra) || {F, A} <- Imports];
     {module, {Module, _Args}} ->
-      [erlang_ls_poi:poi(Tree, {module, Module}, Extra)];
+      [erlang_ls_poi:poi(Tree, module, Module, Extra)];
     {module, Module} ->
-      [erlang_ls_poi:poi(Tree, {module, Module}, Extra)];
+      [erlang_ls_poi:poi(Tree, module, Module, Extra)];
     preprocessor ->
       Name = erl_syntax:atom_value(erl_syntax:attribute_name(Tree)),
       case {Name, erl_syntax:attribute_arguments(Tree)} of
         {define, [Define|_]} ->
           [erlang_ls_poi:poi( Tree
-                            , {define, define_name(Define)}
+                            , define
+                            , define_name(Define)
                             , Extra )];
         {include, [String]} ->
           [erlang_ls_poi:poi( Tree
-                            , {include, erl_syntax:string_literal(String)}
+                            , include
+                            , erl_syntax:string_literal(String)
                             , Extra )];
         {include_lib, [String]} ->
           [erlang_ls_poi:poi( Tree
-                            , {include_lib, erl_syntax:string_literal(String)}
+                            , include_lib
+                            , erl_syntax:string_literal(String)
                             , Extra )];
         _ ->
           []
       end;
     {record, {Record, _Fields}} ->
-      [erlang_ls_poi:poi(Tree, {record, atom_to_list(Record)}, Extra)];
+      [erlang_ls_poi:poi(Tree, record, atom_to_list(Record), Extra)];
     {spec, {spec, {{F, A}, _}}} ->
       SpecLocations = maps:get(spec_locations, Extra, []),
       Locations     = proplists:get_value({F, A}, SpecLocations),
-      [erlang_ls_poi:poi(Tree, {type_application, {T, L}}, Extra) || {T, L} <- Locations];
+      [erlang_ls_poi:poi(Tree, type_application, {T, L}, Extra) || {T, L} <- Locations];
     {type, {type, Type}} ->
       %% TODO: Support type usages in type definitions
       TypeName = element(1, Type),
-      [erlang_ls_poi:poi(Tree, {type_definition, TypeName}, Extra)];
+      [erlang_ls_poi:poi(Tree, type_definition, TypeName, Extra)];
     _ ->
       []
   catch throw:syntax_error ->
@@ -223,7 +226,7 @@ attribute(Tree, Extra) ->
 -spec function(tree(), extra()) -> [erlang_ls_poi:poi()].
 function(Tree, Extra) ->
   {F, A} = erl_syntax_lib:analyze_function(Tree),
-  [erlang_ls_poi:poi(Tree, {function, {F, A}}, Extra)].
+  [erlang_ls_poi:poi(Tree, function, {F, A}, Extra)].
 
 -spec implicit_fun(tree(), extra()) -> [erlang_ls_poi:poi()].
 implicit_fun(Tree, Extra) ->
@@ -235,14 +238,14 @@ implicit_fun(Tree, Extra) ->
             end,
   case FunSpec of
     undefined -> [];
-    _ -> [erlang_ls_poi:poi(Tree, {implicit_fun, FunSpec}, Extra)]
+    _ -> [erlang_ls_poi:poi(Tree, implicit_fun, FunSpec, Extra)]
   end.
 
 -spec macro(tree(), extra()) -> [erlang_ls_poi:poi()].
 macro(Tree, Extra) ->
   case erl_syntax:get_pos(Tree) of
     0 -> [];
-    _ -> [erlang_ls_poi:poi(Tree, {macro, node_name(Tree)}, Extra)]
+    _ -> [erlang_ls_poi:poi(Tree, macro, node_name(Tree), Extra)]
   end.
 
 -spec record_access(tree(), extra()) -> [erlang_ls_poi:poi()].
@@ -252,7 +255,7 @@ record_access(Tree, Extra) ->
     atom ->
       Record = erl_syntax:atom_name(RecordNode),
       Field = erl_syntax:atom_name(erl_syntax:record_access_field(Tree)),
-      [erlang_ls_poi:poi(Tree, {record_access, {Record, Field}}, Extra)];
+      [erlang_ls_poi:poi(Tree, record_access, {Record, Field}, Extra)];
     _ ->
       []
   end.
@@ -263,7 +266,7 @@ record_expr(Tree, Extra) ->
   case erl_syntax:type(RecordNode) of
     atom ->
       Record = erl_syntax:atom_name(RecordNode),
-      [erlang_ls_poi:poi(Tree, {record_expr, Record}, Extra)];
+      [erlang_ls_poi:poi(Tree, record_expr, Record, Extra)];
     _ ->
       []
   end.


### PR DESCRIPTION
### Description

* Remove the pointless `type` field from the POI map.
* Split the `info` field into separate `kind` and `data`
* Be able to retrieve only a subset of POIs

Fixes #125  .
