### PR TITLE
[#131] The definition provider uses indexed data for code navigation

### DIFF
--- a/src/erlang_ls_code_navigation.erl
+++ b/src/erlang_ls_code_navigation.erl
@@ -10,11 +10,6 @@
 %% API
 -export([ goto_definition/2 ]).
 
--export([ app_path/0
-        , deps_path/0
-        , otp_path/0
-        ]).
-
 %%==============================================================================
 %% Includes
 %%==============================================================================
@@ -24,220 +19,106 @@
 %% API
 %%==============================================================================
 
--spec goto_definition(binary(), erlang_ls_poi:poi()) ->
-   {ok, binary(), erlang_ls_poi:range()} | {error, any()}.
-goto_definition(Filename, POI) ->
-  goto_definition(Filename, POI, include_path()).
-
-%% TODO: Abstract pattern
--spec goto_definition(binary(), erlang_ls_poi:poi(), [string()]) ->
-   {ok, binary(), erlang_ls_poi:range()} | {error, any()}.
-goto_definition( _Filename
-               , #{ kind := Kind, data := {M, _F, _A} = Data }
-               , Path
+-spec goto_definition(uri(), erlang_ls_poi:poi()) ->
+   {ok, uri(), erlang_ls_poi:poi()} | {error, any()}.
+goto_definition( _Uri
+               , #{ kind := Kind, data := {M, F, A} }
                ) when Kind =:= application;
                       Kind =:= implicit_fun ->
-  goto_fun_definition(filename(M), Path, Kind, Data);
-goto_definition( Filename
-               , #{ kind := Kind
-                  , data := {_F, _A} = Data
-                  }
-               , Path
+  {ok, Uri} = erlang_ls_db:find(completion_index, M),
+  find(Uri, function, {F, A});
+goto_definition( Uri
+               , #{ kind := Kind, data := {F, A}}
                ) when Kind =:= application;
                       Kind =:= implicit_fun;
                       Kind =:= exports_entry ->
-  goto_fun_definition(filename:basename(Filename), Path, Kind, Data);
-goto_definition(_Filename, #{ kind := behaviour
-                            , data := Behaviour
-                            }, Path) ->
-  search(filename(Behaviour), Path, definition(behaviour, Behaviour));
-goto_definition( _Filename
-               , #{ kind := import_entry
-                  , data := {M, _F, _A} = Data
-                  }
-               , Path) ->
-  search(filename(M), Path, definition(import_entry, Data));
-%% TODO: Eventually search everywhere and suggest a code lens to include a file
-goto_definition(Filename, #{ kind := macro, data := Data }, Path) ->
-  search(filename:basename(Filename), Path, definition(macro, Data));
-goto_definition(Filename, #{ kind := record_access
-                           , data := Data
-                           }, Path) ->
-  search(filename:basename(Filename), Path, definition(record_access, Data));
-goto_definition(Filename, #{ kind := record_expr, data := Data }, Path) ->
-  search(filename:basename(Filename), Path, definition(record_expr, Data));
-goto_definition(_Filename, #{ kind := include, data := Include0 }, Path) ->
-  Include = list_to_binary(string:trim(Include0, both, [$"])),
-  case erlang_ls_tree:annotate_file(Include, Path) of
-    {ok, FullName, _AnnotatedTree} ->
-      {ok, FullName, #{ from => {1, 1}, to => {1, 1} }};
-    {error, Error} ->
-      {error, Error}
+  find(Uri, function, {F, A});
+goto_definition(_Uri, #{ kind := behaviour, data := Behaviour }) ->
+  {ok, Uri} = erlang_ls_db:find(completion_index, Behaviour),
+  find(Uri, module, Behaviour);
+goto_definition(_Uri, #{ kind := import_entry, data := {M, F, A}}) ->
+  {ok, Uri} = erlang_ls_db:find(completion_index, M),
+  find(Uri, function, {F, A});
+goto_definition(Uri, #{ kind := macro, data := Define }) ->
+  find(Uri, define, Define);
+goto_definition(Uri, #{ kind := record_access
+                      , data := {Record, _}}) ->
+  find(Uri, record, Record);
+goto_definition(Uri, #{ kind := record_expr, data := Record }) ->
+  find(Uri, record, Record);
+goto_definition(_Uri, #{ kind := Kind, data := Include }
+               ) when Kind =:= include;
+                      Kind =:= include_lib ->
+  %% TODO: Index header definitions as well
+  FileName = include_filename(Kind, Include),
+  M = list_to_atom(FileName),
+  case erlang_ls_db:find(completion_index, M) of
+    {ok, Uri} ->
+      {ok, Uri, beginning()};
+    not_found ->
+      case erlang_ls_index:find_and_index_file(FileName) of
+        {ok, Uri} ->
+          {ok, Uri, beginning()};
+        {error, Error} ->
+          {error, Error}
+      end
   end;
-goto_definition(_Filename, #{ kind := include_lib, data := Include0 }, Path) ->
-  Include = list_to_binary(lists:last(filename:split(string:trim(Include0, both, [$"])))),
-  case erlang_ls_tree:annotate_file(Include, Path) of
-    {ok, FullName, _AnnotatedTree} ->
-      {ok, FullName, #{ from => {1, 1}, to => {1, 1} }};
-    {error, Error} ->
-      {error, Error}
-  end;
-goto_definition(Filename, #{ kind := type_application, data := Data }, Path) ->
-  search(filename:basename(Filename), Path, definition(type_application, Data));
-goto_definition(_Filename, _, _Path) ->
+goto_definition(Uri, #{ kind := type_application, data := {Type, _} }) ->
+  find(Uri, type_definition, Type);
+goto_definition(_Filename, _) ->
   {error, not_found}.
 
--spec goto_fun_definition(file:name_all(), [string()], erlang_ls_poi:kind(), any()) ->
-  {ok, binary(), erlang_ls_poi:range()} | {error, any()}.
-goto_fun_definition(Filename, Path, Kind, Data)  ->
-  case erlang_ls_tree:annotate_file(Filename, Path) of
-    {ok, FullName, AnnotatedTree} ->
-      case erlang_ls_poi:match(AnnotatedTree, definition(Kind, Data)) of
-        [] -> {error, not_found};
-        Matches ->
-          #{range := Range} = erlang_ls_poi:first(Matches),
-          {ok, FullName, Range}
-      end;
-    {error, Error} ->
-      {error, Error}
-  end.
-
--spec definition(erlang_ls_poi:kind(), any()) -> {atom(), any()}.
-definition(application, {_M, F, A}) ->
-  {function, {F, A}};
-definition(application, {F, A}) ->
-  {function, {F, A}};
-definition(implicit_fun, {_M, F, A}) ->
-  {function, {F, A}};
-definition(implicit_fun, {F, A}) ->
-  {function, {F, A}};
-definition(behaviour, Behaviour) ->
-  {module, Behaviour};
-definition(exports_entry, {F, A}) ->
-  {function, {F, A}};
-definition(import_entry, {_M, F, A}) ->
-  {function, {F, A}};
-definition(macro, Define) ->
-  {define, Define};
-definition(record_access, {Record, _Field}) ->
-  {record, Record};
-definition(record_expr, Record) ->
-  {record, Record};
-definition(type_application, {Type, _}) ->
-  {type_definition, Type}.
-
--spec otp_path() -> [string()].
-otp_path() ->
-  {ok, Root} = erlang_ls_config:get(otp_path),
-  resolve_paths( [ [Root, "lib", "*", "src"]
-                 , [Root, "lib", "*", "include"]
-                 ]).
-
--spec app_path() -> [string()].
-app_path() ->
-  {ok, RootUri} = erlang_ls_config:get(root_uri),
-  RootPath = binary_to_list(erlang_ls_uri:path(RootUri)),
-  resolve_paths( [ [RootPath, "src"]
-                 , [RootPath, "test"]
-                 , [RootPath, "include"]
-                 ]).
-
--spec deps_path() -> [string()].
-deps_path() ->
-  {ok, RootUri} = erlang_ls_config:get(root_uri),
-  RootPath = binary_to_list(erlang_ls_uri:path(RootUri)),
-  {ok, Dirs} = erlang_ls_config:get(deps_dirs),
-  Paths = [ resolve_paths( [ [RootPath, Dir, "src"]
-                           , [RootPath, Dir, "test"]
-                           , [RootPath, Dir, "include"]
-                           ])
-            || Dir <- Dirs
-          ],
-  lists:append(Paths).
-
--spec resolve_paths([[string()]]) -> [[string()]].
-resolve_paths(PathSpecs) ->
-  lists:append([resolve_path(PathSpec) || PathSpec <- PathSpecs]).
-
--spec resolve_path([string()]) -> [string()].
-resolve_path(PathSpec) ->
-  Path = filename:join(PathSpec),
-  Paths = [[P | subdirs(P)] || P <- filelib:wildcard(Path)],
-  lists:append(Paths).
-
-%% Returns all subdirectories for the provided path
--spec subdirs(string()) -> [string()].
-subdirs(Path) ->
-  subdirs(Path, []).
-
--spec subdirs(string(), [string()]) -> [string()].
-subdirs(Path, Subdirs) ->
-  case file:list_dir(Path) of
-    {ok, Files}     -> subdirs_(Path, Files, Subdirs);
-    {error, enoent} -> Subdirs
-  end.
-
--spec subdirs_(string(), [string()], [string()]) -> [string()].
-subdirs_(Path, Files, Subdirs) ->
-  Fold = fun(F, Acc) ->
-             FullPath = filename:join([Path, F]),
-             case filelib:is_dir(FullPath) of
-               true  -> subdirs(FullPath, [FullPath | Acc]);
-               false -> Acc
-             end
-         end,
-  lists:foldl(Fold, Subdirs, Files).
-
--spec include_path() -> [string()].
-include_path() ->
-  lists:append( [ app_path(), otp_path(), deps_path() ]).
-
-%% Look for a definition recursively in a file and its includes.
--spec search(binary(), [string()], any()) ->
-   {ok, binary(), erlang_ls_poi:range()} | {error, any()}.
-search(Filename, Path, Thing) ->
-  case erlang_ls_tree:annotate_file(Filename, Path) of
-    {ok, FullName, AnnotatedTree} ->
-      case find(AnnotatedTree, Thing) of
-        {error, not_found} ->
-          Includes = erlang_ls_poi:match_kind(AnnotatedTree, include),
-          IncludeLibs = erlang_ls_poi:match_kind(AnnotatedTree, include_lib),
-          search_in_includes(Includes ++ IncludeLibs, Path, Thing);
-        {ok, Range} ->
-          {ok, FullName, Range}
-      end;
-    {error, Error} ->
-      {error, Error}
-  end.
-
-%% Look for a definition in a given tree
--spec find(erlang_ls_tree:tree(), any()) ->
-   {ok, erlang_ls_poi:range()} | {error, any()}.
-find(AnnotatedTree, Thing) ->
-  case erlang_ls_poi:match(AnnotatedTree, Thing) of
-    [#{ range := Range }|_] ->
-      {ok, Range};
-    [] ->
-      {error, not_found}
-  end.
-
--spec search_in_includes([erlang_ls_poi:poi()], [string()], any()) ->
-   {ok, binary(), erlang_ls_poi:range()} | {error, any()}.
-search_in_includes([], _Path, _Thing) ->
+%% TODO: Move poi/kind to hrl
+-spec find([uri()], erlang_ls_poi:kind(), any()) ->
+   {ok, uri(), erlang_ls_poi:poi()} | {error, not_found}.
+find([], _Kind, _Data) ->
   {error, not_found};
-search_in_includes([#{kind := Kind, data := Data}|T], Path, Thing) ->
-  Include = normalize_include(Kind, Data),
-  case search(list_to_binary(Include), Path, Thing) of
-    {error, _Error} -> search_in_includes(T, Path, Thing);
-    {ok, FullName, Range} -> {ok, FullName, Range}
+find([Uri|Uris0], Kind, Data) ->
+  case erlang_ls_db:find(documents, Uri) of
+    {ok, Document} ->
+      POIs = erlang_ls_document:points_of_interest(Document, [Kind], Data),
+      case POIs of
+        [] ->
+          find(lists:usort(include_uris(Document) ++ Uris0), Kind, Data);
+        Definitions ->
+          {ok, Uri, lists:last(Definitions)}
+      end;
+    not_found ->
+      find(Uris0, Kind, Data)
+  end;
+find(Uri, Kind, Data) ->
+  find([Uri], Kind, Data).
+
+-spec include_uris(erlang_ls_document:document()) -> [uri()].
+include_uris(Document) ->
+  POIs = erlang_ls_document:points_of_interest( Document
+                                              , [include, include_lib]),
+  lists:foldl(fun add_include_uri/2, [], POIs).
+
+-spec add_include_uri(erlang_ls_poi:poi(), [uri()]) -> [uri()].
+add_include_uri(#{ kind := Kind, data := String }, Acc) ->
+  FileName = include_filename(Kind, String),
+  M = list_to_atom(FileName),
+  case erlang_ls_db:find(completion_index, M) of
+    {ok, Uri} ->
+      [Uri|Acc];
+    not_found ->
+      case erlang_ls_index:find_and_index_file(FileName) of
+        {ok, Uri} ->
+          [Uri|Acc];
+        {error, _Error} ->
+          Acc
+      end
   end.
 
--spec normalize_include(erlang_ls_poi:kind(), string()) -> string().
-normalize_include(include, Include) ->
-  string:trim(Include, both, [$"]);
-normalize_include(include_lib, Include) ->
-  lists:last(filename:split(string:trim(Include, both, [$"]))).
+-spec include_filename('include' | 'include_lib', string()) -> string().
+include_filename(include, String) ->
+  string:trim(String, both, [$"]);
+include_filename(include_lib, String) ->
+  lists:last(filename:split(string:trim(String, both, [$"]))).
 
--spec filename(atom()) -> binary().
-filename(Module) ->
-  list_to_binary(atom_to_list(Module) ++ ".erl").
+-spec beginning() -> #{range => #{from => {1, 1}, to => {1, 1}}}.
+beginning() ->
+  #{range => #{from => {1, 1}, to => {1, 1}}}.
+
+%% TODO: Handle multiple header files with the same name?

--- a/src/erlang_ls_definition_provider.erl
+++ b/src/erlang_ls_definition_provider.erl
@@ -33,16 +33,13 @@ handle_request({definition, Params}, State) ->
     erlang_ls_document:get_element_at_pos(Document, Line + 1, Character + 1)
   of
     [POI|_] ->
-      Filename = erlang_ls_uri:path(Uri),
-      case erlang_ls_code_navigation:goto_definition(Filename, POI) of
-        {error, _Error} ->
-          {null, State};
-        {ok, FullName, Range} ->
-          { #{ uri => erlang_ls_uri:uri(FullName)
-             , range => erlang_ls_protocol:range(Range)
-             }
+      case erlang_ls_code_navigation:goto_definition(Uri, POI) of
+        {ok, DefUri, #{range := Range}} ->
+          { #{ uri => DefUri, range => erlang_ls_protocol:range(Range) }
           , State
-          }
+          };
+        _ ->
+          {null, State}
       end;
     [] ->
       {null, State}

--- a/src/erlang_ls_document.erl
+++ b/src/erlang_ls_document.erl
@@ -14,6 +14,7 @@
         , tree/1
         , points_of_interest/1
         , points_of_interest/2
+        , points_of_interest/3
         , get_element_at_pos/3
         ]).
 
@@ -62,15 +63,25 @@ tree(#{tree := Tree}) ->
   Tree.
 
 -spec points_of_interest(document()) -> [erlang_ls_poi:poi()].
-points_of_interest(#{pois := POIs}) ->
-  POIs.
+points_of_interest(Document) ->
+  points_of_interest(Document, []).
 
 -spec points_of_interest(document(), [erlang_ls_poi:kind()]) -> [erlang_ls_poi:poi()].
-points_of_interest(#{pois := POIs}, Kinds) ->
-  [POI || #{ kind := Kind } = POI <- POIs, lists:member(Kind, Kinds)].
+points_of_interest(Document, Kinds) ->
+  points_of_interest(Document, Kinds, undefined).
+
+-spec points_of_interest(document(), [erlang_ls_poi:kind()], any()) -> [erlang_ls_poi:poi()].
+points_of_interest(#{pois := POIs}, Kinds, undefined) ->
+  [POI || #{ kind := Kind } = POI <- POIs, lists:member(Kind, Kinds)];
+points_of_interest(#{pois := POIs}, Kinds, Pattern) ->
+  [POI || #{ kind := Kind, data := Data } = POI <- POIs
+            , lists:member(Kind, Kinds)
+            , Pattern =:= Data
+  ].
 
 -spec get_element_at_pos(document(), non_neg_integer(), non_neg_integer()) ->
   [any()].
 get_element_at_pos(Document, Line, Column) ->
   AnnotatedTree = maps:get(tree, Document),
+  %% TODO: Refine API
   erlang_ls_poi:match_pos(AnnotatedTree, {Line, Column}).

--- a/src/erlang_ls_poi.erl
+++ b/src/erlang_ls_poi.erl
@@ -36,8 +36,6 @@
 -export([ poi/4 ]).
 
 -export([ list/1
-        , match/2
-        , match_kind/2
         , match_pos/2
         , first/1
         ]).
@@ -56,6 +54,7 @@ poi(Tree, Kind, Data, Extra) ->
    , range => Range
    }.
 
+%% TODO: Really needed?
 %% @edoc List the Points of Interest for a given tree.
 -spec list(erlang_ls_tree:tree()) -> [poi()].
 list(Tree) ->
@@ -66,16 +65,6 @@ list(Tree) ->
           end
       end,
   erl_syntax_lib:fold(F, [], Tree).
-
--spec match(erlang_ls_tree:tree(), {kind(), any()}) -> [poi()].
-match(Tree, {Kind0, Data0}) ->
-  [POI || #{kind := Kind, data := Data} = POI <- list(Tree)
-            , Kind0 =:= Kind
-            , Data0 =:= Data].
-
--spec match_kind(erlang_ls_tree:tree(), atom()) -> [poi()].
-match_kind(Tree, Kind0) ->
-  [POI || #{kind := Kind} = POI <- list(Tree), Kind0 =:= Kind].
 
 -spec match_pos(erlang_ls_tree:tree(), pos()) -> [poi()].
 match_pos(Tree, Pos) ->

--- a/src/erlang_ls_text_synchronization.erl
+++ b/src/erlang_ls_text_synchronization.erl
@@ -34,6 +34,7 @@ did_close(Params) ->
     not_found ->
       lager:debug("[SERVER] Attempting to close un-opened text document, ignoring [uri=~p]", [Uri]);
     {ok, _} ->
+      %% TODO: Do not delete once DB is persistent
       ok = erlang_ls_db:delete(documents, Uri)
   end,
   ok.

--- a/src/erlang_ls_tree.erl
+++ b/src/erlang_ls_tree.erl
@@ -8,7 +8,6 @@
 %%==============================================================================
 -export([ annotate/1
         , annotate/2
-        , annotate_file/2
         , annotate_node/1
         , annotate_node/2
         , postorder_update/3
@@ -36,19 +35,6 @@
 %%==============================================================================
 %% API
 %%==============================================================================
-
--spec annotate_file(binary(), [string()]) ->
-   {ok, binary(), annotated_tree()} | {error, any()}.
-annotate_file(Filename, Path) ->
-  case file:path_open(Path, Filename, [read]) of
-    {ok, IoDevice, FullName} ->
-      %% TODO: Avoid opening file twice
-      file:close(IoDevice),
-      {ok, Tree, Extra} = erlang_ls_parser:parse_file(FullName),
-      {ok, FullName, annotate(Tree, Extra)};
-    {error, Error} ->
-      {error, Error}
-  end.
 
 %% @edoc Given a syntax tree, it returns a new one, annotated with all
 %% the identified _points of interest_ (a.k.a. _poi_).


### PR DESCRIPTION
### Description

The code navigation section was not using the DB and it was partially re-implementing indexing.
This PR heavily refactors the code navigation part to:

* use `uri()` directly instead of converting from/to filenames un-necessarily
* move path management to the indexer, where it belongs to
* remove un-necessary match functions acting on the tree
* make the code navigation code uniform in all clauses
* index also `.hrl` files

This change *should* not change anything in terms of functionality, hence the test suite is untouched.

Fixes #131 .
