### PR TITLE
Make erlang_ls_protocol_impl:initialize/1 work with autozimu/LanguageClient-neovim

### DIFF
--- a/src/erlang_ls_methods.erl
+++ b/src/erlang_ls_methods.erl
@@ -77,11 +77,11 @@ method_to_function_name(Method) ->
 -spec initialize(params(), state()) -> result().
 initialize(Params, State) ->
   #{ <<"rootUri">> := RootUri
-   , <<"initializationOptions">> := InitOptions
      %% TODO: Store client capabilities, use them in completion_provider
      %%       to verify when Context is present
    , <<"capabilities">> := _ClientCapabilities
    } = Params,
+  InitOptions = maps:get(<<"initializationOptions">>, Params, #{}),
   Config = erlang_ls_config:initialize(RootUri, InitOptions),
   ok     = erlang_ls_index:initialize(Config),
   ok     = erlang_ls_provider:initialize(Config),


### PR DESCRIPTION
LanguageClient does not send the `initializationOptions` field of the config.
According to https://github.com/Microsoft/language-server-protocol/issues/567 heavy reliance on this field is discouraged.
This change allows to successfully connect and start using basic `erlang_ls` functionality in Vim, for example providing `erlc` warnings directly in the editor.

In the future I'd be interested in using Gradualizer with Vim through the language server - this is the first necessary step. [My current Gradualizer integration attempt is sufficient for Vim, but not reusable in other editors.](https://github.com/erszcz/neomake/blob/erlang-gradualizer-wip/autoload/neomake/makers/ft/erlang.vim)