### PR TITLE
[Fixes #19] [Fixes #20] Shutdown request keep state

### DIFF
--- a/src/erlang_ls_methods.erl
+++ b/src/erlang_ls_methods.erl
@@ -127,7 +127,7 @@ shutdown(_Params, State) ->
 %% exit
 %%==============================================================================
 
--spec exit(params(), state()) -> result().
+-spec exit(params(), state()) -> no_return().
 exit(_Params, State) ->
   ExitCode = case maps:get(status, State, undefined) of
                shutdown -> 0;

--- a/src/erlang_ls_methods.erl
+++ b/src/erlang_ls_methods.erl
@@ -133,7 +133,7 @@ exit(_Params, State) ->
                shutdown -> 0;
                _        -> 1
              end,
-  erlang:halt(ExitCode).
+  erlang_ls_utils:halt(ExitCode).
 
 %%==============================================================================
 %% textdocument_didopen

--- a/src/erlang_ls_protocol.erl
+++ b/src/erlang_ls_protocol.erl
@@ -10,6 +10,7 @@
 -export([ notification/2
         , request/3
         , response/2
+        , error/2
         ]).
 
 %% Data Structures
@@ -45,6 +46,15 @@ response(RequestId, Result) ->
   Message = #{ jsonrpc => ?JSONRPC_VSN
              , id      => RequestId
              , result  => Result
+             },
+  lager:debug("[Response] [message=~p]", [Message]),
+  content(jsx:encode(Message)).
+
+-spec error(number(), any()) -> any().
+error(RequestId, Error) ->
+  Message = #{ jsonrpc => ?JSONRPC_VSN
+             , id      => RequestId
+             , error   => Error
              },
   lager:debug("[Response] [message=~p]", [Message]),
   content(jsx:encode(Message)).

--- a/src/erlang_ls_server.erl
+++ b/src/erlang_ls_server.erl
@@ -34,7 +34,10 @@
 %%==============================================================================
 %% Record Definitions
 %%==============================================================================
--record(state, {socket, document}).
+-record(state, { socket :: pid()
+               , buffer :: binary()
+               , state  :: map()
+               }).
 
 %%==============================================================================
 %% Type Definitions
@@ -65,7 +68,8 @@ init({Ref, Socket, Transport, _Opts}) ->
                        , []
                        , connected
                        , #state{ socket = Socket
-                               , document = <<>>
+                               , buffer = <<>>
+                               , state  = #{}
                                }
                        ).
 
@@ -82,15 +86,13 @@ terminate(_Reason, _StateName, #state{socket = Socket}) ->
 %% gen_statem State Functions
 %%==============================================================================
 -spec connected(gen_statem:event_type(), any(), state()) -> any().
-connected(info, {tcp, Socket, Packet}, #state{ socket = Socket
-                                             , document = Document
-                                             } = State) ->
-  lager:debug("[SERVER] TCP Packet [document=~p] [packet=~p] ", [Document, Packet]),
-  Data = <<Document/binary, Packet/binary>>,
-  {Requests, NewDocument} = erlang_ls_jsonrpc:split(Data, [return_maps]),
-  [handle_request(Socket, Request) || Request <- Requests],
+connected(info, {tcp, Socket, Packet}, #state{buffer = Buffer} = State0) ->
+  lager:debug("[SERVER] TCP Packet [buffer=~p] [packet=~p] ", [Buffer, Packet]),
+  Data = <<Buffer/binary, Packet/binary>>,
+  {Requests, NewBuffer} = erlang_ls_jsonrpc:split(Data, [return_maps]),
+  State   = lists:foldl(fun handle_request/2, State0, Requests),
   inet:setopts(Socket, [{active, once}]),
-  {keep_state, State#state{ document = NewDocument }};
+  {keep_state, State#state{ buffer = NewBuffer }};
 connected(info, {tcp_closed, _Socket}, _State) ->
   {stop, normal};
 connected(info, {'EXIT', _, normal}, _State) ->
@@ -104,29 +106,33 @@ connected(cast, {notification, M, P}, State) ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec handle_request(any(), map()) -> ok.
-handle_request(Socket, Request) ->
+-spec handle_request(any(), state()) -> state().
+handle_request(Request, #state{ socket = Socket
+                              , state  = InternalState
+                              } = State0) ->
   Method    = maps:get(<<"method">>, Request),
   Params    = maps:get(<<"params">>, Request),
-  case handle_method(Method, Params) of
-    {response, Result} ->
+  case handle_method(Method, Params, InternalState) of
+    {response, Result, NewInternalState} ->
       RequestId = maps:get(<<"id">>, Request),
       Response = erlang_ls_protocol:response(RequestId, Result),
       lager:debug("[SERVER] Sending response [response=~p]", [Response]),
-      gen_tcp:send(Socket, Response);
-    {} ->
+      gen_tcp:send(Socket, Response),
+      State0#state{state = NewInternalState};
+    {noresponse, NewInternalState} ->
       lager:debug("[SERVER] No response", []),
-      ok;
-    {notification, M, P} ->
-      send_notification(Socket, M, P)
+      State0#state{state = NewInternalState};
+    {notification, M, P, NewInternalState} ->
+      send_notification(Socket, M, P),
+      State0#state{state = NewInternalState}
   end.
 
 %% @doc Dispatch the handling of the method to erlang_ls_protocol_impl
--spec handle_method(binary(), map()) ->
+-spec handle_method(binary(), map(), map()) ->
   {response, map() | null} | {} | {notification, binary(), map()}.
-handle_method(Method, Params) ->
+handle_method(Method, Params, InternalState) ->
   Function = method_to_function_name(Method),
-  try erlang_ls_protocol_impl:Function(Params)
+  try erlang_ls_protocol_impl:Function(Params, InternalState)
   catch error:undef -> not_implemented_method(Method)
   end.
 

--- a/src/erlang_ls_utils.erl
+++ b/src/erlang_ls_utils.erl
@@ -1,0 +1,7 @@
+-module(erlang_ls_utils).
+
+-export([halt/1]).
+
+-spec halt(integer()) -> no_return().
+halt(ExitCode) ->
+  erlang:halt(ExitCode).

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -181,6 +181,33 @@ shutdown_post(_S, _Args, Res) ->
   true.
 
 %%------------------------------------------------------------------------------
+%% Shutdown
+%%------------------------------------------------------------------------------
+exit() ->
+  erlang_ls_client:exit().
+
+exit_args(_S) ->
+  [].
+
+exit_pre(#{connected := Connected} = _S) ->
+  Connected.
+
+exit_next(S, _R, _Args) ->
+  %% We disconnect to simulate the server goes down
+  catch disconnect(),
+  S#{shutdown => false, connected => false}.
+
+exit_post(S, _Args, Res) ->
+  ExpectedExitCode = case maps:get(shutdown, S, false) of
+                       true  -> 0;
+                       false -> 1
+                     end,
+  wait_for(halt_called, 1000),
+  ?assert(meck:called(erlang_ls_utils, halt, [ExpectedExitCode])),
+  ?assertMatch(ok, Res),
+  true.
+
+%%------------------------------------------------------------------------------
 %% Disconnect
 %%------------------------------------------------------------------------------
 disconnect() ->
@@ -215,8 +242,12 @@ prop_main() ->
 setup() ->
   meck:new(erlang_ls_compiler_diagnostics, [no_link, passthrough]),
   meck:new(erlang_ls_dialyzer_diagnostics, [no_link, passthrough]),
+  meck:new(erlang_ls_utils, [no_link, passthrough]),
   meck:expect(erlang_ls_compiler_diagnostics, diagnostics, 1, []),
   meck:expect(erlang_ls_dialyzer_diagnostics, diagnostics, 1, []),
+  Self    = erlang:self(),
+  HaltFun = fun(_X) -> Self ! halt_called, {noresponse, #{}} end,
+  meck:expect(erlang_ls_utils, halt, HaltFun),
   application:ensure_all_started(erlang_ls),
   file:write_file("/tmp/erlang_ls.config", <<"">>),
   lager:set_loglevel(lager_console_backend, warning),
@@ -228,6 +259,7 @@ setup() ->
 teardown(_) ->
   meck:unload(erlang_ls_compiler_diagnostics),
   meck:unload(erlang_ls_dialyzer_diagnostics),
+  meck:unload(erlang_ls_utils),
   ok.
 
 %%==============================================================================
@@ -243,3 +275,13 @@ cleanup() ->
 
 assert_shutdown_error(Res) ->
   ?assertMatch(#{error := #{code := _, message := _}}, Res).
+
+meck_matcher_integer(N) ->
+  meck_matcher:new(fun(X) -> X =:= N end).
+
+wait_for(_Message, Timeout) when Timeout =< 0 ->
+  timeout;
+wait_for(Message, Timeout) ->
+  receive Message -> ok
+  after 10 -> wait_for(Message, Timeout - 10)
+  end.


### PR DESCRIPTION
### Description

Keep track of the status of the server so we can respond accordingly to requests after `shutdown` and `exit` with the correct exit code, following the protocol specifications.

Fixes #19. Fixes #20.
