### PR TITLE
[Fixes #164] Avoid generating .beam file with strong_validation option

### DIFF
--- a/src/erlang_ls_compiler_diagnostics.erl
+++ b/src/erlang_ls_compiler_diagnostics.erl
@@ -24,6 +24,7 @@
 -define(COMPILER_OPTS, [ debug_info
                        , return_warnings
                        , return_errors
+                       , strong_validation
                        ]).
 
 %%==============================================================================


### PR DESCRIPTION
### Description

Avoid generating .beam file with strong_validation option

Fixes #164 .
