### PR TITLE
[Fixes #175] Use erlang_ls_utils:find_module/1 and handle all errors

### DIFF
--- a/src/erlang_ls_completion_provider.erl
+++ b/src/erlang_ls_completion_provider.erl
@@ -66,11 +66,11 @@ find_completion( Prefix
   try erl_syntax:type(Token) of
     atom ->
       Module = erl_syntax:atom_value(Token),
-      case erlang_ls_completion_index:find(Module) of
+      case erlang_ls_utils:find_module(Module) of
         {ok, Uri} ->
           {ok, Document} = erlang_ls_db:find(documents, Uri),
           functions(Document, exports_entry);
-        {error, not_found} ->
+        {error, _Error} ->
           null
       end;
     _ -> null


### PR DESCRIPTION
### Description

Use erlang_ls_utils:find_module/1 and handle all errors, not just not_found.

Fixes #175.
