### PR TITLE
Use minimal compiler options for generating compiler diagnostics

### DIFF
--- a/src/erlang_ls_compiler_diagnostics.erl
+++ b/src/erlang_ls_compiler_diagnostics.erl
@@ -21,10 +21,9 @@
 %%==============================================================================
 %% Defines
 %%==============================================================================
--define(COMPILER_OPTS, [ debug_info
-                       , return_warnings
+-define(COMPILER_OPTS, [ return_warnings
                        , return_errors
-                       , strong_validation
+                       , basic_validation
                        ]).
 
 %%==============================================================================


### PR DESCRIPTION
### Description

- `debug_info` is not really necessary to generate warnings and errors.
- `basic_validation` is still useful and faster than `strong_validation`, which applies more compiler passess that might take more time.
