### PR TITLE
[#181] Simply use regular expressions to match modules

### DIFF
--- a/src/erlang_ls_workspace_symbol_provider.erl
+++ b/src/erlang_ls_workspace_symbol_provider.erl
@@ -27,31 +27,8 @@ setup(_Config) ->
 handle_request({symbol, Params}, State) ->
   %% TODO: Version 3.15 of the protocol introduces a much nicer way of
   %%       specifying queries, allowing clients to send the symbol kind.
-  %%       For now, let's use the following convention for queries:
-  %%
-  %%       m     -> Request the list of all modules
-  %%       m-foo -> Request the module 'foo'
   #{ <<"query">> := Query} = Params,
-  Symbols =
-    case Query of
-      <<"m">> ->
-        case modules() of
-          [] ->
-            null;
-          Modules -> Modules
-        end;
-      <<"m-", Binary/binary>> ->
-        Module = binary_to_atom(Binary, utf8),
-        case erlang_ls_db:find(completion_index, Module) of
-          {ok, Uri} ->
-            [symbol_information({Module, Uri})];
-          {error, not_found} ->
-            null
-        end;
-      _ ->
-        null
-    end,
-  {Symbols, State}.
+  {modules(Query), State}.
 
 -spec teardown() -> ok.
 teardown() ->
@@ -61,12 +38,13 @@ teardown() ->
 %% Internal Functions
 %%==============================================================================
 
--spec modules() -> [symbol_information()].
-modules() ->
+-spec modules(binary()) -> [symbol_information()].
+modules(Query) ->
   %% TODO: Stop indexing header files together with modules
   All = erlang_ls_db:list(completion_index),
-  F = fun({_Module, Uri}) ->
-          filename:extension(Uri) =:= <<".erl">>
+  F = fun({Module, Uri}) ->
+          filename:extension(Uri) =:= <<".erl">> andalso
+            re:run(atom_to_binary(Module, utf8), Query) =/= nomatch
       end,
   lists:map(fun symbol_information/1, lists:filter(F, All)).
 


### PR DESCRIPTION
### Description

Use a regexp to help a user finding modules in the current workspace. It only works for modules already indexed (i.e. belonging to the same app or already opened). The indexing part will be fixed separately.

