### PR TITLE
[#112] Include function argument names (when available)

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -557,9 +557,10 @@
                    | type_definition
                    | variable.
 -type poi_range() :: #{ from := pos(), to := pos() }.
--type poi()       :: #{ kind  => poi_kind()
-                      , data  => any()
+-type poi()       :: #{ kind  := poi_kind()
+                      , data  := any()
                       , range := poi_range()
+                      , tree  := tree()
                       }.
 -type tree()      :: erl_syntax:syntaxTree().
 -type extra()     :: any().

--- a/src/erlang_ls_poi.erl
+++ b/src/erlang_ls_poi.erl
@@ -25,6 +25,7 @@ new(Tree, Kind, Data, Extra) ->
   #{ kind  => Kind
    , data  => Data
    , range => Range
+   , tree  => Tree
    }.
 
 -spec match_pos([poi()], pos()) -> [poi()].


### PR DESCRIPTION
### Description

Implements showing variable names when completing function calls. The variable names are extracted from the function definition and not from the specs, since in general specs don't include variables names. If the argument is not a variable but a pattern, then a default `ArgN` is included where `N` is an integer with the number of the argument.

Fixes #112.
