### PR TITLE
[#222] Don't write logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These are the command-line arguments that can be provided to the
 |-------------------------|-------------------------------------------------------------------------------------------------|
 | --transport tcp / stdio | Specifies the transport the server will use for the connection with the client (default: `tcp`) |
 | --port PORT             | Used when the transport is `tcp` (default: `10000`)                                             |
-| --log-dir DIR           | Directory where logs will be written (default: `/usr/local/var/log/erlang_ls`                   |
+| --log-dir DIR           | Directory where logs will be written. When not provided no logs are generated.                  |
 
 ### Emacs Setup
 
@@ -218,9 +218,16 @@ And you can connect to it via:
 The [redbug](https://github.com/massemanet/redbug) application is
 included in _debug mode_, so feel free to use it.
 
-### Logs
+### Logging
 
-Logs are written to `/usr/local/var/log/erlang_ls/PROJECT_DIRNAME/info.log`.
+When the escript is built using the `debug` profile as above, logging
+will be enabled and the logs will be written to `/usr/local/var/log/erlang_ls`.
+It's possible to change this directory either by modifying the default
+value in the `erlang_ls.app.src` file or by having the LSP client
+being used to provide a `--log-dir` option.
+
+When the `escript` is built in the `default` mode (i.e. `rebar3 escript`),
+no log files are generated, unless the `--log-dir` option is provided.
 
 ## References
 

--- a/rebar.config
+++ b/rebar.config
@@ -26,19 +26,6 @@
 
 {minimum_otp_vsn, "21.0"}.
 
-{relx, [ { release
-         , {erlang_ls, "0.0.1"}
-         , [ erlang_ls
-           , redbug
-           , observer
-           ]
-         }
-       , {sys_config, "./config/sys.config"}
-       , {dev_mode, true}
-       , {include_erts, false}
-       , {extended_start_script, true}
-       ]
-}.
 {profiles, [ { debug
              , [ { deps
                    %% The upstream version of redbug does not support
@@ -50,7 +37,8 @@
                    ]
                  }
                , { escript_emu_args
-                 , "%%! -erlang_ls debug_mode true \n"
+                 , "%%! -erlang_ls debug_mode true "
+                   " -erlang_ls logging_enabled true \n"
                  }
                  %% For some reason we need to explicitly include redbug,
                  %% even if it already is a dependency.

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -25,7 +25,8 @@
       , {indexers, 10}
       , {index_otp, true}
       , {index_deps, true}
-        %% Logs
+        %% Logging
+      , {logging_enabled, false}
       , {log_dir, "/usr/local/var/log/erlang_ls"}
       ]
     }


### PR DESCRIPTION
### Description

Don't write logs by default, only when `--log-dir` option is provided.

Fixes #222.
