### PR TITLE
[#228] Remove full syntax tree, add only necessary data

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -558,9 +558,9 @@
                    | variable.
 -type poi_range() :: #{ from := pos(), to := pos() }.
 -type poi()       :: #{ kind  := poi_kind()
+                      , id    := any()
                       , data  := any()
                       , range := poi_range()
-                      , tree  := tree()
                       }.
 -type tree()      :: erl_syntax:syntaxTree().
 -type extra()     :: any().

--- a/src/els_code_navigation.erl
+++ b/src/els_code_navigation.erl
@@ -22,7 +22,7 @@
 -spec goto_definition(uri(), poi()) ->
    {ok, uri(), poi()} | {error, any()}.
 goto_definition( _Uri
-               , #{ kind := Kind, data := {M, F, A} }
+               , #{ kind := Kind, id := {M, F, A} }
                ) when Kind =:= application;
                       Kind =:= implicit_fun;
                       Kind =:= import_entry ->
@@ -31,24 +31,24 @@ goto_definition( _Uri
     {error, Error} -> {error, Error}
   end;
 goto_definition( Uri
-               , #{ kind := Kind, data := {F, A}}
+               , #{ kind := Kind, id := {F, A}}
                ) when Kind =:= application;
                       Kind =:= implicit_fun;
                       Kind =:= exports_entry ->
   find(Uri, function, {F, A});
-goto_definition(_Uri, #{ kind := behaviour, data := Behaviour }) ->
+goto_definition(_Uri, #{ kind := behaviour, id := Behaviour }) ->
   case els_utils:find_module(Behaviour) of
     {ok, Uri}      -> find(Uri, module, Behaviour);
     {error, Error} -> {error, Error}
   end;
-goto_definition(Uri, #{ kind := macro, data := Define }) ->
+goto_definition(Uri, #{ kind := macro, id := Define }) ->
   find(Uri, define, Define);
 goto_definition(Uri, #{ kind := record_access
-                      , data := {Record, _}}) ->
+                      , id := {Record, _}}) ->
   find(Uri, record, Record);
-goto_definition(Uri, #{ kind := record_expr, data := Record }) ->
+goto_definition(Uri, #{ kind := record_expr, id := Record }) ->
   find(Uri, record, Record);
-goto_definition(_Uri, #{ kind := Kind, data := Include }
+goto_definition(_Uri, #{ kind := Kind, id := Include }
                ) when Kind =:= include;
                       Kind =:= include_lib ->
   %% TODO: Index header definitions as well
@@ -58,7 +58,7 @@ goto_definition(_Uri, #{ kind := Kind, data := Include }
     {ok, Uri}      -> {ok, Uri, beginning()};
     {error, Error} -> {error, Error}
   end;
-goto_definition(Uri, #{ kind := type_application, data := {Type, _} }) ->
+goto_definition(Uri, #{ kind := type_application, id := {Type, _} }) ->
   find(Uri, type_definition, Type);
 goto_definition(_Filename, _) ->
   {error, not_found}.
@@ -90,7 +90,7 @@ include_uris(Document) ->
   lists:foldl(fun add_include_uri/2, [], POIs).
 
 -spec add_include_uri(poi(), [uri()]) -> [uri()].
-add_include_uri(#{ data := String }, Acc) ->
+add_include_uri(#{ id := String }, Acc) ->
   FileName = filename:basename(String),
   M = list_to_atom(FileName),
   case els_utils:find_module(M, hrl) of

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -99,5 +99,5 @@ handle_cast(_Msg, State) -> {noreply, State}.
 
 -spec create_table(atom()) -> ok.
 create_table(Name) ->
-  ets:new(Name, [named_table, set, public]),
+  ets:new(Name, [named_table, set, public, {write_concurrency, true}]),
   ok.

--- a/src/els_document.erl
+++ b/src/els_document.erl
@@ -65,9 +65,9 @@ points_of_interest(Document, Kinds) ->
 points_of_interest(#{pois := POIs}, Kinds, undefined) ->
   [POI || #{ kind := Kind } = POI <- POIs, lists:member(Kind, Kinds)];
 points_of_interest(#{pois := POIs}, Kinds, Pattern) ->
-  [POI || #{ kind := Kind, data := Data } = POI <- POIs
+  [POI || #{ kind := Kind, id := Id } = POI <- POIs
             , lists:member(Kind, Kinds)
-            , Pattern =:= Data
+            , Pattern =:= Id
   ].
 
 -spec get_element_at_pos(document(), non_neg_integer(), non_neg_integer()) ->

--- a/src/els_document_symbol_provider.erl
+++ b/src/els_document_symbol_provider.erl
@@ -38,7 +38,7 @@ functions(Uri) ->
                    , location => #{ uri   => Uri
                                   , range => els_protocol:range(Range)
                                   }
-                   } || #{data := {F, A}, range := Range} <- POIs ]).
+                   } || #{id := {F, A}, range := Range} <- POIs ]).
 
 -spec function_name(atom(), non_neg_integer()) -> binary().
 function_name(F, A) ->

--- a/src/els_hover_provider.erl
+++ b/src/els_hover_provider.erl
@@ -44,7 +44,7 @@ documentation(Uri, Line, Character) ->
   end.
 
 -spec documentation(poi()) -> binary().
-documentation(#{kind := application, data := {M, F, A}}) ->
+documentation(#{kind := application, id := {M, F, A}}) ->
   case {specs(M, F, A), edoc(M, F, A)} of
     {<<>>, <<>>} ->
       <<>>;

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -77,7 +77,7 @@ index(Document) ->
   ok = els_db:store(modules, Module, Uri),
   Specs  = els_document:points_of_interest(Document, [spec]),
   [els_db:store(signatures, {Module, F, A}, Tree) ||
-    #{data := {{F, A}, Tree}} <- Specs],
+    #{id := {{F, A}, Tree}} <- Specs],
   Kinds = [application, implicit_fun],
   POIs  = els_document:points_of_interest(Document, Kinds),
   [register_reference(Uri, POI) || POI <- POIs],
@@ -123,7 +123,7 @@ index_dir(Dir) ->
                                           , {0, 0}
                                           ]
                                         ),
-  lager:info("Finished indexing directory. [dir=~s] [time=~p]"
+  lager:info("Finished indexing directory. [dir=~s] [time=~p] "
              "[succeeded=~p] "
              "[failed=~p]", [Dir, Time/1000/1000, Succeeded, Failed]),
   {Succeeded, Failed}.
@@ -197,11 +197,11 @@ index_document(Document, sync) ->
 %% TODO: Specific for references
 
 -spec register_reference(uri(), poi()) -> ok.
-register_reference(Uri, #{data := {M, F, A}, range := Range}) ->
+register_reference(Uri, #{id := {M, F, A}, range := Range}) ->
   Ref = #{uri => Uri, range => Range},
   add_reference({M, F, A}, Ref),
   ok;
-register_reference(Uri, #{data := {F, A}, range := Range}) ->
+register_reference(Uri, #{id := {F, A}, range := Range}) ->
   Ref = #{uri => Uri, range => Range},
   M = els_uri:module(Uri),
   add_reference({M, F, A}, Ref),

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -298,7 +298,19 @@ attribute(Tree, Extra) ->
 -spec function(tree(), extra()) -> [poi()].
 function(Tree, Extra) ->
   {F, A} = erl_syntax_lib:analyze_function(Tree),
-  [els_poi:new(Tree, function, {F, A}, Extra)].
+  Args   = function_args(Tree, A),
+  [els_poi:new(Tree, function, {F, A}, Args, Extra)].
+
+-spec function_args(tree(), arity()) -> [{integer(), string()}].
+function_args(Tree, Arity) ->
+  Clause   = hd(erl_syntax:function_clauses(Tree)),
+  Patterns = erl_syntax:clause_patterns(Clause),
+  [ case erl_syntax:type(P) of
+      variable -> {N, erl_syntax:variable_literal(P)};
+      _        -> {N, "Arg" ++ integer_to_list(N)}
+    end
+    || {N, P} <- lists:zip(lists:seq(1, Arity), Patterns)
+  ].
 
 -spec implicit_fun(tree(), extra()) -> [poi()].
 implicit_fun(Tree, Extra) ->

--- a/src/els_poi.erl
+++ b/src/els_poi.erl
@@ -4,7 +4,9 @@
 -module(els_poi).
 
 %% Constructor
--export([ new/4 ]).
+-export([ new/4
+        , new/5
+        ]).
 
 -export([ match_pos/2 ]).
 
@@ -19,13 +21,18 @@
 
 %% @edoc Constructor for a Point of Interest.
 -spec new(tree(), poi_kind(), any(), extra()) -> poi().
-new(Tree, Kind, Data, Extra) ->
+new(Tree, Kind, Id, Extra) ->
+  new(Tree, Kind, Id, undefined, Extra).
+
+%% @edoc Constructor for a Point of Interest.
+-spec new(tree(), poi_kind(), any(), any(), extra()) -> poi().
+new(Tree, Kind, Id, Data, Extra) ->
   Pos   = erl_syntax:get_pos(Tree),
-  Range = els_range:range(Pos, Kind, Data, Extra),
+  Range = els_range:range(Pos, Kind, Id, Extra),
   #{ kind  => Kind
+   , id    => Id
    , data  => Data
    , range => Range
-   , tree  => Tree
    }.
 
 -spec match_pos([poi()], pos()) -> [poi()].

--- a/src/els_references_provider.erl
+++ b/src/els_references_provider.erl
@@ -41,12 +41,12 @@ handle_request({references, Params}, State) ->
 
 -spec find_references(binary(), poi()) -> any().
 find_references(Uri, #{ kind := Kind
-                      , data := Data
+                      , id   := Id
                       }) when Kind =:= application;
                               Kind =:= implicit_fun;
                               Kind =:= function;
                               Kind =:= exports_entry ->
-  Key = case Data of
+  Key = case Id of
           {F, A}    -> {els_uri:module(Uri), F, A};
           {M, F, A} -> {M, F, A}
         end,

--- a/test/els_parser_SUITE.erl
+++ b/test/els_parser_SUITE.erl
@@ -42,7 +42,7 @@ all() -> els_test_utils:all(?MODULE).
 specs_location(_Config) ->
   Text = "-spec foo(integer()) -> any(); (atom()) -> pid().",
   {ok, POIs} = els_parser:parse(Text),
-  Spec = [POI || #{data := {{foo, 1}, _}, kind := spec} = POI <- POIs],
+  Spec = [POI || #{id := {{foo, 1}, _}, kind := spec} = POI <- POIs],
   ?assertEqual(1, length(Spec)),
   ok.
 


### PR DESCRIPTION
### Description

The reason why we added the full tree to the points of interest was because we wanted to get extra information later. But we could just add the information we need at the time of parsing.

Fixes #228.
