### PR TITLE
[#37] Extract POIs from spec attributes

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -563,4 +563,3 @@
                       , range := poi_range()
                       }.
 -type tree()      :: erl_syntax:syntaxTree().
--type extra()     :: any().

--- a/priv/code_navigation/src/code_navigation.erl
+++ b/priv/code_navigation/src/code_navigation.erl
@@ -52,7 +52,7 @@ function_g(X) ->
   G = {fun code_navigation_extra:do/1, X#included_record_a.field_b},
   {?INCLUDED_MACRO_A, #included_record_a{}, F, G}.
 
--spec function_h() -> type_a().
+-spec function_h() -> type_a() | undefined_type_a().
 function_h() ->
   function_i().
 

--- a/priv/code_navigation/src/code_navigation_extra.erl
+++ b/priv/code_navigation/src/code_navigation_extra.erl
@@ -8,5 +8,6 @@ do(_Config) ->
 do_2() ->
   code_navigation:function_h().
 
-do_3() ->
+-spec do_3(nat(), wot()) -> {atom(), code_navigation_types:type_a()}.
+do_3(_, _) ->
   code_navigation:function_j().

--- a/priv/code_navigation/src/code_navigation_types.erl
+++ b/priv/code_navigation/src/code_navigation_types.erl
@@ -1,0 +1,5 @@
+-module(code_navigation_types).
+
+-type type_a() :: atom().
+
+-export_type([ type_a/0 ]).

--- a/src/els_code_navigation.erl
+++ b/src/els_code_navigation.erl
@@ -34,7 +34,7 @@ goto_definition( Uri
                , #{ kind := Kind, id := {F, A}}
                ) when Kind =:= application;
                       Kind =:= implicit_fun;
-                      Kind =:= exports_entry ->
+                      Kind =:= export_entry ->
   find(Uri, function, {F, A});
 goto_definition(_Uri, #{ kind := behaviour, id := Behaviour }) ->
   case els_utils:find_module(Behaviour) of
@@ -51,15 +51,19 @@ goto_definition(Uri, #{ kind := record_expr, id := Record }) ->
 goto_definition(_Uri, #{ kind := Kind, id := Include }
                ) when Kind =:= include;
                       Kind =:= include_lib ->
-  %% TODO: Index header definitions as well
   FileName = filename:basename(Include),
   M = list_to_atom(FileName),
   case els_utils:find_module(M) of
     {ok, Uri}      -> {ok, Uri, beginning()};
     {error, Error} -> {error, Error}
   end;
-goto_definition(Uri, #{ kind := type_application, id := {Type, _} }) ->
-  find(Uri, type_definition, Type);
+goto_definition(_Uri, #{ kind := type_application, id := {M, T, A} }) ->
+  case els_utils:find_module(M) of
+    {ok, Uri}      -> find(Uri, type_definition, {T, A});
+    {error, Error} -> {error, Error}
+  end;
+goto_definition(Uri, #{ kind := type_application, id := {T, A} }) ->
+  find(Uri, type_definition, {T, A});
 goto_definition(_Filename, _) ->
   {error, not_found}.
 

--- a/src/els_completion_provider.erl
+++ b/src/els_completion_provider.erl
@@ -124,7 +124,7 @@ functions(Document, _OnlyExported = false, Arity) ->
   List = [completion_item_function(POI, Arity) || POI <- POIs],
   lists:usort(List);
 functions(Document, _OnlyExported = true, Arity) ->
-  Exports   = els_document:points_of_interest(Document, [exports_entry]),
+  Exports   = els_document:points_of_interest(Document, [export_entry]),
   Functions = els_document:points_of_interest(Document, [function]),
   ExportsFA = [FA || #{id := FA} <- Exports],
   List      = [ completion_item_function(POI, Arity)

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -77,7 +77,7 @@ index(Document) ->
   ok = els_db:store(modules, Module, Uri),
   Specs  = els_document:points_of_interest(Document, [spec]),
   [els_db:store(signatures, {Module, F, A}, Tree) ||
-    #{id := {{F, A}, Tree}} <- Specs],
+    #{id := {F, A}, data := Tree} <- Specs],
   Kinds = [application, implicit_fun],
   POIs  = els_document:points_of_interest(Document, Kinds),
   [register_reference(Uri, POI) || POI <- POIs],

--- a/src/els_poi.erl
+++ b/src/els_poi.erl
@@ -4,8 +4,8 @@
 -module(els_poi).
 
 %% Constructor
--export([ new/4
-        , new/5
+-export([ new/3
+        , new/4
         ]).
 
 -export([ match_pos/2 ]).
@@ -20,15 +20,14 @@
 %%==============================================================================
 
 %% @edoc Constructor for a Point of Interest.
--spec new(tree(), poi_kind(), any(), extra()) -> poi().
-new(Tree, Kind, Id, Extra) ->
-  new(Tree, Kind, Id, undefined, Extra).
+-spec new(pos(), poi_kind(), any()) -> poi().
+new(Pos, Kind, Id) ->
+  new(Pos, Kind, Id, undefined).
 
 %% @edoc Constructor for a Point of Interest.
--spec new(tree(), poi_kind(), any(), any(), extra()) -> poi().
-new(Tree, Kind, Id, Data, Extra) ->
-  Pos   = erl_syntax:get_pos(Tree),
-  Range = els_range:range(Pos, Kind, Id, Extra),
+-spec new(pos(), poi_kind(), any(), any()) -> poi().
+new(Pos, Kind, Id, Data) ->
+  Range = els_range:range(Pos, Kind, Id),
   #{ kind  => Kind
    , id    => Id
    , data  => Data

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -79,7 +79,7 @@ range({Line, Column}, type_application, {F, _A}) ->
   #{ from => From, to => To };
 range({Line, Column}, type_application, {M, F, _A}) ->
   From = {Line, Column - 1},
-  To = {Line, Column + length(atom_to_list(M)) + length(atom_to_list(F)) - 1},
+  To = {Line, Column + length(atom_to_list(M)) + length(atom_to_list(F))},
   #{ from => From, to => To };
 range({Line, Column}, type_definition, _Type) ->
   From = {Line, Column},

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -79,7 +79,7 @@ range({Line, Column}, type_application, {F, _A}) ->
   #{ from => From, to => To };
 range({Line, Column}, type_application, {M, F, _A}) ->
   From = {Line, Column - 1},
-  To = {Line, Column + length(atom_to_list(M)), + length(atom_to_list(F)) - 1},
+  To = {Line, Column + length(atom_to_list(M)) + length(atom_to_list(F)) - 1},
   #{ from => From, to => To };
 range({Line, Column}, type_definition, _Type) ->
   From = {Line, Column},

--- a/src/els_references_provider.erl
+++ b/src/els_references_provider.erl
@@ -45,7 +45,7 @@ find_references(Uri, #{ kind := Kind
                       }) when Kind =:= application;
                               Kind =:= implicit_fun;
                               Kind =:= function;
-                              Kind =:= exports_entry ->
+                              Kind =:= export_entry ->
   Key = case Id of
           {F, A}    -> {els_uri:module(Uri), F, A};
           {M, F, A} -> {M, F, A}

--- a/test/els_completion_SUITE.erl
+++ b/test/els_completion_SUITE.erl
@@ -84,12 +84,16 @@ atom_completions(Config) ->
                 }
              , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
                 , kind             => ?COMPLETION_ITEM_KIND_MODULE
+                , label            => <<"code_navigation_types">>
+                }
+             , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                , kind             => ?COMPLETION_ITEM_KIND_MODULE
                 , label            => <<"code_navigation.hrl">>
                 }
-             , #{ insertText => <<"do_3()">>
+             , #{ insertText => <<"do_3(${1:Arg1}, ${2:Arg2})">>
                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
-                  label => <<"do_3/0">>
+                  label => <<"do_3/2">>
                 }
              , #{ insertText => <<"do_2()">>
                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET

--- a/test/els_definition_SUITE.erl
+++ b/test/els_definition_SUITE.erl
@@ -34,7 +34,9 @@
         , record_access_included/1
         , record_expr/1
         , record_expr_included/1
-        , type_application/1
+        , type_application_remote/1
+        , type_application_undefined/1
+        , type_application_user/1
         ]).
 
 %%==============================================================================
@@ -291,8 +293,27 @@ record_expr_included(Config) ->
               , Range),
   ok.
 
--spec type_application(config()) -> ok.
-type_application(Config) ->
+-spec type_application_remote(config()) -> ok.
+type_application_remote(Config) ->
+  ExtraUri = ?config(code_navigation_extra_uri, Config),
+  TypesUri = ?config(code_navigation_types_uri, Config),
+  Def = els_client:definition(ExtraUri, 11, 38),
+  #{result := #{range := Range, uri := DefUri}} = Def,
+  ?assertEqual(TypesUri, DefUri),
+  ?assertEqual( els_protocol:range(#{from => {3, 2}, to => {3, 2}})
+              , Range),
+  ok.
+
+-spec type_application_undefined(config()) -> ok.
+type_application_undefined(Config) ->
+  Uri = ?config(code_navigation_uri, Config),
+  Def = els_client:definition(Uri, 55, 42),
+  #{result := Result} =  Def,
+  ?assertEqual(null, Result),
+  ok.
+
+-spec type_application_user(config()) -> ok.
+type_application_user(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   Def = els_client:definition(Uri, 55, 25),
   #{result := #{range := Range, uri := DefUri}} = Def,

--- a/test/els_hover_SUITE.erl
+++ b/test/els_hover_SUITE.erl
@@ -65,7 +65,7 @@ end_per_testcase(TestCase, Config) ->
 -spec hover_docs(config()) -> ok.
 hover_docs(Config) ->
   Uri = ?config(code_navigation_extra_uri, Config),
-  #{result := Result} = els_client:hover(Uri, 12, 26),
+  #{result := Result} = els_client:hover(Uri, 13, 26),
   ?assert(maps:is_key(contents, Result)),
   Contents = maps:get(contents, Result),
   ?assertEqual( #{ kind  => <<"markdown">>

--- a/test/els_parser_SUITE.erl
+++ b/test/els_parser_SUITE.erl
@@ -42,7 +42,7 @@ all() -> els_test_utils:all(?MODULE).
 specs_location(_Config) ->
   Text = "-spec foo(integer()) -> any(); (atom()) -> pid().",
   {ok, POIs} = els_parser:parse(Text),
-  Spec = [POI || #{id := {{foo, 1}, _}, kind := spec} = POI <- POIs],
+  Spec = [POI || #{id := {foo, 1}, kind := spec} = POI <- POIs],
   ?assertEqual(1, length(Spec)),
   ok.
 

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -48,6 +48,9 @@ init_per_suite(Config) ->
   ExtraPath              = filename:join([ RootPath
                                          , <<"src">>
                                          , <<"code_navigation_extra.erl">>]),
+  TypesPath              = filename:join([ RootPath
+                                         , <<"src">>
+                                         , <<"code_navigation_types.erl">>]),
   BehaviourPath          = filename:join([ RootPath
                                          , <<"src">>
                                          , <<"behaviour_a.erl">>]),
@@ -63,6 +66,7 @@ init_per_suite(Config) ->
 
   Uri                    = els_uri:uri(Path),
   ExtraUri               = els_uri:uri(ExtraPath),
+  TypesUri               = els_uri:uri(TypesPath),
   BehaviourUri           = els_uri:uri(BehaviourPath),
   IncludeUri             = els_uri:uri(IncludePath),
   DiagnosticsUri         = els_uri:uri(DiagnosticsPath),
@@ -78,6 +82,7 @@ init_per_suite(Config) ->
   , {code_navigation_uri, Uri}
   , {code_navigation_text, Text}
   , {code_navigation_extra_uri, ExtraUri}
+  , {code_navigation_types_uri, TypesUri}
   , {behaviour_uri, BehaviourUri}
   , {include_uri, IncludeUri}
   , {diagnostics_uri, DiagnosticsUri}
@@ -118,10 +123,12 @@ init_per_testcase(_TestCase, Config) ->
   els_client:did_open(Uri, erlang, 1, Text),
 
   %% Ensure modules used in test suites are indexed
-  els_indexer:find_and_index_file("behaviour_a", async),
-  els_indexer:find_and_index_file("code_navigation_extra", async),
-  els_indexer:find_and_index_file("code_navigation.hrl", async),
-  els_indexer:find_and_index_file("diagnostics.hrl", async),
+  els_indexer:find_and_index_file("behaviour_a", sync),
+  els_indexer:find_and_index_file("code_navigation", sync),
+  els_indexer:find_and_index_file("code_navigation_extra", sync),
+  els_indexer:find_and_index_file("code_navigation_types", sync),
+  els_indexer:find_and_index_file("code_navigation.hrl", sync),
+  els_indexer:find_and_index_file("diagnostics.hrl", sync),
 
   [{started, Started} | Config].
 

--- a/test/els_workspace_symbol_SUITE.erl
+++ b/test/els_workspace_symbol_SUITE.erl
@@ -69,6 +69,7 @@ query_multiple(Config) ->
   Query = <<"code_navigation">>,
   Uri = ?config(code_navigation_uri, Config),
   ExtraUri = ?config(code_navigation_extra_uri, Config),
+  TypesUri = ?config(code_navigation_types_uri, Config),
   #{result := Result} = els_client:workspace_symbol(Query),
   Expected = [ #{ kind => ?SYMBOLKIND_MODULE
                 , location =>
@@ -89,6 +90,16 @@ query_multiple(Config) ->
                      , uri  => ExtraUri
                      }
                 , name => <<"code_navigation_extra">>
+                }
+             , #{ kind => ?SYMBOLKIND_MODULE
+                , location =>
+                    #{ range =>
+                         #{ 'end' => #{character => 0, line => 0}
+                          , start => #{character => 0, line => 0}
+                          }
+                     , uri  => TypesUri
+                     }
+                , name => <<"code_navigation_types">>
                 }
              ],
   ?assertEqual(lists:sort(Expected), lists:sort(Result)),


### PR DESCRIPTION
### Description

* Enable code navigation for remote types
* Rename exports_entry into export_entry for consistency
* Get rid of the "extra" context in the parser
* Pass a location instead of the whole tree to `els_poi:new/X`
* Refactor the parser

Fixes #37 and  #180.
