### PR TITLE
[#242] Avoid writing to temporary file for parsing

### DIFF
--- a/src/els_io_string.erl
+++ b/src/els_io_string.erl
@@ -1,0 +1,139 @@
+-module(els_io_string).
+
+-export([new/1]).
+
+-export([ start_link/1
+        , init/1
+        , loop/1
+        , skip/3
+        ]).
+
+-type state() :: #{ buffer   := string()
+                  , original := string()
+                  }.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec new(string() | binary()) -> pid().
+new(Str) when is_binary(Str) ->
+  new(unicode:characters_to_list(Str));
+new(Str) ->
+  start_link(Str).
+
+%%------------------------------------------------------------------------------
+%% IO server
+%%
+%% Implementation of a subset of the io protocol in order to only support
+%% reading operations.
+%%------------------------------------------------------------------------------
+
+-spec start_link(string()) -> pid().
+start_link(Str) ->
+  spawn_link(?MODULE, init, [Str]).
+
+-spec init(string()) -> ok.
+init(Str) ->
+  State = #{buffer => Str, original => Str},
+  ?MODULE:loop(State).
+
+-spec loop(state()) -> ok.
+loop(#{buffer := Str} = State) ->
+  receive
+    {io_request, From, ReplyAs, Request} ->
+      {Reply, NewStr} = request(Request, Str),
+      reply(From, ReplyAs, Reply),
+      ?MODULE:loop(State#{buffer := NewStr});
+    {file_request, From, Ref, close} ->
+      file_reply(From, Ref, ok);
+    {file_request, From, Ref, {position, Pos}} ->
+      {Reply, NewState} = file_position(Pos, State),
+      file_reply(From, Ref, Reply),
+      ?MODULE:loop(NewState);
+    _Unknown ->
+      ?MODULE:loop(State)
+  end.
+
+-spec reply(pid(), pid(), any()) -> any().
+reply(From, ReplyAs, Reply) ->
+  From ! {io_reply, ReplyAs, Reply}.
+
+-spec file_reply(pid(), pid(), any()) -> any().
+file_reply(From, ReplyAs, Reply) ->
+  From ! {file_reply, ReplyAs, Reply}.
+
+-spec file_position(integer(), state()) -> {any(), state()}.
+file_position(Pos, #{original := Original} = State) ->
+  Buffer = lists:nthtail(Pos, Original),
+  {{ok, Pos}, State#{buffer => Buffer}}.
+
+-spec request(any(), string()) -> {string() | {error, request}, string()}.
+request({get_chars, _Encoding, _Prompt, N}, Str) ->
+  get_chars(N, Str);
+request({get_line, _Encoding, _Prompt}, Str) ->
+  get_line(Str);
+request({get_until, _Encoding, _Prompt, Module, Function, Xargs}, Str) ->
+  get_until(Module, Function, Xargs, Str);
+request(_Other, State) ->
+  {{error, request}, State}.
+
+-spec get_chars(integer(), string()) -> {string() | eof, string()}.
+get_chars(_N, []) ->
+  {eof, []};
+get_chars(1, [Ch | Str]) ->
+  {[Ch], Str};
+get_chars(N, Str) ->
+  do_get_chars(N, Str, []).
+
+-spec do_get_chars(integer(), string(), string()) -> {string(), string()}.
+do_get_chars(0, Str, Result) ->
+  {lists:flatten(Result), Str};
+do_get_chars(_N, [], Result) ->
+  {Result, []};
+do_get_chars(N, [Ch | NewStr], Result) ->
+  do_get_chars(N - 1, NewStr, [Result, Ch]).
+
+-spec get_line(string()) -> {string() | eof, string()}.
+get_line([]) ->
+  {eof, []};
+get_line(Str) ->
+  do_get_line(Str, []).
+
+-spec do_get_line(string(), string()) -> {string() | eof, string()}.
+do_get_line([], Result) ->
+  {lists:flatten(Result), []};
+do_get_line("\r\n" ++ RestStr, Result) ->
+  {lists:flatten(Result), RestStr};
+do_get_line("\n" ++ RestStr, Result) ->
+  {lists:flatten(Result), RestStr};
+do_get_line("\r" ++ RestStr, Result) ->
+  {lists:flatten(Result), RestStr};
+do_get_line([Ch | RestStr], Result) ->
+  do_get_line(RestStr, [Result, Ch]).
+
+-spec get_until(module(), atom(), list(), term()) ->
+  {term(), string()}.
+get_until(Module, Function, XArgs, Str) ->
+  apply_get_until(Module, Function, [], Str, XArgs).
+
+-spec apply_get_until(module(), atom(), any(), string() | eof, list()) ->
+  {term(), string()}.
+apply_get_until(Module, Function, State, String, XArgs) ->
+  case apply(Module, Function, [State, String | XArgs]) of
+    {done, Result, NewStr} ->
+      {Result, NewStr};
+    {more, NewState} ->
+      apply_get_until(Module, Function, NewState, eof, XArgs)
+  end.
+
+-spec skip(string() | {cont, integer(), string()}, term(), integer()) ->
+  {more, {cont, integer(), string()}} | {done, integer(), string()}.
+skip(Str, _Data, Length) when is_list(Str) ->
+  {more, {cont, Length, Str}};
+skip({cont, 0, Str}, _Data, Length) ->
+  {done, Length, Str};
+skip({cont, Length, []}, _Data, Length) ->
+  {done, eof, []};
+skip({cont, Length, [_ | RestStr]}, _Data, _Length) ->
+  {more, {cont, Length - 1, RestStr}}.

--- a/test/els_completion_SUITE.erl
+++ b/test/els_completion_SUITE.erl
@@ -139,11 +139,11 @@ exported_functions(Config) ->
 
   #{result := Completion1} =
     els_client:completion(Uri, 32, 25, TriggerKind, <<":">>),
-  ?assertEqual(lists:sort(Completion1), lists:sort(ExpectedCompletion)),
+  ?assertEqual(lists:sort(ExpectedCompletion), lists:sort(Completion1)),
 
   #{result := Completion2} =
     els_client:completion(Uri, 52, 34, TriggerKind, <<":">>),
-  ?assertEqual(lists:sort(Completion2), lists:sort(ExpectedCompletion)),
+  ?assertEqual(lists:sort(ExpectedCompletion), lists:sort(Completion2)),
 
   ok.
 
@@ -163,7 +163,7 @@ exported_functions_arity(Config) ->
 
   #{result := Completion} =
     els_client:completion(Uri, 52, 35, TriggerKind, <<"">>),
-  ?assertEqual(lists:sort(Completion), lists:sort(ExpectedCompletion)),
+  ?assertEqual(lists:sort(ExpectedCompletion), lists:sort(Completion)),
 
   ok.
 
@@ -232,11 +232,11 @@ macros(Config) ->
 
   #{result := Completion1} =
     els_client:completion(Uri, 24, 1, TriggerKindChar, <<"?">>),
-  ?assertEqual(lists:sort(Completion1), lists:sort(Expected)),
+  ?assertEqual(lists:sort(Expected), lists:sort(Completion1)),
 
   #{result := Completion2} =
     els_client:completion(Uri, 40, 5, TriggerKindInvoked, <<"">>),
-  ?assertEqual(lists:sort(Completion2), lists:sort(Expected)),
+  ?assertEqual(lists:sort(Expected), lists:sort(Completion2)),
 
   ok.
 
@@ -258,7 +258,7 @@ only_exported_functions_after_colon(Config) ->
 
   #{result := Completion} =
     els_client:completion(Uri, 32, 26, TriggerKind, <<"d">>),
-  ?assertEqual(lists:sort(Completion), lists:sort(ExpectedCompletion)),
+  ?assertEqual(lists:sort(ExpectedCompletion), lists:sort(Completion)),
 
   ok.
 
@@ -272,6 +272,6 @@ variables(Config) ->
 
   #{result := Completion} =
     els_client:completion(Uri, 5, 8, TriggerKind, <<"">>),
-  ?assertEqual(lists:sort(Completion), lists:sort(Expected)),
+  ?assertEqual(lists:sort(Expected), lists:sort(Completion)),
 
   ok.

--- a/test/els_io_string_SUITE.erl
+++ b/test/els_io_string_SUITE.erl
@@ -1,0 +1,94 @@
+-module(els_io_string_SUITE).
+
+%% CT Callbacks
+-export([ init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , all/0
+        ]).
+
+%% Test cases
+-export([ scan_forms/1
+        , parse_text/1
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec all() -> [atom()].
+all() -> els_test_utils:all(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(_TestCase, Config) -> Config.
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(_TestCase, _Config) -> ok.
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+
+-spec scan_forms(config()) -> ok.
+scan_forms(Config) ->
+  Path         = ?config(code_navigation_path, Config),
+  {ok, IoFile} = file:open(Path, [read]),
+  Expected     = scan_all_forms(IoFile, []),
+  ok           = file:close(IoFile),
+
+  Text     = ?config(code_navigation_text, Config),
+  IoString = els_io_string:new(Text),
+  Result   = scan_all_forms(IoString, []),
+  ok       = file:close(IoString),
+
+  ?assertEqual(Expected, Result),
+
+  ok.
+
+-spec parse_text(config()) -> ok.
+parse_text(Config) ->
+  Path           = ?config(code_navigation_path, Config),
+  {ok, IoFile}   = file:open(Path, [read]),
+  {ok, Expected} = els_parser:parse_file(IoFile),
+  ok             = file:close(IoFile),
+
+  Text           = ?config(code_navigation_text, Config),
+  IoString       = els_io_string:new(Text),
+  {ok, Result}   = els_parser:parse_file(IoString),
+  ok             = file:close(IoString),
+
+  ?assertEqual(Expected, Result),
+
+  ok.
+
+%%==============================================================================
+%% Helper functions
+%%==============================================================================
+
+-spec scan_all_forms(file:io_device(), [any()]) -> [any()].
+scan_all_forms(IoDevice, Acc) ->
+  case io:scan_erl_form(IoDevice, "") of
+    {ok, Tokens, _} ->
+      scan_all_forms(IoDevice, [Tokens | Acc]);
+    {eof, _} ->
+      Acc
+  end.

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -80,6 +80,7 @@ init_per_suite(Config) ->
 
   [ {root_uri, RootUri}
   , {code_navigation_uri, Uri}
+  , {code_navigation_path, Path}
   , {code_navigation_text, Text}
   , {code_navigation_extra_uri, ExtraUri}
   , {code_navigation_types_uri, TypesUri}


### PR DESCRIPTION
### Description

Avoid writing to temporary file for parsing.

Fixes #242.
