### PR TITLE
[#241] Add code navigation for opaque types

### DIFF
--- a/priv/code_navigation/src/code_navigation_extra.erl
+++ b/priv/code_navigation/src/code_navigation_extra.erl
@@ -11,3 +11,9 @@ do_2() ->
 -spec do_3(nat(), wot()) -> {atom(), code_navigation_types:type_a()}.
 do_3(_, _) ->
   code_navigation:function_j().
+
+-spec do_4(nat(), opaque_local()) -> {atom(), code_navigation_types:opaque_type_a()}.
+do_4(_, _) ->
+  code_navigation:function_j().
+
+-opaque opaque_local() :: atom().

--- a/priv/code_navigation/src/code_navigation_types.erl
+++ b/priv/code_navigation/src/code_navigation_types.erl
@@ -3,3 +3,7 @@
 -type type_a() :: atom().
 
 -export_type([ type_a/0 ]).
+
+-opaque opaque_type_a() :: atom().
+
+-export_type([ opaque_type_a/0 ]).

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -242,6 +242,8 @@ attribute(Tree) ->
       [els_poi:new(Pos, spec, {F, A}, Tree)];
     {type, {type, {Type, _, Args}}} ->
       [els_poi:new(Pos, type_definition, {Type, length(Args)})];
+    {opaque, {opaque, {Type, _, Args}}} ->
+      [els_poi:new(Pos, type_definition, {Type, length(Args)})];
     _ ->
       []
   catch throw:syntax_error ->

--- a/test/els_completion_SUITE.erl
+++ b/test/els_completion_SUITE.erl
@@ -90,6 +90,11 @@ atom_completions(Config) ->
                 , kind             => ?COMPLETION_ITEM_KIND_MODULE
                 , label            => <<"code_navigation.hrl">>
                 }
+             , #{ insertText => <<"do_4(${1:Arg1}, ${2:Arg2})">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
+                  label => <<"do_4/2">>
+                }
              , #{ insertText => <<"do_3(${1:Arg1}, ${2:Arg2})">>
                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,

--- a/test/els_definition_SUITE.erl
+++ b/test/els_definition_SUITE.erl
@@ -37,6 +37,8 @@
         , type_application_remote/1
         , type_application_undefined/1
         , type_application_user/1
+        , opaque_application_remote/1
+        , opaque_application_user/1
         ]).
 
 %%==============================================================================
@@ -319,5 +321,26 @@ type_application_user(Config) ->
   #{result := #{range := Range, uri := DefUri}} = Def,
   ?assertEqual(Uri, DefUri),
   ?assertEqual( els_protocol:range(#{from => {37, 2}, to => {37, 2}})
+              , Range),
+  ok.
+
+-spec opaque_application_remote(config()) -> ok.
+opaque_application_remote(Config) ->
+  ExtraUri = ?config(code_navigation_extra_uri, Config),
+  TypesUri = ?config(code_navigation_types_uri, Config),
+  Def = els_client:definition(ExtraUri, 15, 61),
+  #{result := #{range := Range, uri := DefUri}} = Def,
+  ?assertEqual(TypesUri, DefUri),
+  ?assertEqual( els_protocol:range(#{from => {7, 2}, to => {7, 2}})
+              , Range),
+  ok.
+
+-spec opaque_application_user(config()) -> ok.
+opaque_application_user(Config) ->
+  ExtraUri = ?config(code_navigation_extra_uri, Config),
+  Def      = els_client:definition(ExtraUri, 15, 24),
+  #{result := #{range := Range, uri := DefUri}} = Def,
+  ?assertEqual(ExtraUri, DefUri),
+  ?assertEqual( els_protocol:range(#{from => {19, 2}, to => {19, 2}})
               , Range),
   ok.


### PR DESCRIPTION
### Description

Fixes #241.

I am not distinguishing between types and opaques, but we could change this if the distinction becomes necessary.
