### PR TITLE
[#229] Resolve paths recursively only for the ones used with file:path_open/3

### DIFF
--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -51,11 +51,8 @@ find_and_index_file(FileName) ->
 -spec find_and_index_file(string(), async | sync) ->
    {ok, uri()} | {error, any()}.
 find_and_index_file(FileName, SyncAsync) ->
-  Paths = lists:append([ els_config:get(app_paths)
-                       , els_config:get(deps_paths)
-                       , els_config:get(otp_paths)
-                       ]),
-  case file:path_open(Paths, list_to_binary(FileName), [read]) of
+  SearchPaths = els_config:get(search_paths),
+  case file:path_open(SearchPaths, list_to_binary(FileName), [read]) of
     {ok, IoDevice, FullName} ->
       %% TODO: Avoid opening file twice
       file:close(IoDevice),


### PR DESCRIPTION
### Description

Avoid going over the same subdirs more than once while indexing.

Fixes #229.

The following are the results of calling `ets:i/0` before and after this change (including only relevant tables), to check that the number of items in each table was the same.

# Before

```
 id              name              type  size   mem      owner
 ----------------------------------------------------------------------------
 documents       documents         set   1967   87944313 els_db
 modules         modules           set   1651   25103    els_db
 references      references        set   62570  10334672 els_db
 signatures      signatures        set   12035  15965340 els_db
```

# After

```
id              name              type  size   mem      owner
 ----------------------------------------------------------------------------
 documents       documents         set   1967   87945491 els_db
 modules         modules           set   1651   25103    els_db
 references      references        set   62570  10326540 els_db
 signatures      signatures        set   12035  15965844 els_db
```

