### PR TITLE
[#245] flush references db on update

### DIFF
--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -2,6 +2,7 @@
 
 %% API
 -export([ find/2
+        , find_multi/2
         , keys/1
         , list/1
         , store/3
@@ -18,10 +19,10 @@
         ]).
 
 -define(SERVER, ?MODULE).
--define(TABLES, [ documents
-                , modules
-                , references
-                , signatures
+-define(TABLES, [ {documents,  set}
+                , {modules,    set}
+                , {references, duplicate_bag}
+                , {signatures, set}
                 ]).
 
 -type state() :: #{}.
@@ -41,6 +42,15 @@ find(Table, Key) ->
   case ets:lookup(Table, Key) of
     [] -> {error, not_found};
     [{Key, Value}] -> {ok, Value}
+  end.
+
+-spec find_multi(table(), key()) -> {ok, nonempty_list(any())}
+                                    | {error, not_found}.
+find_multi(Table, Key) ->
+  case ets:lookup(Table, Key) of
+    [] -> {error, not_found};
+    KVs -> {ok, KVs} %% Return as is, we need to iterate the result
+                     %% anyway, no point doing it twice.
   end.
 
 -spec keys(table()) -> [any()].
@@ -70,6 +80,8 @@ update(Table, Key, UpdateFun, Default) ->
       Replace = [{{Key, Old}, [], [{const, {Key, New}}]}],
       case ets:select_replace(Table, Replace) of
         1 -> ok;
+        %% AZ: The next line is a recursive call. If it is ever hit,
+        %%     will we have an infinite loop?
         0 -> update(Table, Key, UpdateFun, Default)
       end
   end.
@@ -81,8 +93,8 @@ delete(Table, Key) ->
 
 -spec flush_all_tables() -> ok.
 flush_all_tables() ->
-  [delete_table(Name) || Name <- ?TABLES],
-  [create_table(Name) || Name <- ?TABLES],
+  [delete_table(Details) || Details <- ?TABLES],
+  [create_table(Details) || Details <- ?TABLES],
   ok.
 
 %%==============================================================================
@@ -104,10 +116,10 @@ handle_cast(_Msg, State) -> {noreply, State}.
 %% Internal functions
 %%==============================================================================
 
--spec create_table(atom()) -> ok.
-create_table(Name) ->
+-spec create_table({atom(), atom()}) -> ok.
+create_table({Name, Type}) ->
   Opts = [ named_table
-         , set
+         , Type
          , public
          , {write_concurrency, true}
          , compressed
@@ -115,7 +127,7 @@ create_table(Name) ->
   ets:new(Name, Opts),
   ok.
 
--spec delete_table(atom()) -> ok.
-delete_table(Name) ->
+-spec delete_table({atom(), atom()}) -> ok.
+delete_table({Name, _}) ->
   ets:delete(Name),
   ok.

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -7,6 +7,7 @@
         , store/3
         , update/4
         , delete/2
+        , flush_all_tables/0
         , start_link/0
         ]).
 
@@ -78,6 +79,12 @@ delete(Table, Key) ->
   true = ets:delete(Table, Key),
   ok.
 
+-spec flush_all_tables() -> ok.
+flush_all_tables() ->
+  [delete_table(Name) || Name <- ?TABLES],
+  [create_table(Name) || Name <- ?TABLES],
+  ok.
+
 %%==============================================================================
 %% gen_server Callback Functions
 %%==============================================================================
@@ -106,4 +113,9 @@ create_table(Name) ->
          , compressed
          ],
   ets:new(Name, Opts),
+  ok.
+
+-spec delete_table(atom()) -> ok.
+delete_table(Name) ->
+  ets:delete(Name),
   ok.

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -78,7 +78,7 @@ index(Document) ->
     #{id := {F, A}, data := Tree} <- Specs],
   Kinds = [application, implicit_fun],
   POIs  = els_document:points_of_interest(Document, Kinds),
-  purge_reference_uri(Uri),
+  purge_uri_references(Uri),
   [register_reference(Uri, POI) || POI <- POIs],
   ok.
 
@@ -214,8 +214,8 @@ add_reference(Key, Value) ->
   ok = els_db:store(references, Key, Value).
 
 %% @edoc Remove all references to a given uri()
--spec purge_reference_uri(uri()) -> ok.
-purge_reference_uri(Uri) ->
+-spec purge_uri_references(uri()) -> ok.
+purge_uri_references(Uri) ->
     MatchSpec = ets:fun2ms(fun({_K, #{uri => U}}) -> U =:= Uri end),
     _DeletedCount = ets:select_delete(references, MatchSpec),
     ok.

--- a/src/els_references_provider.erl
+++ b/src/els_references_provider.erl
@@ -50,13 +50,11 @@ find_references(Uri, #{ kind := Kind
           {F, A}    -> {els_uri:module(Uri), F, A};
           {M, F, A} -> {M, F, A}
         end,
-  case els_db:find(references, Key) of
+  case els_db:find_multi(references, Key) of
     {error, not_found} ->
       null;
-    {ok, []} ->
-      null;
     {ok, Refs} ->
-      [location(U, R) || #{uri := U, range := R} <- ordsets:to_list(Refs)]
+      [location(U, R) || {_, #{uri := U, range := R}} <- Refs]
   end;
 find_references(_Uri, _POI) ->
   null.

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -17,7 +17,7 @@
         , fun_local/1
         , fun_remote/1
         , export_entry/1
-        , flush_references_db/1
+        , purge_references/1
         ]).
 
 %%==============================================================================
@@ -150,8 +150,8 @@ export_entry(Config) ->
   ok.
 
 %% Issue #245
--spec flush_references_db(config()) -> ok.
-flush_references_db(_Config) ->
+-spec purge_references(config()) -> ok.
+purge_references(_Config) ->
   els_db:flush_all_tables(),
   Uri = <<"file://tmp/foo.erl">>,
   Text0 = "-spec foo(integer()) -> ok.\nfoo _X -> ok.\nbar() -> foo(1).",

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -162,8 +162,8 @@ flush_references_db(_Config) ->
   els_indexer:index(Doc1),
   ?assertEqual([{foo,<<"file://tmp/foo.erl">>}],els_db:list(modules)),
   ?assertEqual([{{foo,foo,1},
-                 [#{range => #{from => {4,10},to => {4,13}},
-                    uri => <<"file://tmp/foo.erl">>}]}],
+                 #{range => #{from => {4,10},to => {4,13}},
+                   uri => <<"file://tmp/foo.erl">>}}],
                els_db:list(references)),
   ok.
 


### PR DESCRIPTION
### Description

When indexing a file, remove any references to the previous iteration of the file before adding the current ones.

Fixes #245.
