### PR TITLE
[#252] Don't assume unicode when getting a binary

### DIFF
--- a/src/els_io_string.erl
+++ b/src/els_io_string.erl
@@ -18,7 +18,7 @@
 
 -spec new(string() | binary()) -> pid().
 new(Str) when is_binary(Str) ->
-  new(unicode:characters_to_list(Str));
+  new(binary_to_list(Str));
 new(Str) ->
   start_link(Str).
 


### PR DESCRIPTION
### Description

Use `erlang:binary_to_string/1` instead.

Fixes #252.
