### PR TITLE
Enable compression for ETS tables

### DIFF
--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -99,5 +99,11 @@ handle_cast(_Msg, State) -> {noreply, State}.
 
 -spec create_table(atom()) -> ok.
 create_table(Name) ->
-  ets:new(Name, [named_table, set, public, {write_concurrency, true}]),
+  Opts = [ named_table
+         , set
+         , public
+         , {write_concurrency, true}
+         , compressed
+         ],
+  ets:new(Name, Opts),
   ok.


### PR DESCRIPTION
### Description

Enabling the compression for ETS tables reduces the memory usage quite significantly. The memory used when compressing is roughly 40% of the uncompressed usage.