### PR TITLE
[#258] Do not crash when calculating subdirs if a file is named test

### DIFF
--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -212,8 +212,8 @@ subdirs(Path) ->
 -spec subdirs(string(), [string()]) -> [string()].
 subdirs(Path, Subdirs) ->
   case file:list_dir(Path) of
-    {ok, Files}     -> subdirs_(Path, Files, Subdirs);
-    {error, enoent} -> Subdirs
+    {ok, Files} -> subdirs_(Path, Files, Subdirs);
+    {error, _}  -> Subdirs
   end.
 
 -spec subdirs_(string(), [string()], [string()]) -> [string()].


### PR DESCRIPTION
### Description

Fixes #258 .
