### PR TITLE
[#235] Single pass over forms

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,6 +34,7 @@
                    %% upstream version:
                    %% https://github.com/massemanet/redbug/pull/10
                  , [ {redbug, {git, "https://github.com/robertoaloi/redbug.git", {branch, "relax-beam-lib-error-matching"}}}
+                   , {eflame, {git, "https://github.com/jfacorro/eflame.git", {branch, "various.improvements"}}}
                    ]
                  }
                , { escript_emu_args

--- a/src/els_code_navigation.erl
+++ b/src/els_code_navigation.erl
@@ -79,7 +79,7 @@ find([Uri|Uris0], Kind, Data) ->
         [] ->
           find(lists:usort(include_uris(Document) ++ Uris0), Kind, Data);
         Definitions ->
-          {ok, Uri, lists:last(Definitions)}
+          {ok, Uri, hd(lists:sort(Definitions))}
       end;
     {error, not_found} ->
       find(Uris0, Kind, Data)

--- a/src/els_dodger.erl
+++ b/src/els_dodger.erl
@@ -79,9 +79,9 @@
 
 -export([parse_file/1, quick_parse_file/1, parse_file/2,
          quick_parse_file/2, parse/1, quick_parse/1, parse/2,
-         quick_parse/2, parse/3, quick_parse/3, parse_form/2,
+         quick_parse/2, parse/3, parse/4, quick_parse/3, parse_form/2,
          parse_form/3, quick_parse_form/2, quick_parse_form/3,
-         format_error/1, tokens_to_string/1]).
+         format_error/1, tokens_to_string/1, normal_parser/2]).
 
 
 %% The following should be: 1) pseudo-uniquely identifiable, and 2)

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -25,46 +25,47 @@ parse(Text) ->
 
 -spec parse_file(file:io_device()) -> {ok, [poi()]}.
 parse_file(IoDevice) ->
-  {ok, Forms} = els_dodger:parse(IoDevice, {1, 1}),
-  Tree = erl_syntax:form_list(Forms),
-  %% Reset file pointer position.
-  {ok, 0} = file:position(IoDevice, 0),
-  {ok, Extra} = parse_attribute_pois(IoDevice, [], {1, 1}),
+  {ok, NestedPOIs} = els_dodger:parse(IoDevice, {1, 1}, fun parse_form/3, []),
   ok = file:close(IoDevice),
-  POIs = points_of_interest(Tree),
-  {ok, Extra ++ POIs}.
+  {ok, lists:flatten(NestedPOIs)}.
+
+-spec parse_form(file:io_device(), any(), [any()]) ->
+    {'ok', erl_syntax:forms()
+  | none, integer()}
+  | {'eof', integer()}
+  | {'error', any(), integer()}.
+parse_form(Dev, L0, Options) ->
+  parse_form(Dev, L0, fun els_dodger:normal_parser/2, Options).
+
+-spec parse_form(file:io_device(), any(), function(), [any()]) ->
+  {'ok', erl_syntax:forms() | none, integer()}
+  | {'eof', integer()}
+  | {'error', any(), integer()}.
+parse_form(Dev, L0, Parser, _Options) ->
+  case io:scan_erl_form(Dev, "", L0) of
+    {ok, Ts, L1} ->
+      case catch {ok, Parser(Ts, undefined)} of
+        {ok, F} ->
+          POIs = [find_attribute_pois(F, Ts), points_of_interest(F)],
+          {ok, POIs, L1};
+        _ ->
+          {ok, [], L1}
+      end;
+    {error, _IoErr, _L1} = Err -> Err;
+    {error, _Reason} -> {eof, L0}; % This is probably encoding problem
+    {eof, _L1} = Eof -> Eof
+  end.
 
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
-
--spec parse_attribute_pois(io:device(), [poi()], erl_anno:location()) ->
-   {ok, [poi()]} | {error, any()}.
-parse_attribute_pois(IoDevice, Acc, StartLoc) ->
-  case io:scan_erl_form(IoDevice, "", StartLoc) of
-    {ok, Tokens, EndLoc} ->
-      case erl_parse:parse_form(Tokens) of
-        {ok, Form} ->
-          POIs = find_attribute_pois(Form, Tokens),
-          parse_attribute_pois(IoDevice, POIs ++ Acc, EndLoc);
-        {error, _Error} ->
-          parse_attribute_pois(IoDevice, Acc, EndLoc)
-      end;
-    {eof, _} ->
-      {ok, Acc};
-    {error, ErrorInfo, EndLoc} ->
-      lager:warning( "Could not parse extra information [end_loc=p] ~p"
-                   , [EndLoc, ErrorInfo]
-                   ),
-      {ok, Acc}
-  end.
 
 -spec find_attribute_pois(erl_parse:abstract_form(), [erl_scan:token()]) ->
    [poi()].
 find_attribute_pois(Form, Tokens) ->
   case erl_syntax:type(Form) of
     attribute ->
-      case erl_syntax_lib:analyze_attribute(Form) of
+      case catch erl_syntax_lib:analyze_attribute(Form) of
         {export, Exports} ->
           %% The first atom is the attribute name, so we skip it.
           [_|Atoms] = [T|| {atom, _, _} = T <- Tokens],
@@ -114,11 +115,8 @@ do_find_spec_points_of_interest(Tree, Acc) ->
 
 -spec points_of_interest(tree()) -> [poi()].
 points_of_interest(Tree) ->
-  lists:flatten(
-    erl_syntax_lib:fold(
-      fun(T, Acc) ->
-          [do_points_of_interest(T)|Acc]
-      end, [], Tree)).
+  FoldFun = fun(T, Acc) -> do_points_of_interest(T) ++ Acc end,
+  erl_syntax_lib:fold(FoldFun, [], Tree).
 
 %% @edoc Return the list of points of interest for a given `Tree`.
 -spec do_points_of_interest(tree()) -> [poi()].

--- a/test/els_document_symbol_SUITE.erl
+++ b/test/els_document_symbol_SUITE.erl
@@ -78,7 +78,7 @@ functions(Config) ->
                 } || {Name, {FromL, FromC}, {ToL, ToC}}
                        <- lists:append([functions()])],
   ?assertEqual(length(Expected), length(Symbols)),
-  Pairs = lists:zip(Expected, Symbols),
+  Pairs = lists:zip(lists:sort(Expected), lists:sort(Symbols)),
   [?assertEqual(E, S) || {E, S} <- Pairs],
   ok.
 


### PR DESCRIPTION
### Description

Expose functions from `els_dodger` to be able to make a single pass over all the forms. This improves the performance a bit, although not as much as we would have expected.

Fixes #235.

The following are flame graphs captured by running `eflame:apply(els_indexer, index_dir, ["src"]).` and then generating the SVG with the following command:
```
export NAME=stacks; cat $NAME.out | sort | grep -v "<0.349.0>" > "$NAME.out.sort"; _build/debug/lib/eflame/stack_to_flame.sh < $NAME.out.sort > $NAME.svg; open -a Google\ Chrome $NAME.svg
```

#### Before
![before](https://user-images.githubusercontent.com/1522569/69356025-14f3ea00-0c83-11ea-804c-a5d6dacc1a34.png)

#### After
![after](https://user-images.githubusercontent.com/1522569/69356082-2a691400-0c83-11ea-8ff4-cc906f620daf.png)