### PR TITLE
[#264] Handle generic errors to avoid crashing the els_server process

### DIFF
--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -189,9 +189,8 @@ try_index_file(FullName, SyncAsync) ->
 index_document(Document, async) ->
   ok = wpool:cast(indexers, {?MODULE, index, [Document]});
 index_document(Document, sync) ->
-  %% wpool:call/2 returns {ok, Result}
-  _ = wpool:call(indexers, {?MODULE, index, [Document]}),
-  ok.
+  %% Don't use the pool for synchronous indexing
+  ok = index(Document).
 
 %% TODO: Specific for references
 

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -39,7 +39,15 @@
 dispatch(Method, Params, State) ->
   Function = method_to_function_name(Method),
   try do_dispatch(Function, Params, State)
-  catch error:undef -> not_implemented_method(Method, State)
+  catch
+    error:undef ->
+      not_implemented_method(Method, State);
+    Type:Reason ->
+      lager:error("Unexpected error [type=~p] [error=~p]", [Type, Reason]),
+      Error = #{ code    => ?ERR_UNKNOWN_ERROR_CODE
+               , message => <<"Unexpected error while ", Method/binary>>
+               },
+      {error, Error, State}
   end.
 
 -spec do_dispatch(atom(), params(), state()) -> result().


### PR DESCRIPTION
### Description

Handle generic errors to avoid crashing the els_server process

Fixed #264.