### PR TITLE
[#235] Catch the correct type of exception

### DIFF
--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -84,7 +84,7 @@ find_attribute_pois(Form, Tokens) ->
           lists:flatten([find_spec_points_of_interest(FT) || FT <- FTs]);
         _ -> []
       catch
-        error:syntax_error -> []
+        throw:syntax_error -> []
       end;
     _ ->
       []


### PR DESCRIPTION
### Description

`erl_syntax_lib:analyze_attribute/1` generates a `throw` exception, not an `error`.

Fixes #235.
