### PR TITLE
[#181] Compile regex before using it multiple times

### DIFF
--- a/src/els_workspace_symbol_provider.erl
+++ b/src/els_workspace_symbol_provider.erl
@@ -21,7 +21,7 @@ is_enabled() ->
 handle_request({symbol, Params}, State) ->
   %% TODO: Version 3.15 of the protocol introduces a much nicer way of
   %%       specifying queries, allowing clients to send the symbol kind.
-  #{ <<"query">> := Query} = Params,
+  #{<<"query">> := Query} = Params,
   {modules(Query), State}.
 
 %%==============================================================================
@@ -31,9 +31,11 @@ handle_request({symbol, Params}, State) ->
 -spec modules(binary()) -> [symbol_information()].
 modules(Query) ->
   All = els_db:list(modules),
+  {ok, RePattern} = re:compile(Query),
+  ReOpts = [{capture, none}],
   F = fun({Module, Uri}) ->
           filename:extension(Uri) =:= <<".erl">> andalso
-            re:run(atom_to_binary(Module, utf8), Query) =/= nomatch
+            re:run(atom_to_binary(Module, utf8), RePattern, ReOpts) =:= match
       end,
   lists:map(fun symbol_information/1, lists:filter(F, All)).
 


### PR DESCRIPTION
### Description

From the [`re:compile/2`](http://erlang.org/doc/man/re.html#compile-2) docs:

> Compiling the regular expression before matching is useful if the same expression is to be used in matching against multiple subjects during the lifetime of the program. Compiling once and executing many times is far more efficient than compiling each time one wants to match.
