### PR TITLE
[#278] Report the server version on startup.

### DIFF
--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -129,7 +129,17 @@ initialize(Params, State) ->
 
 -spec initialized(params(), state()) -> result().
 initialized(_Params, State) ->
-  {noresponse, State#{status => initialized}}.
+  %% Report to the user the server version
+  {ok,     App} = application:get_application(),
+  {ok, Version} = application:get_key(App, vsn),
+  lager:info("initialized: [App=~p] [Version=~p]", [App, Version]),
+  BinVersion = list_to_binary(Version),
+  Message = <<"Erlang LS version: ", BinVersion/binary>>,
+  Method  = <<"window/showMessage">>,
+  Params  = #{ type    => ?MESSAGE_TYPE_INFO
+             , message => Message
+             },
+  {notification, Method, Params, State#{status => initialized}}.
 
 %%==============================================================================
 %% shutdown

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -1,6 +1,6 @@
 { application, erlang_ls
 , [ {description, "The Erlang Language Server"}
-  , {vsn, "1.0.0"}
+  , {vsn, git}
   , {registered, []}
   , {mod, { els_app, []}}
   , { applications


### PR DESCRIPTION
### Description

Reports the server version as a `window/showMessage` once initialisation is complete.

Also logs it, if logging is enabled.

Fixes #278.
