### PR TITLE
[#239] Resolve line length for compiler diagnostics

### DIFF
--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -19,9 +19,11 @@ compare(_, _) ->
 
 -spec range(pos(), poi_kind(), any()) -> poi_range().
 range({Line, Column}, application, {M, F, _A}) ->
+  %% Column indicates the position of the :
   CFrom = Column - length(atom_to_list(M)),
   From = {Line, CFrom},
-  CTo = Column + length(atom_to_list(F)),
+  %% module:function
+  CTo = Column + length(atom_to_list(F)) + 1,
   To = {Line, CTo},
   #{ from => From, to => To };
 range({Line, Column}, application, {F, _A}) ->

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -81,11 +81,11 @@ compiler(Config) ->
   ?assertEqual(1, length(Errors)),
   [#{range := WarningRange}] = Warnings,
   [#{range := ErrorRange}] = Errors,
-  ?assertEqual( #{'end' => #{character => 0,line => 5},
+  ?assertEqual( #{'end' => #{character => 0,line => 6},
                   start => #{character => 0,line => 5}}
               , WarningRange
               ),
-  ?assertEqual( #{'end' => #{character => 0,line => 4},
+  ?assertEqual( #{'end' => #{character => 0,line => 5},
                   start => #{character => 0,line => 4}}
               , ErrorRange
               ),

--- a/test/els_document_highlight_SUITE.erl
+++ b/test/els_document_highlight_SUITE.erl
@@ -80,7 +80,7 @@ application_local(Config) ->
 application_remote(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 32, 13),
-  ExpectedLocations = [ #{ range => #{from => {32, 3}, to => {32, 26}}
+  ExpectedLocations = [ #{ range => #{from => {32, 3}, to => {32, 27}}
                          }
                       , #{ range => #{from => {52, 8}, to => {52, 38}}
                          }
@@ -117,7 +117,7 @@ fun_local(Config) ->
 fun_remote(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 52, 14),
-  ExpectedLocations = [ #{ range => #{from => {32, 3}, to => {32, 26}}
+  ExpectedLocations = [ #{ range => #{from => {32, 3}, to => {32, 27}}
                          }
                       , #{ range => #{from => {52, 8}, to => {52, 38}}
                          }

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -84,7 +84,7 @@ application_remote(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:references(Uri, 32, 13),
   ExpectedLocations = [ #{ uri => Uri
-                         , range => #{from => {32, 3}, to => {32, 26}}
+                         , range => #{from => {32, 3}, to => {32, 27}}
                          }
                       , #{ uri => Uri
                          , range => #{from => {52, 8}, to => {52, 38}}
@@ -126,7 +126,7 @@ fun_remote(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:references(Uri, 52, 14),
   ExpectedLocations = [ #{ uri => Uri
-                         , range => #{from => {32, 3}, to => {32, 26}}
+                         , range => #{from => {32, 3}, to => {32, 27}}
                          }
                       , #{ uri => Uri
                          , range => #{from => {52, 8}, to => {52, 38}}


### PR DESCRIPTION
### Description

Resolve line length for compiler diagnostics, fix calculation for application's range.

Related to #239.
