### PR TITLE
[#260] Elvis diagnostics

### DIFF
--- a/priv/code_navigation/elvis.config
+++ b/priv/code_navigation/elvis.config
@@ -1,0 +1,22 @@
+[{ elvis
+ , [
+    { config,
+      [ #{ dirs    => ["src"]
+         , filter  => "*.erl"
+         , ruleset => erl_files
+         , rules   => [ {elvis_style, invalid_dynamic_call }
+                      , {elvis_style, line_length, #{limit => 80, skip_comments => false}}
+                      ]
+         , ignore => []
+         }
+      , #{ dirs    => ["."]
+         , filter  => "rebar.config"
+         , ruleset => rebar_config
+         }
+      , #{ dirs    => ["."]
+         , filter  => "elvis.config"
+         , ruleset => elvis_config
+         }
+      ]}
+   ]}
+].

--- a/priv/code_navigation/src/elvis_diagnostics.erl
+++ b/priv/code_navigation/src/elvis_diagnostics.erl
@@ -1,0 +1,7 @@
+-module(elvis_diagnostics).
+
+-export([foo/2]).
+
+%% Trigger some elvis warnings
+-spec foo(any(),any()) -> any().
+foo(_X,_Y) -> 3 .

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,7 @@
        , {yamerl,      "0.7.0"}
        , {docsh,       "0.7.2"}
        , {worker_pool, "4.0.1"}
+       , {elvis,       "0.4.2", {pkg, elvis_core}}
        ]
 }.
 
@@ -56,7 +57,6 @@
                    , {proper,         "1.3.0"}
                    , {proper_contrib, "0.2.0"}
                    , {coveralls,      "2.0.1"}
-                   , {elvis_core,     "0.4.2"}
                    ]
                  }
                , { pre_hooks

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,26 +1,34 @@
 {"1.1.0",
-[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.3.0">>},0},
+[{<<"aleppo">>,{pkg,<<"inaka_aleppo">>,<<"1.1.1">>},2},
+ {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.3.0">>},0},
  {<<"docsh">>,{pkg,<<"docsh">>,<<"0.7.2">>},0},
+ {<<"elvis">>,{pkg,<<"elvis_core">>,<<"0.4.2">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},2},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.9.0">>},0},
+ {<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.1.2">>},1},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.6.8">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.8.1">>},1},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},0},
  {<<"redbug">>,{pkg,<<"redbug">>,<<"1.2.1">>},0},
  {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"4.0.1">>},0},
- {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0}]}.
+ {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0},
+ {<<"zipper">>,{pkg,<<"zipper">>,<<"1.0.1">>},1}]}.
 [
 {pkg_hash,[
+ {<<"aleppo">>, <<"B0F7D05A118C5EBC3A735D68E92A7BD5837FE53455495EDE37CF0AA8BA4912E3">>},
  {<<"cowlib">>, <<"BBD58EF537904E4F7C1DD62E6AA8BC831C8183CE4EFA9BD1150164FE15BE4CAA">>},
  {<<"docsh">>, <<"F893D5317A0E14269DD7FE79CF95FB6B9BA23513DA0480EC6E77C73221CAE4F2">>},
+ {<<"elvis">>, <<"ED5D861A38493B7750427DAECFE0D844001E017C9DBC1F7F8DE302DB6226BC24">>},
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
  {<<"jsx">>, <<"D2F6E5F069C00266CAD52FB15D87C428579EA4D7D73A33669E12679E203329DD">>},
+ {<<"katana_code">>, <<"347D42D5E89AC6C4BF8D02B64633AC1BFE14B7724B5910260D39EFEAFE737F01">>},
  {<<"lager">>, <<"897EFC7679BB82383448646C96768CDC4E747464DD18B999C7AACA485686B0DA">>},
  {<<"providers">>, <<"70B4197869514344A8A60E2B2A4EF41CA03DEF43CFB1712ECF076A0F3C62F083">>},
  {<<"ranch">>, <<"6B1FAB51B49196860B733A49C07604465A47BDB78AA10C1C16A3D199F7F8C881">>},
  {<<"redbug">>, <<"9153EE50E42C39CE3F6EFA65EE746F4A52896DA66862CFB59E7C0F838B7B8414">>},
  {<<"worker_pool">>, <<"8CDEBCE7E09ECB4F1EB4BBF78AA99248064AC357077668C011AC600599973723">>},
- {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>}]}
+ {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>},
+ {<<"zipper">>, <<"3CCB4F14B97C06B2749B93D8B6C204A1ECB6FAFC6050CACC3B93B9870C05952A">>}]}
 ].

--- a/src/els_elvis_diagnostics.erl
+++ b/src/els_elvis_diagnostics.erl
@@ -1,0 +1,81 @@
+%%==============================================================================
+%% Compiler diagnostics
+%%==============================================================================
+-module(els_elvis_diagnostics).
+
+%%==============================================================================
+%% Behaviours
+%%==============================================================================
+-behaviour(els_diagnostics).
+
+%%==============================================================================
+%% Exports
+%%==============================================================================
+-export([ diagnostics/1 ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("erlang_ls.hrl").
+
+%%==============================================================================
+%% Callback Functions
+%%==============================================================================
+-spec diagnostics(uri()) -> [diagnostic()].
+diagnostics(Uri) ->
+  RelFile = els_utils:project_relative(Uri),
+
+  %% Note: elvis_core:rock_this requires a file path relative to the
+  %%       project root, formatted as a string.
+  try elvis_core:rock_this(RelFile) of
+      ok -> [] ;
+      {fail, Problems} -> lists:flatmap(fun format_diagnostics/1, Problems)
+  catch Err ->
+      lager:warning("Elvis error.[Err=~p] ", [Err]),
+      []
+  end.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+-spec format_diagnostics(any()) -> [map()].
+format_diagnostics(#{file := Path, rules := Rules}) ->
+  R = format_rules(Path, Rules),
+  lists:flatten(R).
+
+
+%%% This section is based directly on elvis_result:print_rules
+-spec format_rules(any(), [any()]) -> [[map()]].
+format_rules(_File, []) ->
+    [];
+format_rules(File, [#{items := []} | Items]) ->
+    format_rules(File, Items);
+format_rules(File, [#{items := Items, name := Name} | EItems]) ->
+    ItemDiags = format_item(File, Name, Items),
+    [lists:flatten(ItemDiags) | format_rules(File, EItems)].
+
+%% Item
+-spec format_item(any(), any(), [any()]) -> [[map()]].
+format_item(File, Name,
+            [#{message := Msg, line_num := Ln, info := Info} | Items]) ->
+    Diagnostic = diagnostic(File, Name, Msg, Ln, Info),
+    [Diagnostic | format_item(File, Name, Items)];
+format_item(_File, _Name, []) ->
+    [].
+
+%%% End of section based directly on elvis_result:print_rules
+
+-spec diagnostic(any(), any(), any(), integer(), [any()]) -> [map()].
+diagnostic(_File, Name, Msg, Ln, Info) ->
+  FMsg = io_lib:format(Msg, Info),
+  Range   = els_protocol:range(#{ from => {Ln, 1}
+                                , to   => {Ln+1, 1}
+                                }),
+  Message = list_to_binary(FMsg),
+  [#{ range    => Range
+    , severity => ?DIAGNOSTIC_WARNING
+    , code     => Name
+    , source   => <<"elvis">>
+    , message  => Message
+    , relatedInformation => []
+    }].

--- a/src/els_text_synchronization.erl
+++ b/src/els_text_synchronization.erl
@@ -19,9 +19,10 @@ did_save(Params, Server) ->
   Uri          = maps:get(<<"uri">>         , TextDocument),
   CDiagnostics = els_compiler_diagnostics:diagnostics(Uri),
   DDiagnostics = els_dialyzer_diagnostics:diagnostics(Uri),
+  EDiagnostics = els_elvis_diagnostics:diagnostics(Uri),
   Method = <<"textDocument/publishDiagnostics">>,
   Params1  = #{ uri => Uri
-              , diagnostics => CDiagnostics ++ DDiagnostics
+              , diagnostics => CDiagnostics ++ DDiagnostics ++ EDiagnostics
               },
   els_server:send_notification(Server, Method, Params1).
 

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -4,6 +4,7 @@
         , find_module/1
         , find_module/2
         , fold_files/4
+        , project_relative/1
         , halt/1
         , start_epmd/0
         ]).
@@ -65,6 +66,16 @@ halt(ExitCode) ->
 start_epmd() ->
     [] = os:cmd(epmd_path() ++ " -daemon"),
     ok.
+
+%% @doc Returns a project-relative file path for a given URI
+-spec project_relative(uri()) -> file:filename().
+project_relative(Uri) ->
+  Path = els_uri:path(Uri),
+  RootDir = els_config:get(root_uri),
+  RootPath = els_uri:path(RootDir),
+  RelativeBin = string:prefix(string:prefix(Path, RootPath), <<"/">>),
+  binary_to_list(RelativeBin).
+
 
 %%==============================================================================
 %% Internal functions

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -14,6 +14,7 @@
       , yamerl
       , docsh
       , worker_pool
+      , elvis
       ]
     }
   , { env

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -60,6 +60,9 @@ init_per_suite(Config) ->
   DiagnosticsPath        = filename:join([ RootPath
                                          , <<"src">>
                                          , <<"diagnostics.erl">>]),
+  ElvisDiagnosticsPath   = filename:join([ RootPath
+                                         , <<"src">>
+                                         , <<"elvis_diagnostics.erl">>]),
   DiagnosticsIncludePath = filename:join([ RootPath
                                          , <<"include">>
                                          , <<"diagnostics.hrl">>]),
@@ -70,6 +73,7 @@ init_per_suite(Config) ->
   BehaviourUri           = els_uri:uri(BehaviourPath),
   IncludeUri             = els_uri:uri(IncludePath),
   DiagnosticsUri         = els_uri:uri(DiagnosticsPath),
+  ElvisDiagnosticsUri    = els_uri:uri(ElvisDiagnosticsPath),
   DiagnosticsIncludeUri  = els_uri:uri(DiagnosticsIncludePath),
 
   {ok, Text} = file:read_file(Path),
@@ -79,6 +83,7 @@ init_per_suite(Config) ->
   application:set_env(erlang_ls, index_deps, false),
 
   [ {root_uri, RootUri}
+  , {root_path, RootPath}
   , {code_navigation_uri, Uri}
   , {code_navigation_path, Path}
   , {code_navigation_text, Text}
@@ -87,6 +92,7 @@ init_per_suite(Config) ->
   , {behaviour_uri, BehaviourUri}
   , {include_uri, IncludeUri}
   , {diagnostics_uri, DiagnosticsUri}
+  , {elvis_diagnostics_uri, ElvisDiagnosticsUri}
   , {diagnostics_include_uri, DiagnosticsIncludeUri}
   | Config
   ].

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -253,9 +253,11 @@ prop_main() ->
 setup() ->
   meck:new(els_compiler_diagnostics, [no_link, passthrough]),
   meck:new(els_dialyzer_diagnostics, [no_link, passthrough]),
+  meck:new(els_elvis_diagnostics, [no_link, passthrough]),
   meck:new(els_utils, [no_link, passthrough]),
   meck:expect(els_compiler_diagnostics, diagnostics, 1, []),
   meck:expect(els_dialyzer_diagnostics, diagnostics, 1, []),
+  meck:expect(els_elvis_diagnostics, diagnostics, 1, []),
   Self    = erlang:self(),
   HaltFun = fun(_X) -> Self ! halt_called, {noresponse, #{}} end,
   meck:expect(els_utils, halt, HaltFun),
@@ -272,6 +274,7 @@ setup() ->
 teardown(_) ->
   meck:unload(els_compiler_diagnostics),
   meck:unload(els_dialyzer_diagnostics),
+  meck:unload(els_elvis_diagnostics),
   meck:unload(els_utils),
   ok.
 


### PR DESCRIPTION
Generates Elvis diagnostics when a file is saved, so long as an Elvis configuration exists.

### Description

Add [elvis](https://hex.pm/packages/elvis_core) as a diagnostics source.

Fixes #260 .
