### PR TITLE
[#283] Don't fail with function name as macro

### DIFF
--- a/priv/code_navigation/src/code_navigation.erl
+++ b/priv/code_navigation/src/code_navigation.erl
@@ -66,3 +66,6 @@ function_i() -> two.
 -spec function_j() -> pos_integer().
 function_j() ->
   53.
+
+%% [#283] Macro as function name crashes parser
+?macro_A() -> ok.

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -138,16 +138,19 @@ points_of_interest(Tree) ->
 %% @edoc Return the list of points of interest for a given `Tree`.
 -spec do_points_of_interest(tree()) -> [poi()].
 do_points_of_interest(Tree) ->
-  case erl_syntax:type(Tree) of
-    application   -> application(Tree);
-    attribute     -> attribute(Tree);
-    function      -> function(Tree);
-    implicit_fun  -> implicit_fun(Tree);
-    macro         -> macro(Tree);
-    record_access -> record_access(Tree);
-    record_expr   -> record_expr(Tree);
-    variable      -> variable(Tree);
-    _             -> []
+  try
+    case erl_syntax:type(Tree) of
+      application   -> application(Tree);
+      attribute     -> attribute(Tree);
+      function      -> function(Tree);
+      implicit_fun  -> implicit_fun(Tree);
+      macro         -> macro(Tree);
+      record_access -> record_access(Tree);
+      record_expr   -> record_expr(Tree);
+      variable      -> variable(Tree);
+      _             -> []
+    end
+  catch throw:syntax_error -> []
   end.
 
 -spec application(tree()) -> [poi()].


### PR DESCRIPTION
### Description

Re-add the `try...catch` for `syntax_error`s. 

Fixes #283.
