### PR TITLE
[#296] Split client in tcp_client and stdio_client

### DIFF
--- a/src/els_jsonrpc.erl
+++ b/src/els_jsonrpc.erl
@@ -6,7 +6,8 @@
 %%==============================================================================
 %% Exports
 %%==============================================================================
--export([ split/1
+-export([ default_opts/0
+        , split/1
         , split/2
         ]).
 
@@ -20,7 +21,7 @@
 %%==============================================================================
 -spec split(binary()) -> {[map()], binary()}.
 split(Data) ->
-  split(Data, [], []).
+  split(Data, default_opts()).
 
 -spec split(binary(), [any()]) -> {[map()], binary()}.
 split(Data, DecodeOpts) ->
@@ -44,3 +45,7 @@ split(Data, DecodeOpts, Responses) ->
   catch _:_ ->
       {lists:reverse(Responses), Data}
   end.
+
+-spec default_opts() -> [any()].
+default_opts() ->
+  [return_maps, {labels, atom}].

--- a/src/els_stdio_client.erl
+++ b/src/els_stdio_client.erl
@@ -1,0 +1,38 @@
+%%==============================================================================
+%% Erlang LS TCP Client
+%%==============================================================================
+
+-module(els_stdio_client).
+
+%%==============================================================================
+%% Behaviour els_client
+%%==============================================================================
+
+-behaviour(els_client).
+-export( [ start_link/1
+         , send/2
+         ]).
+
+%%==============================================================================
+%% Type Definitions
+%%==============================================================================
+
+-type args()  :: #{ io_device := any() }.
+
+%%==============================================================================
+%% Callbacks for the els_client behaviour
+%%==============================================================================
+
+-spec start_link(args()) -> {ok, pid()}.
+start_link(#{io_device := IoDevice}) ->
+  Args = [ []
+         , IoDevice
+         , fun els_client:handle_responses/1
+         , els_jsonrpc:default_opts()
+         ],
+  _Pid = proc_lib:spawn_link(els_stdio, loop, Args),
+  {ok, IoDevice}.
+
+-spec send(pid(), iolist()) -> ok.
+send(Server, Payload) ->
+  io:format(Server, iolist_to_binary(Payload), []).

--- a/src/els_tcp.erl
+++ b/src/els_tcp.erl
@@ -41,8 +41,8 @@ start_link(Ref, Socket, Transport, Opts) ->
 %% els_transport callbacks
 %%==============================================================================
 
--spec start_listener(pid()) -> {ok, pid()}.
-start_listener(_Server) ->
+-spec start_listener(function()) -> {ok, pid()}.
+start_listener(_Cb) ->
   lager:info("Starting ranch listener.."),
   {ok, Port} = application:get_env(erlang_ls, port),
   {ok, _} = ranch:start_listener( erlang_ls

--- a/src/els_tcp_client.erl
+++ b/src/els_tcp_client.erl
@@ -1,0 +1,91 @@
+%%==============================================================================
+%% Erlang LS TCP Client
+%%==============================================================================
+
+-module(els_tcp_client).
+
+%%==============================================================================
+%% Behaviour els_client
+%%==============================================================================
+
+-behaviour(els_client).
+-export( [ start_link/1
+         , send/2
+         ]).
+
+%%==============================================================================
+%% Behaviour gen_server
+%%==============================================================================
+
+-behaviour(gen_server).
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        ]).
+
+%%==============================================================================
+%% Type Definitions
+%%==============================================================================
+
+-type args()  :: #{ host := tuple()
+                  , port := pos_integer()
+                  }.
+-type state() :: #{ socket := any()
+                  , buffer := binary()
+                  }.
+
+%%==============================================================================
+%% Callbacks for the els_client behaviour
+%%==============================================================================
+
+-spec start_link(args()) -> {ok, pid()}.
+start_link(Args) ->
+  gen_server:start_link(?MODULE, Args, []).
+
+-spec init(args()) -> {ok, state()}.
+init(#{host := Host, port := Port}) ->
+  {ok, Socket} = gen_tcp:connect(Host, Port, default_tcp_opts()),
+  {ok, #{socket => Socket, buffer => <<>>}}.
+
+-spec send(pid(), iolist()) -> ok.
+send(Server, Payload) ->
+  gen_server:call(Server, {send, Payload}).
+
+-spec terminate(any(), state()) -> ok.
+terminate(_Reason, #{socket := Socket}) ->
+  ok = gen_tcp:close(Socket).
+
+%%==============================================================================
+%% Callbacks for the gen_server behaviour
+%%==============================================================================
+
+-spec handle_call(any(), any(), state()) -> {reply, ok, state()}.
+handle_call({send, Payload}, _From, #{ socket := Socket } = State) ->
+  ok = gen_tcp:send(Socket, Payload),
+  {reply, ok, State}.
+
+-spec handle_cast(any(), state()) -> {noreply, state()}.
+handle_cast(_Msg, State) ->
+  {noreply, State}.
+
+-spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info({tcp, Socket, Packet}, State) ->
+  #{socket := Socket, buffer := Buffer0} = State,
+  Data = <<Buffer0/binary, Packet/binary>>,
+  {Responses, Buffer} = els_jsonrpc:split(Data),
+  els_client:handle_responses(Responses),
+  inet:setopts(Socket, [{active, once}]),
+  {noreply, State#{ buffer => Buffer }};
+handle_info({tcp_closed, _Socket}, State) ->
+  {stop, normal, State};
+handle_info({tcp_error, _Socket, Reason}, State) ->
+  {stop, Reason, State}.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+-spec default_tcp_opts() -> [any()].
+default_tcp_opts() ->
+  [binary, {active, once}, {packet, 0}].

--- a/src/els_transport.erl
+++ b/src/els_transport.erl
@@ -1,5 +1,5 @@
 -module(els_transport).
 
--callback start_listener(pid()) -> {ok, pid()}.
--callback init(any()) -> any().
--callback send(any(), binary()) -> ok.
+-callback start_listener(function()) -> {ok, pid()}.
+-callback init(any())                -> any().
+-callback send(any(), binary())      -> ok.

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -113,10 +113,10 @@ init_per_testcase(_TestCase, Config) ->
 
         ok = application:set_env(erlang_ls, transport, els_stdio),
         ok = application:set_env(erlang_ls, io_device, ServerIo),
-        {stdio, ClientIo};
+        {stdio, #{io_device => ClientIo}};
       tcp ->
         ok = application:set_env(erlang_ls, transport, els_tcp),
-        {tcp, {?HOSTNAME, ?PORT}}
+        {tcp, #{host => ?HOSTNAME, port => ?PORT}}
     end,
 
   {ok, Started} = application:ensure_all_started(erlang_ls),

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -52,7 +52,7 @@ weight(_S, _Cmd)     -> 5.
 %% Connect
 %%------------------------------------------------------------------------------
 connect() ->
-  els_client:start_link(tcp, {?HOSTNAME, ?PORT}).
+  els_client:start_link(tcp, #{ host => ?HOSTNAME, port => ?PORT}).
 
 connect_args(_S) ->
   [].


### PR DESCRIPTION
### Description

Part of a long-due cleanup on how the two transports (tcp, stdio) are used by client and server.

Fixes #296 .
