### PR TITLE
[#313] Index files with unknown extension and assign 'other' kind

### DIFF
--- a/src/els_dt_document.erl
+++ b/src/els_dt_document.erl
@@ -25,7 +25,6 @@
         , pois/1
         , pois/2
         , get_element_at_pos/3
-        , is_extension_supported/1
         ]).
 
 %%==============================================================================
@@ -37,7 +36,7 @@
 %% Type Definitions
 %%==============================================================================
 -type id()   :: atom().
--type kind() :: module | header.
+-type kind() :: module | header | other.
 
 %%==============================================================================
 %% Item Definition
@@ -129,12 +128,14 @@ lookup(Uri) ->
 -spec new(uri(), binary()) -> item().
 new(Uri, Text) ->
   Extension = filename:extension(Uri),
-  Id         = binary_to_atom(filename:basename(Uri, Extension), utf8),
+  Id = binary_to_atom(filename:basename(Uri, Extension), utf8),
   case Extension of
     <<".erl">> ->
       new(Uri, Text, Id, module);
     <<".hrl">> ->
-      new(Uri, Text, Id, header)
+      new(Uri, Text, Id, header);
+    _  ->
+      new(Uri, Text, Id, other)
   end.
 
 -spec new(uri(), binary(), atom(), kind()) -> item().
@@ -166,7 +167,3 @@ get_element_at_pos(Item, Line, Column) ->
   POIs = maps:get(pois, Item),
   MatchedPOIs = els_poi:match_pos(POIs, {Line, Column}),
   els_poi:sort(MatchedPOIs).
-
--spec is_extension_supported(binary()) -> boolean().
-is_extension_supported(Extension) ->
-  lists:member(Extension, [<<".erl">>, <<".hrl">>]).

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -187,16 +187,10 @@ terminate(_, _State) ->
 try_index_file(FullName, SyncAsync) ->
   try
     Uri = els_uri:uri(FullName),
-    Extension = filename:extension(Uri),
-    case els_dt_document:is_extension_supported(Extension) of
-      true ->
-        lager:debug("Indexing file. [filename=~s]", [FullName]),
-        {ok, Text} = file:read_file(FullName),
-        Document   = els_dt_document:new(Uri, Text),
-        ok         = index_document(Document, SyncAsync);
-      false ->
-        lager:debug("Skipping file. [filename=~s]", [FullName])
-    end
+    lager:debug("Indexing file. [filename=~s]", [FullName]),
+    {ok, Text} = file:read_file(FullName),
+    Document   = els_dt_document:new(Uri, Text),
+    ok         = index_document(Document, SyncAsync)
   catch Type:Reason:St ->
       lager:error("Error indexing file "
                   "[filename=~s] "

--- a/test/els_indexer_SUITE.erl
+++ b/test/els_indexer_SUITE.erl
@@ -12,7 +12,7 @@
 %% Test cases
 -export([ index_erl_file/1
         , index_hrl_file/1
-        , skip_unkown_extension/1
+        , index_unkown_extension/1
         ]).
 
 %%==============================================================================
@@ -72,10 +72,10 @@ index_hrl_file(Config) ->
   {ok, [#{id := test, kind := header}]} = els_dt_document:lookup(Uri),
   ok.
 
--spec skip_unkown_extension(config()) -> ok.
-skip_unkown_extension(Config) ->
+-spec index_unkown_extension(config()) -> ok.
+index_unkown_extension(Config) ->
   DataDir = ?config(data_dir, Config),
   Path = filename:join(list_to_binary(DataDir), "test.foo"),
   {ok, Uri} = els_indexer:index_file(Path, sync),
-  {ok, []} = els_dt_document:lookup(Uri),
+  {ok, [#{kind := other}]} = els_dt_document:lookup(Uri),
   ok.


### PR DESCRIPTION
### Description

Files like `rebar.config` or `application.app.src` should have the server's features available, so we should index files with unknown extension and assign kind `other` to them.

Fixes #313.
