### PR TITLE
[#305] Build Workflow using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,31 @@
-name: Erlang CI
-
+name: Build
 on: [push]
-
 jobs:
-
   build:
-
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-
+        platform: [ubuntu-latest]
+        otp-version: [21.3, 22.2]
     runs-on: ${{ matrix.platform }}
-
-    container:      
-      image: erlang:22.0.7
-
+    container:
+      image: erlang:${{ matrix.otp-version }}
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Cache Hex packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/rebar3/hex/hexpm/packages
+        key: ${{ runner.os }}-hex-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
+        restore-keys: |
+          ${{ runner.os }}-hex-
+    - name: Cache Dialyzer PLTs
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/rebar3/rebar3_*.plt
+        key: ${{ runner.os }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}
+        restore-keys: |
+          ${{ runner.os }}-dialyzer-
     - name: Compile
       run: rebar3 compile
     - name: Run CT Tests


### PR DESCRIPTION
### Description

Unfortunately, there's no Erlang installed by default on Windows or Mac systems and the existing `setup-erlang` actions do not work on Windows or Mac, so we would need to write one. For the time being, I'm simply adding a Linux-based workflow that we can keep in parallel to the Travis CI pipelines, to verify how both behave, which one is faster and so on. So, see this PR as a contribution to #152 which prepares #305.
