### PR TITLE
[#329] Missing dialyzer diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,13 +260,14 @@ A sample `erlang_ls.config` file would look like the following:
 
 Currently, the following customizations are possible:
 
-| Parameter          | Description                                                                             |
-|--------------------|-----------------------------------------------------------------------------------------|
-| otp\_path          | Path to the OTP installation                                                            |
-| deps\_dirs         | List of directories containing dependencies. It supports wildcards.                     |
-| apps\_dirs         | List of directories containing project applications. It supports wildcards.             |
-| include\_dirs      | List of directories provided to the compiler as include dirs. It supports wildcards.    |
-| otp\_apps\_exclude | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx) |
+| Parameter          | Description                                                                                          |
+|--------------------|------------------------------------------------------------------------------------------------------|
+| otp\_path          | Path to the OTP installation                                                                         |
+| plt\_path          | Path to the dialyzer PLT file. When none is provided the dialyzer diagnostics will not be available. |
+| deps\_dirs         | List of directories containing dependencies. It supports wildcards.                                  |
+| apps\_dirs         | List of directories containing project applications. It supports wildcards.                          |
+| include\_dirs      | List of directories provided to the compiler as include dirs. It supports wildcards.                 |
+| otp\_apps\_exclude | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)              |
 
 ## Troubleshooting
 

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -42,6 +42,7 @@
                | otp_path
                | otp_paths
                | otp_apps_exclude
+               | plt_path
                | root_uri
                | search_paths.
 -type path()  :: file:filename().
@@ -54,6 +55,7 @@
                   , otp_path          => path()
                   , otp_paths         => [path()]
                   , otp_apps_exclude  => [string()]
+                  , plt_path          => path()
                   , root_uri          => uri()
                   , search_paths      => [path()]
                   }.
@@ -67,14 +69,15 @@ initialize(RootUri, Capabilities, InitOptions) ->
   Config = consult_config(filename:join([ els_uri:path(RootUri)
                                         , config_path(InitOptions)
                                         ])),
-  OtpPath        = maps:get("otp_path", Config, code:root_dir()),
-  DepsDirs       = maps:get("deps_dirs", Config, []),
-  AppsDirs       = maps:get("apps_dirs", Config, ["."]),
-  IncludeDirs    = maps:get("include_dirs", Config, ["include"]),
-  OtpAppsExclude = maps:get( "otp_apps_exclude"
-                           , Config
-                           , ?DEFAULT_EXCLUDED_OTP_APPS
-                           ),
+  OtpPath         = maps:get("otp_path", Config, code:root_dir()),
+  DepsDirs        = maps:get("deps_dirs", Config, []),
+  AppsDirs        = maps:get("apps_dirs", Config, ["."]),
+  IncludeDirs     = maps:get("include_dirs", Config, ["include"]),
+  DialyzerPltPath = maps:get("plt_path", Config, undefined),
+  OtpAppsExclude  = maps:get( "otp_apps_exclude"
+                            , Config
+                            , ?DEFAULT_EXCLUDED_OTP_APPS
+                            ),
   ExcludePathsSpecs = [[OtpPath, "lib", P ++ "*"] || P <- OtpAppsExclude],
   ExcludePaths      = resolve_paths(ExcludePathsSpecs, true),
   lager:info("Excluded OTP Applications: ~p", [OtpAppsExclude]),
@@ -86,6 +89,7 @@ initialize(RootUri, Capabilities, InitOptions) ->
   ok = set(deps_dirs     , DepsDirs),
   ok = set(apps_dirs     , AppsDirs),
   ok = set(include_dirs  , IncludeDirs),
+  ok = set(plt_path      , DialyzerPltPath),
   %% Calculated from the above
   ok = set(apps_paths    , project_paths(RootUri, AppsDirs, false)),
   ok = set(deps_paths    , project_paths(RootUri, DepsDirs, false)),

--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -25,8 +25,7 @@
 diagnostics(Uri) ->
   Path = els_uri:path(Uri),
   WS = try dialyzer:run([{files, [binary_to_list(Path)]}, {from, src_code}])
-       catch _:_ ->
-           []
+       catch _:_ -> []
        end,
   [diagnostic(W) || W <- WS].
 
@@ -35,8 +34,8 @@ diagnostics(Uri) ->
 %%==============================================================================
 -spec diagnostic({any(), {any(), integer()}, any()}) -> diagnostic().
 diagnostic({_, {_, Line}, _} = Warning) ->
-  Range   = els_protocol:range(#{ from => {Line - 1, 0}
-                                , to   => {Line - 1, 0}
+  Range   = els_protocol:range(#{ from => {Line, 0}
+                                , to   => {Line, 0}
                                 }),
   Message = list_to_binary(lists:flatten(dialyzer:format_warning(Warning))),
   #{ range    => Range

--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -24,10 +24,17 @@
 -spec diagnostics(uri()) -> [diagnostic()].
 diagnostics(Uri) ->
   Path = els_uri:path(Uri),
-  WS = try dialyzer:run([{files, [binary_to_list(Path)]}, {from, src_code}])
-       catch _:_ -> []
-       end,
-  [diagnostic(W) || W <- WS].
+  case els_config:get(plt_path) of
+    undefined -> [];
+    DialyzerPltPath ->
+      WS = try dialyzer:run([ {files, [binary_to_list(Path)]}
+                            , {from, src_code}
+                            , {plts, [DialyzerPltPath]}
+                            ])
+           catch _:_ -> []
+           end,
+      [diagnostic(W) || W <- WS]
+  end.
 
 %%==============================================================================
 %% Internal Functions


### PR DESCRIPTION
### Description

Add a new `plt_path` configuration option. When it's not defined dialyzer diagnostics are not available.

I'm leaving the code lens approach we discussed for the future.

Fixes #329.
