### PR TITLE
Add optional parameter to erlang_ls.config where the timeout to load mnesia tables can be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Currently, the following customizations are possible:
 | apps\_dirs         | List of directories containing project applications. It supports wildcards.                          |
 | include\_dirs      | List of directories provided to the compiler as include dirs. It supports wildcards.                 |
 | otp\_apps\_exclude | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)              |
+| db\_wait\_timeout  | Timeout to load all Mnesia tables                                                                    |
 
 ## Troubleshooting
 

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,6 @@
                 , els_dt_references
                 , els_dt_signatures
                 ]).
--define(TIMEOUT, 20000).
 
 %%==============================================================================
 %% Exported functions
@@ -49,7 +48,7 @@ ensure_db() ->
   lager:info("Preparing tables"),
   application:start(mnesia),
   ensure_tables(),
-  wait_for_tables(),
+  wait_for_tables(els_config:get(db_wait_timeout)),
   lager:info("DB Initialized"),
   ok.
 
@@ -78,10 +77,6 @@ write(Record) when is_tuple(Record) ->
 clear_tables() ->
   [ok = clear_table(T) || T <- ?TABLES],
   ok.
-
--spec wait_for_tables() -> ok.
-wait_for_tables() ->
-  wait_for_tables(?TIMEOUT).
 
 -spec wait_for_tables(pos_integer()) -> ok.
 wait_for_tables(Timeout) ->


### PR DESCRIPTION
### Description

I've noticed that sometimes erlang_ls fails to start properly due to the `els_db:wait_for_tables` call timing out. The timeout is hardcoded to 20000 and cannot be overridden (as far as I could see?). This PR adds the option to set a longer timeout on a per project basis through the `erlang_ls.config`