### PR TITLE
[#335] Use platform dependent log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ the Database Directory on your system:
 ### Logging
 
 When the escript is built using the `debug` profile as above, logging
-will be enabled and the logs will be written to `/usr/local/var/log/erlang_ls`.
+will be enabled and the logs will be written to your platform's log
+directory (i.e. return value from `filename:basedir(user_log, "erlang_ls")`).
 It's possible to change this directory either by modifying the default
 value in the `erlang_ls.app.src` file or by having the LSP client
 being used to provide a `--log-dir` option.

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -31,7 +31,6 @@
       , {index_deps, true}
         %% Logging
       , {logging_enabled, false}
-      , {log_dir, "/usr/local/var/log/erlang_ls"}
       ]
     }
   , {modules, []}

--- a/src/erlang_ls.erl
+++ b/src/erlang_ls.erl
@@ -75,7 +75,8 @@ lager_handlers(LogRoot) ->
 
 -spec log_root() -> string().
 log_root() ->
-  {ok, LogDir}     = application:get_env(?APP, log_dir),
+  DefaultLogDir    = filename:basedir(user_log, "erlang_ls"),
+  LogDir           = application:get_env(?APP, log_dir, DefaultLogDir),
   {ok, CurrentDir} = file:get_cwd(),
   Dirname          = filename:basename(CurrentDir),
   filename:join([LogDir, Dirname]).


### PR DESCRIPTION
### Description

Use platform dependent log directory.

Fixes #335.
