### PR TITLE
[#330] Remove dialyzer (which depends on wx) from required applications

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -78,10 +78,9 @@
 {coveralls_coverdata, ["_build/test/cover/ct.coverdata", "_build/test/cover/proper.coverdata"]}.
 {coveralls_service_name, "travis-ci"}.
 
-{dialyzer, [ {warnings, [ unknown
-                        ]}
+{dialyzer, [ {warnings, [unknown]}
            , {plt_apps, all_deps}
-           , {plt_extra_apps, [mnesia]}
+           , {plt_extra_apps, [dialyzer, mnesia]}
            ]}.
 
 {xref_checks, [ undefined_function_calls

--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -31,7 +31,11 @@ diagnostics(Uri) ->
                             , {from, src_code}
                             , {plts, [DialyzerPltPath]}
                             ])
-           catch _:_ -> []
+           catch Type:Error ->
+               lager:error( "Error while running dialyzer [type=~p] [error=~p]"
+                          , [Type, Error]
+                          ),
+               []
            end,
       [diagnostic(W) || W <- WS]
   end.

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -6,7 +6,6 @@
   , { applications
     , [ kernel
       , stdlib
-      , dialyzer
       , ranch
       , jsx
       , cowlib


### PR DESCRIPTION
### Description

Remove dialyzer (which depends on wx) from required applications.

Fixes #330.
