### PR TITLE
[#363] Add implementation provider and support for gen_server callbacks

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -4,7 +4,8 @@
       [ #{ dirs    => ["src"]
          , filter  => "*.erl"
          , ruleset => erl_files
-         , rules   => [ {elvis_style, invalid_dynamic_call, #{ignore => [ els_compiler_diagnostics
+         , rules   => [ {elvis_style, god_modules, #{ignore => [els_client]}}
+                      , {elvis_style, invalid_dynamic_call, #{ignore => [ els_compiler_diagnostics
                                                                         , els_server
                                                                         , els_app
                                                                         , els_tcp

--- a/priv/code_navigation/src/my_gen_server.erl
+++ b/priv/code_navigation/src/my_gen_server.erl
@@ -1,0 +1,140 @@
+-module(my_gen_server).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, format_status/2]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link() -> {ok, Pid :: pid()} |
+                      {error, Error :: {already_started, pid()}} |
+                      {error, Error :: term()} |
+                      ignore.
+start_link() ->
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%% @end
+%%--------------------------------------------------------------------
+-spec init(Args :: term()) -> {ok, State :: term()} |
+                              {ok, State :: term(), Timeout :: timeout()} |
+                              {ok, State :: term(), hibernate} |
+                              {stop, Reason :: term()} |
+                              ignore.
+init([]) ->
+  process_flag(trap_exit, true),
+  {ok, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_call(Request :: term(), From :: {pid(), term()}, State :: term()) ->
+                     {reply, Reply :: term(), NewState :: term()} |
+                     {reply, Reply :: term(), NewState :: term(), Timeout :: timeout()} |
+                     {reply, Reply :: term(), NewState :: term(), hibernate} |
+                     {noreply, NewState :: term()} |
+                     {noreply, NewState :: term(), Timeout :: timeout()} |
+                     {noreply, NewState :: term(), hibernate} |
+                     {stop, Reason :: term(), Reply :: term(), NewState :: term()} |
+                     {stop, Reason :: term(), NewState :: term()}.
+handle_call(_Request, _From, State) ->
+  Reply = ok,
+  {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_cast(Request :: term(), State :: term()) ->
+                     {noreply, NewState :: term()} |
+                     {noreply, NewState :: term(), Timeout :: timeout()} |
+                     {noreply, NewState :: term(), hibernate} |
+                     {stop, Reason :: term(), NewState :: term()}.
+handle_cast(_Request, State) ->
+  {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_info(Info :: timeout() | term(), State :: term()) ->
+                     {noreply, NewState :: term()} |
+                     {noreply, NewState :: term(), Timeout :: timeout()} |
+                     {noreply, NewState :: term(), hibernate} |
+                     {stop, Reason :: normal | term(), NewState :: term()}.
+handle_info(_Info, State) ->
+  {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%%--------------------------------------------------------------------
+-spec terminate(Reason :: normal | shutdown | {shutdown, term()} | term(),
+                State :: term()) -> any().
+terminate(_Reason, _State) ->
+  ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%% @end
+%%--------------------------------------------------------------------
+-spec code_change(OldVsn :: term() | {down, term()},
+                  State :: term(),
+                  Extra :: term()) -> {ok, NewState :: term()} |
+                                      {error, Reason :: term()}.
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called for changing the form and appearance
+%% of gen_server status when it is returned from sys:get_status/1,2
+%% or when it appears in termination error logs.
+%% @end
+%%--------------------------------------------------------------------
+-spec format_status(Opt :: normal | terminate,
+                    Status :: list()) -> Status :: term().
+format_status(_Opt, Status) ->
+  Status.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/els_client.erl
+++ b/src/els_client.erl
@@ -30,6 +30,7 @@
         , document_symbol/1
         , exit/0
         , hover/3
+        , implementation/3
         , initialize/2
         , references/3
         , document_highlight/3
@@ -99,6 +100,10 @@ definition(Uri, Line, Char) ->
 -spec hover(uri(), non_neg_integer(), non_neg_integer()) -> ok.
 hover(Uri, Line, Char) ->
   gen_server:call(?SERVER, {hover, {Uri, Line, Char}}).
+
+-spec implementation(uri(), non_neg_integer(), non_neg_integer()) -> ok.
+implementation(Uri, Line, Char) ->
+  gen_server:call(?SERVER, {implementation, {Uri, Line, Char}}).
 
 -spec references(uri(), non_neg_integer(), non_neg_integer()) -> ok.
 references(Uri, Line, Char) ->
@@ -284,6 +289,7 @@ method_lookup(did_open)                 -> <<"textDocument/didOpen">>;
 method_lookup(did_save)                 -> <<"textDocument/didSave">>;
 method_lookup(did_close)                -> <<"textDocument/didClose">>;
 method_lookup(hover)                    -> <<"textDocument/hover">>;
+method_lookup(implementation)           -> <<"textDocument/implementation">>;
 method_lookup(workspace_symbol)         -> <<"workspace/symbol">>;
 method_lookup(folding_range)            -> <<"textDocument/foldingRange">>;
 method_lookup(initialize)               -> <<"initialize">>.

--- a/src/els_implementation_provider.erl
+++ b/src/els_implementation_provider.erl
@@ -1,0 +1,76 @@
+-module(els_implementation_provider).
+
+-behaviour(els_provider).
+
+-include("erlang_ls.hrl").
+
+-export([ handle_request/2
+        , is_enabled/0
+        ]).
+
+%%==============================================================================
+%% els_provider functions
+%%==============================================================================
+
+-spec is_enabled() -> boolean().
+is_enabled() ->
+  true.
+
+-spec handle_request(tuple(), els_provider:state()) ->
+   {null | location(), els_provider:state()}.
+handle_request({implementation, Params}, State) ->
+  #{ <<"position">>     := #{ <<"line">>      := Line
+                            , <<"character">> := Character
+                            }
+   , <<"textDocument">> := #{<<"uri">> := Uri}
+   } = Params,
+  {ok, Document} = els_utils:lookup_document(Uri),
+  case find_implementation(Document, Line, Character) of
+    [#{range := Range}|_] ->
+      {#{uri => Uri, range => els_protocol:range(Range)}, State};
+    [] ->
+      {null, State}
+  end.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+-spec find_implementation( els_dt_document:item()
+                         , non_neg_integer()
+                         , non_neg_integer()
+                         ) -> [poi()].
+find_implementation(Document, Line, Character) ->
+  case els_dt_document:get_element_at_pos(Document, Line + 1, Character + 1) of
+    [POI|_] -> implementation(Document, POI);
+    []      -> []
+  end.
+
+-spec implementation(els_dt_document:item(), poi()) -> [poi()].
+implementation(Document, #{kind := application, id := MFA}) ->
+  case callback(MFA) of
+    {CF, CA} ->
+      POIs = els_dt_document:pois(Document, [function]),
+      [POI || #{id := {F, A}} = POI <- POIs, F =:= CF, A =:= CA];
+    undefined ->
+      []
+  end;
+implementation(_Document, _POI) ->
+  [].
+
+-spec callback(mfa()) -> {atom(), non_neg_integer()} | undefined.
+%% gen_server
+callback({gen_server, abcast, 2})     -> {handle_cast, 2};
+callback({gen_server, abcast, 3})     -> {handle_cast, 2};
+callback({gen_server, call, 2})       -> {handle_call, 3};
+callback({gen_server, call, 3})       -> {handle_call, 3};
+callback({gen_server, cast, 2})       -> {handle_cast, 2};
+callback({gen_server, multi_call, 2}) -> {handle_call, 3};
+callback({gen_server, multi_call, 3}) -> {handle_call, 3};
+callback({gen_server, multi_call, 4}) -> {handle_call, 3};
+callback({gen_server, start, 3})      -> {init, 1};
+callback({gen_server, start, 4})      -> {init, 1};
+callback({gen_server, start_link, 3}) -> {init, 1};
+callback({gen_server, start_link, 4}) -> {init, 1};
+callback({gen_server, stop, 1})       -> {terminate, 2};
+callback({gen_server, stop, 3})       -> {terminate, 2};
+callback(_)                           -> undefined.

--- a/src/els_implementation_provider.erl
+++ b/src/els_implementation_provider.erl
@@ -58,19 +58,43 @@ implementation(_Document, _POI) ->
   [].
 
 -spec callback(mfa()) -> {atom(), non_neg_integer()} | undefined.
+%% gen_event
+callback({gen_event, add_handler, 3})     -> {init, 1};
+callback({gen_event, add_sup_handler, 3}) -> {init, 1};
+callback({gen_event, call, 3})            -> {handle_call, 2};
+callback({gen_event, call, 4})            -> {handle_call, 2};
+callback({gen_event, delete_handler, 1})  -> {terminate, 2};
+callback({gen_event, notify, 2})          -> {handle_event, 2};
+callback({gen_event, sync_notify, 2})     -> {handle_event, 2};
+callback({gen_event, stop, 1})            -> {terminate, 2};
+callback({gen_event, stop, 3})            -> {terminate, 2};
 %% gen_server
-callback({gen_server, abcast, 2})     -> {handle_cast, 2};
-callback({gen_server, abcast, 3})     -> {handle_cast, 2};
-callback({gen_server, call, 2})       -> {handle_call, 3};
-callback({gen_server, call, 3})       -> {handle_call, 3};
-callback({gen_server, cast, 2})       -> {handle_cast, 2};
-callback({gen_server, multi_call, 2}) -> {handle_call, 3};
-callback({gen_server, multi_call, 3}) -> {handle_call, 3};
-callback({gen_server, multi_call, 4}) -> {handle_call, 3};
-callback({gen_server, start, 3})      -> {init, 1};
-callback({gen_server, start, 4})      -> {init, 1};
-callback({gen_server, start_link, 3}) -> {init, 1};
-callback({gen_server, start_link, 4}) -> {init, 1};
-callback({gen_server, stop, 1})       -> {terminate, 2};
-callback({gen_server, stop, 3})       -> {terminate, 2};
-callback(_)                           -> undefined.
+callback({gen_server, abcast, 2})         -> {handle_cast, 2};
+callback({gen_server, abcast, 3})         -> {handle_cast, 2};
+callback({gen_server, call, 2})           -> {handle_call, 3};
+callback({gen_server, call, 3})           -> {handle_call, 3};
+callback({gen_server, cast, 2})           -> {handle_cast, 2};
+callback({gen_server, multi_call, 2})     -> {handle_call, 3};
+callback({gen_server, multi_call, 3})     -> {handle_call, 3};
+callback({gen_server, multi_call, 4})     -> {handle_call, 3};
+callback({gen_server, start, 3})          -> {init, 1};
+callback({gen_server, start, 4})          -> {init, 1};
+callback({gen_server, start_link, 3})     -> {init, 1};
+callback({gen_server, start_link, 4})     -> {init, 1};
+callback({gen_server, stop, 1})           -> {terminate, 2};
+callback({gen_server, stop, 3})           -> {terminate, 2};
+%% gen_statem
+callback({gen_statem, call, 2})           -> {handle_event, 4};
+callback({gen_statem, call, 3})           -> {handle_event, 4};
+callback({gen_statem, cast, 2})           -> {handle_event, 4};
+callback({gen_statem, start, 3})          -> {init, 1};
+callback({gen_statem, start, 4})          -> {init, 1};
+callback({gen_statem, start_link, 3})     -> {init, 1};
+callback({gen_statem, start_link, 4})     -> {init, 1};
+callback({gen_statem, stop, 1})           -> {terminate, 3};
+callback({gen_statem, stop, 3})           -> {terminate, 3};
+%% supervisor
+callback({supervisor, start_link, 2})     -> {init, 1};
+callback({supervisor, start_link, 3})     -> {init, 1};
+%% Everything else
+callback(_)                               -> undefined.

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -20,6 +20,7 @@
         , textdocument_documentsymbol/2
         , textdocument_hover/2
         , textdocument_definition/2
+        , textdocument_implementation/2
         , textdocument_references/2
         , textdocument_documenthighlight/2
         , textdocument_formatting/2
@@ -154,6 +155,8 @@ initialize(Params, State) ->
               els_formatting_provider:is_enabled_on_type()
           , foldingRangeProvider =>
               els_folding_range_provider:is_enabled()
+          , implementationProvider =>
+              els_implementation_provider:is_enabled()
           %% AZ: didchangewatchedfiles is not listed in
           %%     ServerCapabilities in the LSP spec.
           , didChangeWatchedFiles =>
@@ -348,6 +351,16 @@ textdocument_foldingrange(Params, State) ->
   Provider = els_folding_range_provider,
   Response = els_provider:handle_request( Provider
                                         , {document_foldingrange, Params}),
+  {response, Response, State}.
+
+%%==============================================================================
+%% textDocument/implementation
+%%==============================================================================
+
+-spec textdocument_implementation(params(), state()) -> result().
+textdocument_implementation(Params, State) ->
+  Provider = els_implementation_provider,
+  Response = els_provider:handle_request(Provider, {implementation, Params}),
   {response, Response, State}.
 
 %%==============================================================================

--- a/src/els_provider.erl
+++ b/src/els_provider.erl
@@ -25,7 +25,8 @@
                   | els_formatting_provider
                   | els_document_highlight_provider
                   | els_workspace_symbol_provider
-                  | els_folding_range_provider.
+                  | els_folding_range_provider
+                  | els_implementation_provider.
 -type request()  :: {atom(), map()}.
 -type state()    :: any().
 
@@ -91,6 +92,7 @@ providers() ->
   , els_document_highlight_provider
   , els_workspace_symbol_provider
   , els_folding_range_provider
+  , els_implementation_provider
   ].
 
 -spec enabled_providers() -> [provider()].

--- a/test/els_implementation_SUITE.erl
+++ b/test/els_implementation_SUITE.erl
@@ -1,0 +1,76 @@
+-module(els_implementation_SUITE).
+
+-include("erlang_ls.hrl").
+
+%% CT Callbacks
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , groups/0
+        , all/0
+        ]).
+
+%% Test cases
+-export([ gen_server_call/1
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+  [{timetrap, {seconds, 30}}].
+
+-spec all() -> [{group, stdio | tcp}].
+all() ->
+  [{group, tcp}, {group, stdio}].
+
+-spec groups() -> [atom()].
+groups() ->
+  els_test_utils:groups(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(TestCase, Config) ->
+  els_test_utils:init_per_testcase(TestCase, Config).
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) ->
+  els_test_utils:end_per_testcase(TestCase, Config).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+
+-spec gen_server_call(config()) -> ok.
+gen_server_call(Config) ->
+  Uri = ?config(gen_server_uri, Config),
+  #{result := Result} = els_client:implementation(Uri, 30, 10),
+  Expected = #{ range =>
+                  #{ 'end' => #{character => 4,line => 46}
+                   , start => #{character => 0,line => 46}
+                   }
+              , uri => Uri
+              },
+  ?assertEqual(Expected, Result),
+  ok.

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -74,6 +74,9 @@ init_per_suite(Config) ->
   FormatInputPath        = filename:join([ RootPath
                                          , <<"src">>
                                          , <<"format_input.erl">>]),
+  GenServerPath          = filename:join([ RootPath
+                                         , <<"src">>
+                                         , <<"my_gen_server.erl">>]),
 
   Uri                    = els_uri:uri(Path),
   ExtraUri               = els_uri:uri(ExtraPath),
@@ -84,6 +87,7 @@ init_per_suite(Config) ->
   ElvisDiagnosticsUri    = els_uri:uri(ElvisDiagnosticsPath),
   DiagnosticsIncludeUri  = els_uri:uri(DiagnosticsIncludePath),
   FormatInputUri         = els_uri:uri(FormatInputPath),
+  GenServerUri           = els_uri:uri(GenServerPath),
 
   {ok, Text} = file:read_file(Path),
 
@@ -108,6 +112,7 @@ init_per_suite(Config) ->
   , {elvis_diagnostics_uri, ElvisDiagnosticsUri}
   , {diagnostics_include_uri, DiagnosticsIncludeUri}
   , {format_input_uri, FormatInputUri}
+  , {gen_server_uri, GenServerUri}
   | Config
   ].
 
@@ -130,6 +135,7 @@ init_per_testcase(_TestCase, Config) ->
   els_indexer:find_and_index_file("code_navigation_types", sync),
   els_indexer:find_and_index_file("code_navigation.hrl", sync),
   els_indexer:find_and_index_file("diagnostics.hrl", sync),
+  els_indexer:find_and_index_file("my_gen_server", sync),
 
   [{started, Started} | Config].
 

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -108,6 +108,7 @@ initialize_post(_S, _Args, Res) ->
                         , save      => #{includeText => true}
                         }
                    , definitionProvider      => true
+                   , implementationProvider  => true
                    , referencesProvider      => true
                    , documentHighlightProvider => true
                    , documentSymbolProvider  => true


### PR DESCRIPTION
### Description

A maybe opinionated way to use the _implementation_ provider to navigate to callback functions for OTP behaviours.

Something that I longed for a long time was the ability to navigate from a call such as `gen_server:call(...)` to the respective `handle_call`. To limit the magic happening, this is restricted to the same module.

Fixes #363.
