### PR TITLE
[#377] Show debug level logs in debug mode

### DIFF
--- a/src/erlang_ls.erl
+++ b/src/erlang_ls.erl
@@ -64,11 +64,11 @@ lager_config() ->
 
 -spec lager_handlers(string()) -> [any()].
 lager_handlers(LogRoot) ->
-  LogFile = filename:join([LogRoot, "info.log"]),
+  LogFile = filename:join([LogRoot, "debug.log"]),
   ok      = filelib:ensure_dir(LogFile),
   [ { lager_file_backend
     , [ {file, LogFile}
-      , {level, info}
+      , {level, debug}
       ]
     }
   ].


### PR DESCRIPTION
### Description

This level was lowered to INFO in the old times when the whole buffer
content was part of the DEBUG logs, making them un-readable. This is
not the case any longer, so the change can be reverted. DEBUG messages
include the actual request/response messages, which is vital to find
the root cause of a bug.

Fixes #377 .
