### PR TITLE
fix not shutting down properly when using stdio transport

### DIFF
--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -203,7 +203,7 @@ exit(_Params, State) ->
                _        -> 1
              end,
   els_utils:halt(ExitCode),
-  {noresponse, State}.
+  {noresponse, #{}}.
 
 %%==============================================================================
 %% textDocument/didopen

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -197,11 +197,13 @@ shutdown(_Params, State) ->
 
 -spec exit(params(), state()) -> no_return().
 exit(_Params, State) ->
+  lager:info("Language server stopping..."),
   ExitCode = case maps:get(status, State, undefined) of
                shutdown -> 0;
                _        -> 1
              end,
-  els_utils:halt(ExitCode).
+  els_utils:halt(ExitCode),
+  {noresponse, State}.
 
 %%==============================================================================
 %% textDocument/didopen

--- a/src/els_stdio.erl
+++ b/src/els_stdio.erl
@@ -44,6 +44,11 @@ loop(Lines, IoDevice, Cb, JsonOpts) ->
       Request       = jsx:decode(Payload, JsonOpts),
       Cb([Request]),
       ?MODULE:loop([], IoDevice, Cb, JsonOpts);
+    eof ->
+      Cb([#{
+          <<"method">> => <<"exit">>,
+          <<"params">> => []
+        }]);
     Line ->
       ?MODULE:loop([Line | Lines], IoDevice, Cb, JsonOpts)
   end.

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -85,7 +85,7 @@ resolve_paths(PathSpecs, RootPath, Recursive) ->
 -spec halt(integer()) -> no_return().
 halt(ExitCode) ->
   els_db:stop(),
-  init:stop(ExitCode).
+  ok = init:stop(ExitCode).
 
 %% @doc Returns a project-relative file path for a given URI
 -spec project_relative(uri()) -> file:filename().

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -85,7 +85,7 @@ resolve_paths(PathSpecs, RootPath, Recursive) ->
 -spec halt(integer()) -> no_return().
 halt(ExitCode) ->
   els_db:stop(),
-  erlang:halt(ExitCode).
+  init:stop(ExitCode).
 
 %% @doc Returns a project-relative file path for a given URI
 -spec project_relative(uri()) -> file:filename().

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -299,7 +299,7 @@ setup() ->
   meck:expect(els_dialyzer_diagnostics, diagnostics, 1, []),
   meck:expect(els_elvis_diagnostics, diagnostics, 1, []),
   Self    = erlang:self(),
-  HaltFun = fun(_X) -> Self ! halt_called, {noresponse, #{}} end,
+  HaltFun = fun(_X) -> Self ! halt_called, ok end,
   meck:expect(els_utils, halt, HaltFun),
   application:ensure_all_started(erlang_ls),
   application:set_env(erlang_ls, index_otp, false),


### PR DESCRIPTION
### Description

Handle method 'exit' received from the stdio transport.
Also change halt to init:stop to tear down gracefully.


I see in the meantime `els_db:stop(),` call was added, I think this can be removed as `init:stop` should tear down the applications in dependency order. 


Fixes erlang-ls/vscode#11 .
