### PR TITLE
Clean up edoc comments

### DIFF
--- a/src/els_dodger.erl
+++ b/src/els_dodger.erl
@@ -250,7 +250,7 @@ parse(Dev) ->
 
 %% @spec parse(IODevice, StartLoc) -> {ok, Forms} | {error, errorinfo()}
 %%       IODevice = pid()
-%%       StartLoc = erl_anno:location
+%%       StartLoc = erl_anno:location()
 %%       Forms = [erl_syntax:syntaxTree()]
 %%
 %% @equiv parse(IODevice, StartLoc, [])

--- a/src/els_dt_document.erl
+++ b/src/els_dt_document.erl
@@ -150,13 +150,13 @@ new(Uri, Text, Id, Kind) ->
    , pois => POIs
    }.
 
-%% @edoc Returns the list of POIs for the current document
+%% @doc Returns the list of POIs for the current document
 -spec pois(item()) -> [poi()].
 pois(#{ pois := POIs }) ->
   POIs.
 
-%% @edoc Returns the list of POIs of the given types for the current
-%%       document
+%% @doc Returns the list of POIs of the given types for the current
+%%      document
 -spec pois(item(), [poi_kind()]) -> [poi()].
 pois(Item, Kinds) ->
   [POI || #{kind := K} = POI <- pois(Item), lists:member(K, Kinds)].

--- a/src/els_dt_references.erl
+++ b/src/els_dt_references.erl
@@ -91,13 +91,13 @@ insert(Map) when is_map(Map) ->
   Record = from_item(Map),
   els_db:write(Record).
 
-%% @edoc Find all
+%% @doc Find all
 -spec find_all() -> {ok, [item()]} | {error, any()}.
 find_all() ->
   Pattern = #els_dt_references{_ = '_'},
   find_by(Pattern).
 
-%% @edoc Find by id
+%% @doc Find by id
 -spec find_by_id(any()) -> {ok, [item()]} | {error, any()}.
 find_by_id(Id) ->
   Pattern = #els_dt_references{id = Id, _ = '_'},

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -182,7 +182,7 @@ terminate(_, _State) ->
 %% Internal functions
 %%==============================================================================
 
-%% @edoc Try indexing a file.
+%% @doc Try indexing a file.
 -spec try_index_file(binary(), sync | async) -> ok | {error, any()}.
 try_index_file(FullName, SyncAsync) ->
   try

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -104,7 +104,7 @@ find_attribute_tokens([ {'-', Anno}, {atom, _, export} | [_|_] = Rest]) ->
 find_attribute_tokens(_) ->
   [].
 
-%% @edoc Find points of interest in a spec attribute.
+%% @doc Find points of interest in a spec attribute.
 -spec find_spec_points_of_interest(tree()) -> [poi()].
 find_spec_points_of_interest(Tree) ->
   Fun = fun do_find_spec_points_of_interest/2,
@@ -136,7 +136,7 @@ points_of_interest(Tree, EndLocation) ->
   FoldFun = fun(T, Acc) -> [do_points_of_interest(T, EndLocation), Acc] end,
   erl_syntax_lib:fold(FoldFun, [], Tree).
 
-%% @edoc Return the list of points of interest for a given `Tree`.
+%% @doc Return the list of points of interest for a given `Tree'.
 -spec do_points_of_interest(tree(), erl_anno:location()) -> [poi()].
 do_points_of_interest(Tree, EndLocation) ->
   try

--- a/src/els_poi.erl
+++ b/src/els_poi.erl
@@ -21,12 +21,12 @@
 %% API
 %%==============================================================================
 
-%% @edoc Constructor for a Point of Interest.
+%% @doc Constructor for a Point of Interest.
 -spec new(poi_range(), poi_kind(), any()) -> poi().
 new(Range, Kind, Id) ->
   new(Range, Kind, Id, undefined).
 
-%% @edoc Constructor for a Point of Interest.
+%% @doc Constructor for a Point of Interest.
 -spec new(poi_range(), poi_kind(), any(), any()) -> poi().
 new(Range, Kind, Id, Data) ->
   #{ kind  => Kind


### PR DESCRIPTION
There were various errors.

We should perhaps run edoc as part of the `make` process.
