### PR TITLE
[#406] Add and use `pa_dirs` configuration setting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ all:
 	@ rebar3 escriptize
 
 ci:
-	rebar3 do compile, ct, proper --cover --constraint_tries 100, dialyzer, xref, cover, edoc
+	rebar3 do compile, ct # ct sets -pa, need to restart for the res
+	rebar3 do compile, proper --cover --constraint_tries 100, dialyzer, xref, cover, edoc
 
 coveralls:
 	rebar3 coveralls send

--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ deps_dirs:
 include_dirs:
   - "include"
   - "_build/default/lib"
+pa_dirs:
+  - "_build/default/lib/mylib/ebin"
 macros:
   - name: DEFINED_WITH_VALUE
     value: 42
@@ -417,6 +419,7 @@ The following customizations are possible:
 | deps\_dirs         | List of directories containing dependencies. It supports wildcards.                                                                       |
 | apps\_dirs         | List of directories containing project applications. It supports wildcards.                                                               |
 | include\_dirs      | List of directories provided to the compiler as include dirs. It supports wildcards.                                                      |
+| pa\_dirs           | List of directories containing beam files for e.g. behaviours.                                                                            |
 | macros             | List of cusom macros to be passed to the compiler, expressed as a name/value pair. If the value is omitted or is invalid, 'true' is used. |
 | otp\_apps\_exclude | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)                                                   |
 | code\_reload       | Whether or not an rpc call should be made to a remote node to compile and reload a module                                                 |

--- a/priv/behaviour/LICENSE
+++ b/priv/behaviour/LICENSE
@@ -1,0 +1,191 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2020, Alan Zimmerman <alanzimm@fb.com>.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/priv/behaviour/README.md
+++ b/priv/behaviour/README.md
@@ -1,0 +1,9 @@
+mylib
+=====
+
+An OTP application
+
+Build
+-----
+
+    $ rebar3 compile

--- a/priv/behaviour/erlang_ls.config
+++ b/priv/behaviour/erlang_ls.config
@@ -1,0 +1,2 @@
+pa_dirs:
+ - "_build/test/lib/mylib/ebin"

--- a/priv/behaviour/rebar.config
+++ b/priv/behaviour/rebar.config
@@ -1,0 +1,7 @@
+{erl_opts, [debug_info]}.
+{deps, []}.
+
+{shell, [
+  % {config, "config/sys.config"},
+    {apps, [mylib]}
+]}.

--- a/priv/behaviour/src/mylib.app.src
+++ b/priv/behaviour/src/mylib.app.src
@@ -1,0 +1,15 @@
+{application, mylib,
+ [{description, "An OTP application"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {mod, {mylib_app, []}},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {licenses, ["Apache 2.0"]},
+  {links, []}
+ ]}.

--- a/priv/behaviour/src/mylib_app.erl
+++ b/priv/behaviour/src/mylib_app.erl
@@ -1,0 +1,19 @@
+%%%-------------------------------------------------------------------
+%% @doc mylib public API
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(mylib_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    mylib_sup:start_link().
+
+stop(_State) ->
+    Foo = 3,
+    ok.
+
+%% internal functions

--- a/priv/behaviour/src/mylib_behaviour.erl
+++ b/priv/behaviour/src/mylib_behaviour.erl
@@ -1,0 +1,4 @@
+-module(mylib_behaviour).
+
+-callback init(any())                -> any().
+-callback foo(any(), binary())       -> ok.

--- a/priv/behaviour/src/mylib_imp.erl
+++ b/priv/behaviour/src/mylib_imp.erl
@@ -1,0 +1,11 @@
+-module(mylib_imp).
+
+-behaviour(mylib_behaviour).
+
+-export([init/1, foo/2]).
+
+init(A) ->
+    ok.
+
+foo(_A,_B) ->
+    ok.

--- a/priv/behaviour/src/mylib_sup.erl
+++ b/priv/behaviour/src/mylib_sup.erl
@@ -1,0 +1,35 @@
+%%%-------------------------------------------------------------------
+%% @doc mylib top level supervisor.
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(mylib_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%% sup_flags() = #{strategy => strategy(),         % optional
+%%                 intensity => non_neg_integer(), % optional
+%%                 period => pos_integer()}        % optional
+%% child_spec() = #{id => child_id(),       % mandatory
+%%                  start => mfargs(),      % mandatory
+%%                  restart => restart(),   % optional
+%%                  shutdown => shutdown(), % optional
+%%                  type => worker(),       % optional
+%%                  modules => modules()}   % optional
+init([]) ->
+    SupFlags = #{strategy => one_for_all,
+                 intensity => 0,
+                 period => 1},
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.
+
+%% internal functions

--- a/rebar.config
+++ b/rebar.config
@@ -65,6 +65,9 @@
                , { pre_hooks
                  , [ { compile
                      , "erl -pa _build/test/lib/*/ebin -noshell -eval 'init:stop(case elvis_core:rock() of ok -> 0; _ -> 1 end)'"
+                     },
+                     { ct
+                     , "sh -c '(cd priv/behaviour && rebar3 as test compile)'"
                      }
                    ]
                  }

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -36,6 +36,7 @@
                | apps_paths
                | capabilities
                | deps_dirs
+               | pa_dirs
                | deps_paths
                | include_dirs
                | include_paths
@@ -52,6 +53,7 @@
                   , apps_paths       => [path()]
                   , deps_dirs        => [path()]
                   , deps_paths       => [path()]
+                  , pa_dirs          => [path()]
                   , include_dirs     => [path()]
                   , include_paths    => [path()]
                   , otp_path         => path()
@@ -73,6 +75,7 @@ initialize(RootUri, Capabilities, InitOptions) ->
   Config = consult_config(config_paths(RootPath, InitOptions)),
   OtpPath         = maps:get("otp_path", Config, code:root_dir()),
   DepsDirs        = maps:get("deps_dirs", Config, []),
+  PaDirs          = maps:get("pa_dirs", Config, []),
   AppsDirs        = maps:get("apps_dirs", Config, ["."]),
   IncludeDirs     = maps:get("include_dirs", Config, ["include"]),
   Macros          = maps:get("macros", Config, []),
@@ -91,6 +94,7 @@ initialize(RootUri, Capabilities, InitOptions) ->
   %% Read from the erlang_ls.config file
   ok = set(otp_path       , OtpPath),
   ok = set(deps_dirs      , DepsDirs),
+  ok = set(pa_dirs        , PaDirs),
   ok = set(apps_dirs      , AppsDirs),
   ok = set(include_dirs   , IncludeDirs),
   ok = set(macros         , Macros),
@@ -108,6 +112,7 @@ initialize(RootUri, Capabilities, InitOptions) ->
                          , otp_paths(OtpPath, true)
                          ])
           ),
+
   %% Init Options
   ok = set(capabilities  , Capabilities),
   ok.


### PR DESCRIPTION
This allows compiler diagnostics to load existing behaviour beam files, avoiding false error reporting.

It does this by adding a new config file option, `pa_dirs`, corresponding to the `-pa` command line flag.

Fixes #406  .
