### PR TITLE
[#405] handle error in els_compiler_diagnostic:parse/1

### DIFF
--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -14,6 +14,7 @@
 -export([ compiler/1
         , compiler_with_custom_macros/1
         , code_reload/1
+        , compiler_parse/1
         , elvis/1
         ]).
 
@@ -125,6 +126,13 @@ compiler_with_custom_macros(Config) ->
                            , start => #{character => 0,line => 8}}
                         ],
   ?assertEqual(ExpectedErrorRanges, ErrorRanges),
+  ok.
+
+-spec compiler_parse(config()) -> ok.
+compiler_parse(_Config) ->
+  Uri = els_uri:uri(<<"nonexistent_file.hrl">>),
+  Res = els_compiler_diagnostics:diagnostics(Uri),
+  ?assertEqual([], Res),
   ok.
 
 -spec elvis(config()) -> ok.


### PR DESCRIPTION
If a `.hrl` file does not exist, or does not open for any reason, log
a warning and return an empty diagnostic list.

Fixes #405.
