### PR TITLE
Implement functionality for hot code swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,8 +431,12 @@ The following customizations are possible:
 | apps\_dirs             | List of directories containing project applications. It supports wildcards.                          |
 | include\_dirs          | List of directories provided to the compiler as include dirs. It supports wildcards.                 |
 | otp\_apps\_exclude     | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)              |
-| code\_reload\_enabled  | Whether or not an rpc call should be mode to a remote node to compile and reload a module            |
-| code\_reload\_node     | If code\_reload\_enabled is set to true, the node to be called should be provided. Example: "els@xx" |
+| code\_reload           | Whether or not an rpc call should be made to a remote node to compile and reload a module            |
+
+The `code_reload` takes a list of the following options:
+| Parameter              | Description                                                                                          |
+|------------------------|------------------------------------------------------------------------------------------------------|
+| node                   | The node to be called for code reloading. Example erlang_ls@hostname                                 |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -423,14 +423,16 @@ The file format is `yaml`.
 
 The following customizations are possible:
 
-| Parameter          | Description                                                                                          |
-|--------------------|------------------------------------------------------------------------------------------------------|
-| otp\_path          | Path to the OTP installation                                                                         |
-| plt\_path          | Path to the dialyzer PLT file. When none is provided the dialyzer diagnostics will not be available. |
-| deps\_dirs         | List of directories containing dependencies. It supports wildcards.                                  |
-| apps\_dirs         | List of directories containing project applications. It supports wildcards.                          |
-| include\_dirs      | List of directories provided to the compiler as include dirs. It supports wildcards.                 |
-| otp\_apps\_exclude | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)              |
+| Parameter              | Description                                                                                          |
+|------------------------|------------------------------------------------------------------------------------------------------|
+| otp\_path              | Path to the OTP installation                                                                         |
+| plt\_path              | Path to the dialyzer PLT file. When none is provided the dialyzer diagnostics will not be available. |
+| deps\_dirs             | List of directories containing dependencies. It supports wildcards.                                  |
+| apps\_dirs             | List of directories containing project applications. It supports wildcards.                          |
+| include\_dirs          | List of directories provided to the compiler as include dirs. It supports wildcards.                 |
+| otp\_apps\_exclude     | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)              |
+| code\_reload\_enabled  | Whether or not an rpc call should be mode to a remote node to compile and reload a module            |
+| code\_reload\_node     | If code\_reload\_enabled is set to true, the node to be called should be provided. Example: "els@xx" |
 
 ## Troubleshooting
 

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -45,24 +45,22 @@
                | plt_path
                | root_uri
                | search_paths
-               | code_reload_enabled
-               | code_reload_node.
+               | code_reload.
 
 -type path()  :: file:filename().
--type state() :: #{ apps_dirs           => [path()]
-                  , apps_paths          => [path()]
-                  , deps_dirs           => [path()]
-                  , deps_paths          => [path()]
-                  , include_dirs        => [path()]
-                  , include_paths       => [path()]
-                  , otp_path            => path()
-                  , otp_paths           => [path()]
-                  , otp_apps_exclude    => [string()]
-                  , plt_path            => path()
-                  , root_uri            => uri()
-                  , search_paths        => [path()]
-                  , code_reload_enabled => boolean()
-                  , code_reload_node    => atom()
+-type state() :: #{ apps_dirs        => [path()]
+                  , apps_paths       => [path()]
+                  , deps_dirs        => [path()]
+                  , deps_paths       => [path()]
+                  , include_dirs     => [path()]
+                  , include_paths    => [path()]
+                  , otp_path         => path()
+                  , otp_paths        => [path()]
+                  , otp_apps_exclude => [string()]
+                  , plt_path         => path()
+                  , root_uri         => uri()
+                  , search_paths     => [path()]
+                  , code_reload      => map() | 'disabled'
                   }.
 
 %%==============================================================================
@@ -85,24 +83,22 @@ initialize(RootUri, Capabilities, InitOptions) ->
   ExcludePathsSpecs = [[OtpPath, "lib", P ++ "*"] || P <- OtpAppsExclude],
   ExcludePaths = els_utils:resolve_paths(ExcludePathsSpecs, RootPath, true),
   lager:info("Excluded OTP Applications: ~p", [OtpAppsExclude]),
-  CodeReloadRenabled = maps:get("hot_code_reload_enabled", Config, false),
-  CodeReloadNode = maps:get("hot_code_reload_node", Config, ""),
+  CodeReload = maps:get("code_reload", Config, disabled),
 
   %% Passed by the LSP client
-  ok = set(root_uri            , RootUri),
+  ok = set(root_uri       , RootUri),
   %% Read from the erlang_ls.config file
-  ok = set(otp_path            , OtpPath),
-  ok = set(deps_dirs           , DepsDirs),
-  ok = set(apps_dirs           , AppsDirs),
-  ok = set(include_dirs        , IncludeDirs),
-  ok = set(plt_path            , DialyzerPltPath),
-  ok = set(code_reload_enabled , CodeReloadRenabled),
-  ok = set(code_reload_node    , list_to_atom(CodeReloadNode)),
+  ok = set(otp_path       , OtpPath),
+  ok = set(deps_dirs      , DepsDirs),
+  ok = set(apps_dirs      , AppsDirs),
+  ok = set(include_dirs   , IncludeDirs),
+  ok = set(plt_path       , DialyzerPltPath),
+  ok = set(code_reload    , CodeReload),
   %% Calculated from the above
-  ok = set(apps_paths          , project_paths(RootPath, AppsDirs, false)),
-  ok = set(deps_paths          , project_paths(RootPath, DepsDirs, false)),
-  ok = set(include_paths       , include_paths(RootPath, IncludeDirs, false)),
-  ok = set(otp_paths           , otp_paths(OtpPath, false) -- ExcludePaths),
+  ok = set(apps_paths     , project_paths(RootPath, AppsDirs, false)),
+  ok = set(deps_paths     , project_paths(RootPath, DepsDirs, false)),
+  ok = set(include_paths  , include_paths(RootPath, IncludeDirs, false)),
+  ok = set(otp_paths      , otp_paths(OtpPath, false) -- ExcludePaths),
   %% All (including subdirs) paths used to search files with file:path_open/3
   ok = set( search_paths
           , lists:append([ project_paths(RootPath, AppsDirs, true)

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -189,10 +189,8 @@ mock_code_reload_enabled() ->
   meck:new(els_config, [passthrough, no_link]),
   meck:expect( els_config
              , get
-             , fun(code_reload_enabled) ->
-                   true;
-                  (code_reload_node) ->
-                   'fakenode';
+             , fun(code_reload) ->
+                   #{"node" => "fakenode"};
                   (Key) ->
                    meck:passthrough([Key])
                end


### PR DESCRIPTION
### Description

One of the features that I miss most when coming from EDTS is the ability of hot code reloading my changes.
This PR introduces this ability and should help in getting users of EDTS switched over to erlang_ls.

There are a few things in this PR that I'm not a huge fan of and I'm happy to discuss:
- I have not found a nice way of being able to test this functionality in a test SUITE.
  I have exported the function that is called using `ifdef(TEST)` (which I personally generally dislike),
  after trying several ways this seemed like the least intrusive way of testing this.
  If you'd prefer another approach, please let me know.

- Ideally I'd like to provide the Mod and Function that should be used to recompile as part of a config as well.
  This to aid any users that have implemented some custom way of compiling their code.
  I'd like some input if you believe this is a decent idea.