### PR TITLE
[#430] Remove unused debug_mode application variable

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,8 +42,7 @@
                    ]
                  }
                , { escript_emu_args
-                 , "%%! -erlang_ls debug_mode true "
-                   " -erlang_ls logging_enabled true \n"
+                 , "%%! -erlang_ls logging_enabled true \n"
                  }
                  %% For some reason we need to explicitly include redbug,
                  %% even if it already is a dependency.

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -23,7 +23,6 @@
     , [ {transport, els_tcp}
       , {io_device, standard_io}
       , {port, 10000}
-      , {debug_mode, false}
         %% Indexing
       , {indexers, 10}
       , {index_otp, true}


### PR DESCRIPTION
### Description

Remove unused `debug_mode` application variable.
