### PR TITLE
Inject exit message when TCP socket is closed.

### DIFF
--- a/src/els_tcp.erl
+++ b/src/els_tcp.erl
@@ -80,6 +80,10 @@ loop(#state{buffer = Buffer} = State) ->
       inet:setopts(Socket, [{active, once}]),
       loop(State#state{buffer = NewBuffer});
     {tcp_closed, _Socket} ->
+      ok = els_server:process_requests([#{
+                                          <<"method">> => <<"exit">>,
+                                          <<"params">> => []
+                                         }]),
       ok;
     Message ->
       lager:warning("Unsupported message: ~p", [Message]),


### PR DESCRIPTION
This matches the stdio behaviour, as per #379

Fixes https://github.com/erlang-ls/vscode/issues/11

