### PR TITLE
[#438] Use upstream redbug again

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,7 @@
                    %% A PR is pending approval for updating the
                    %% upstream version:
                    %% https://github.com/massemanet/redbug/pull/10
-                 , [ {redbug, {git, "https://github.com/robertoaloi/redbug.git", {branch, "relax-beam-lib-error-matching"}}}
+                 , [ {redbug, {git, "https://github.com/massemanet/redbug.git", {ref, "8dd853154799da973b20be3a33fc8da9618e6393"}}}
                    , {eflame, {git, "https://github.com/jfacorro/eflame.git", {branch, "various.improvements"}}}
                    ]
                  }


### PR DESCRIPTION
### Description

A tag is not yet available for the latest version of redbug, so let's keep an eye on that.

Fixes #438 .
