### PR TITLE
Add include_dirs as additional option to dialyzer:run/1 in els_dialyzer_diagnostics

### DIFF
--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -31,6 +31,7 @@ diagnostics(Uri) ->
     DialyzerPltPath ->
       WS = try dialyzer:run([ {files, [binary_to_list(Path)]}
                             , {from, src_code}
+                            , {include_dirs, els_config:get(include_paths)}
                             , {plts, [DialyzerPltPath]}
                             ])
            catch Type:Error ->


### PR DESCRIPTION
### Description

Today I tried to add `plt_path` to one of my projects but realized that dialyzer was not reporting any errors. The reason turned out to be that `dialyzer:run/1` was unable to operate on the src code since it was unable to find the includes that were required. 

Adding the `include_dirs` option solved the problem. 

Note:
I did not add a test for this since I was unable to find any dialyzer tests at all? Unless I'm mistaken, I suggest we add an issue for adding some tests for `els_dialyzer_diagnostics`