### PR TITLE
468 async dialyzer and elvis checks

### DIFF
--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -203,6 +203,15 @@ elvis(Config) ->
       file:set_cwd(RootPath),
       Uri = ?config(elvis_diagnostics_uri, Config),
       ok = els_client:did_save(Uri),
+      %% Only the compiler diagnostics are in this notification
+      {CMethod, CParams} = wait_for_notification(),
+      ?assertEqual( <<"textDocument/publishDiagnostics">>
+                  , CMethod),
+      ?assert(maps:is_key(diagnostics, CParams)),
+      #{diagnostics := CDiagnostics} = CParams,
+      ?assertEqual(0, length(CDiagnostics)),
+
+      %% Dialyzer and Elvis diagnostics are in this notification
       {Method, Params} = wait_for_notification(),
       ?assertEqual( <<"textDocument/publishDiagnostics">>
                   , Method),


### PR DESCRIPTION
### Description

After raising #468 I found that with a minor rewrite we could work around the slowness of Dialyzer by performing Elvis and Dialyzer checks asynchronously. The (opinionated) view here being that compiler diagnostics and the ability to use code_reload and run your tests quickly are more important than seeing Dialyzer and Elvis warnings in your editor. 

They still show up but with a slight delay. Basically the flow went from:
- compile -> dialyzer -> elvis -> code_reload -> notify editor

to:
- compile -> code_reload -> notify editor -> dialyzer -> elvis -> notify editor 

For the end-user very little changed other than that Dialyzer and Elvis warnings come with a slight delay after the user has been notified of compiler warnings / code_reload result. 

Fixes #468
