### PR TITLE
[#481] Check MD5 before parsing file content

### DIFF
--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -230,8 +230,7 @@ textdocument_didchange(Params, State) ->
   case ContentChanges of
     []                      -> ok;
     [#{<<"text">> := Text}] ->
-      Document = els_dt_document:new(Uri, Text),
-      els_indexer:index(Document)
+      els_indexer:index(Uri, Text)
   end,
   {noresponse, State}.
 

--- a/src/els_text_synchronization.erl
+++ b/src/els_text_synchronization.erl
@@ -16,8 +16,7 @@ did_open(Params) ->
   TextDocument = maps:get(<<"textDocument">>, Params),
   Uri          = maps:get(<<"uri">>         , TextDocument),
   Text         = maps:get(<<"text">>        , TextDocument),
-  Document     = els_dt_document:new(Uri, Text),
-  ok           = els_indexer:index(Document),
+  ok           = els_indexer:index(Uri, Text),
   spawn (?MODULE, generate_diagnostics, [Uri]),
   ok.
 

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -185,15 +185,14 @@ record(Config) ->
 -spec purge_references(config()) -> ok.
 purge_references(_Config) ->
   els_db:clear_tables(),
-  Uri = <<"file://tmp/foo.erl">>,
+  Uri   = <<"file://tmp/foo.erl">>,
   Text0 = "-spec foo(integer()) -> ok.\nfoo(_X) -> ok.\nbar() -> foo(1).",
   Text1 = "\n-spec foo(integer()) -> ok.\nfoo(_X)-> ok.\nbar() -> foo(1).",
-  Doc0 = els_dt_document:new(Uri, Text0),
-  Doc1 = els_dt_document:new(Uri, Text1),
+  Doc0  = els_dt_document:new(Uri, Text0),
+  Doc1  = els_dt_document:new(Uri, Text1),
 
-  els_indexer:index(Doc0),
-  ?assertEqual({ok, [Doc0]}
-              , els_dt_document:lookup(Uri)),
+  ok = els_indexer:index(Uri, Text0),
+  ?assertEqual({ok, [Doc0]}, els_dt_document:lookup(Uri)),
   ?assertEqual({ok, [#{ id    => {foo, foo, 1}
                       , range => #{from => {3, 10}, to => {3, 13}}
                       , uri   => <<"file://tmp/foo.erl">>
@@ -201,9 +200,8 @@ purge_references(_Config) ->
               , els_dt_references:find_all()
               ),
 
-  els_indexer:index(Doc1),
-  ?assertEqual({ok, [Doc1]}
-              , els_dt_document:lookup(Uri)),
+  ok = els_indexer:index(Uri, Text1),
+  ?assertEqual({ok, [Doc1]}, els_dt_document:lookup(Uri)),
   ?assertEqual({ok, [#{ id    => {foo, foo, 1}
                       , range => #{from => {4, 10}, to => {4, 13}}
                       , uri   => <<"file://tmp/foo.erl">>


### PR DESCRIPTION
### Description

Check MD5 before parsing file content.

Fixes #481.
