### PR TITLE
[#500] Run GitHub actions when pull request is opened

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   build:
     strategy:


### PR DESCRIPTION
### Description

Enable running GitHub actions for pull requests to `master` (when they are created, updated or re-opened) and pushes to `master` (when the PRs are merged).

See [here](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request) for documentation on what events are available.

Fixes #500.
