### PR TITLE
[#413] Avoid negative columns

### DIFF
--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -54,8 +54,8 @@ source() ->
 %%==============================================================================
 -spec diagnostic({any(), {any(), integer()}, any()}) -> diagnostic().
 diagnostic({_, {_, Line}, _} = Warning) ->
-  Range   = els_protocol:range(#{ from => {Line, 0}
-                                , to   => {Line, 0}
+  Range   = els_protocol:range(#{ from => {Line, 1}
+                                , to   => {Line + 1, 1}
                                 }),
   Message = list_to_binary(lists:flatten(dialyzer:format_warning(Warning))),
   #{ range    => Range


### PR DESCRIPTION
### Description

The diagnostics returned for dialyzer contained a negative column number which prevented any other diagnostics to be reported in VS Code.

Fixes #413 .
