### PR TITLE
Fix readme for code reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ macros:
   - name: DEFINED_WITH_VALUE
     value: 42
   - name: DEFINED_WITHOUT_VALUE
+code_reload:
+  node: node@example
 ```
 
 The file format is `yaml`.

--- a/src/els_text_synchronization.erl
+++ b/src/els_text_synchronization.erl
@@ -61,7 +61,7 @@ diagnostics(Uri, Modules, Previous) ->
 -spec maybe_compile_and_load(uri(), [diagnostic()]) -> ok.
 maybe_compile_and_load(Uri, [] = _CDiagnostics) ->
   case els_config:get(code_reload) of
-    #{"node" := NodeStr} ->
+    [#{"node" := NodeStr}] ->
       Node = list_to_atom(NodeStr),
       Module = els_uri:module(Uri),
       case rpc:call(Node, code, is_sticky, [Module]) of

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -309,7 +309,7 @@ mock_code_reload_enabled() ->
   meck:expect( els_config
              , get
              , fun(code_reload) ->
-                   #{"node" => "fakenode"};
+                   [#{"node" => "fakenode"}];
                   (Key) ->
                    meck:passthrough([Key])
                end


### PR DESCRIPTION
### Description

I'm honestly not exactly sure how the `code_reload` should be structured from a `yaml`-purist perspective but plenty of yaml-examples I find use the following standard. 

Currently it's confusing since it's not well documented and most users would assume which is "wrong" according to how the code is written :cry: 
```yaml
code_reload:
  - node: foo@example
```

Since the test uses meck, the test didn't catch this which I'll see how to resolve in a PR that I'm working now that follows up on: https://github.com/erlang-ls/erlang_ls/pull/469 (cleaning up the code now and finalizing some Dialyzer tests) 
