### PR TITLE
Fix readme for code reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ macros:
   - name: DEFINED_WITH_VALUE
     value: 42
   - name: DEFINED_WITHOUT_VALUE
+code_reload:
+  node: node@example
 ```
 
 The file format is `yaml`.
@@ -435,7 +437,7 @@ The following customizations are possible:
 | otp\_apps\_exclude | List of OTP applications that will not be indexed (default: megaco, diameter, snmp, wx)                                                   |
 | code\_reload       | Whether or not an rpc call should be made to a remote node to compile and reload a module                                                 |
 
-The `code_reload` takes a list of the following options:
+The `code_reload` takes the following options:
 | Parameter | Description                                                          |
 |-----------|----------------------------------------------------------------------|
 | node      | The node to be called for code reloading. Example erlang_ls@hostname |


### PR DESCRIPTION
### Description

I'm honestly not exactly sure how the `code_reload` should be structured from a `yaml`-purist perspective but plenty of yaml-examples I find use the following standard. 

Currently it's confusing since it's not well documented and most users would assume which is "wrong" according to how the code is written :cry: 
```yaml
code_reload:
  - node: foo@example
```

Since the test uses meck, the test didn't catch this which I'll see how to resolve in a PR that I'm working now that follows up on: https://github.com/erlang-ls/erlang_ls/pull/469 (cleaning up the code now and finalizing some Dialyzer tests) 
