### PR TITLE
[#484] Hovering over export entries shows information

### DIFF
--- a/priv/code_navigation/src/code_navigation.erl
+++ b/priv/code_navigation/src/code_navigation.erl
@@ -2,7 +2,7 @@
 
 -behaviour(behaviour_a).
 
--export([ function_a/0, function_g/1, function_b/0 ]).
+-export([ function_a/0, function_b/0, function_g/1, function_j/0 ]).
 
 %% behaviour_a callbacks
 -export([ callback_a/0 ]).

--- a/src/els_hover_provider.erl
+++ b/src/els_hover_provider.erl
@@ -49,6 +49,8 @@ documentation(_M, #{kind := application, id := {M, F, A}}) ->
   get_docs(M, F, A);
 documentation(M, #{kind := application, id := {F, A}}) ->
   get_docs(M, F, A);
+documentation(M, #{kind := export_entry, id := {F, A}}) ->
+  get_docs(M, F, A);
 documentation(_M, _POI) ->
   <<>>.
 

--- a/test/els_document_highlight_SUITE.erl
+++ b/test/els_document_highlight_SUITE.erl
@@ -68,10 +68,8 @@ end_per_testcase(TestCase, Config) ->
 application_local(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 22, 5),
-  ExpectedLocations = [ #{ range => #{from => {22, 3}, to => {22, 13}}
-                         }
-                      , #{ range => #{from => {51, 7}, to => {51, 23}}
-                         }
+  ExpectedLocations = [ #{range => #{from => {22, 3}, to => {22, 13}}}
+                      , #{range => #{from => {51, 7}, to => {51, 23}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.
@@ -80,10 +78,8 @@ application_local(Config) ->
 application_remote(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 32, 13),
-  ExpectedLocations = [ #{ range => #{from => {32, 3}, to => {32, 27}}
-                         }
-                      , #{ range => #{from => {52, 8}, to => {52, 38}}
-                         }
+  ExpectedLocations = [ #{range => #{from => {32, 3}, to => {32, 27}}}
+                      , #{range => #{from => {52, 8}, to => {52, 38}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.
@@ -93,10 +89,8 @@ function_definition(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 25, 1),
     %% TODO:AZ: I would expect 25,1 to 25,10 to also show up
-  ExpectedLocations = [ #{ range => #{from => {22, 3}, to => {22, 13}}
-                         }
-                      , #{ range => #{from => {51, 7}, to => {51, 23}}
-                         }
+  ExpectedLocations = [ #{range => #{from => {22, 3}, to => {22, 13}}}
+                      , #{range => #{from => {51, 7}, to => {51, 23}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.
@@ -105,10 +99,8 @@ function_definition(Config) ->
 fun_local(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 51, 16),
-  ExpectedLocations = [ #{ range => #{from => {22, 3}, to => {22, 13}}
-                         }
-                      , #{ range => #{from => {51, 7}, to => {51, 23}}
-                         }
+  ExpectedLocations = [ #{range => #{from => {22, 3}, to => {22, 13}}}
+                      , #{range => #{from => {51, 7}, to => {51, 23}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.
@@ -117,10 +109,8 @@ fun_local(Config) ->
 fun_remote(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   #{result := Locations} = els_client:document_highlight(Uri, 52, 14),
-  ExpectedLocations = [ #{ range => #{from => {32, 3}, to => {32, 27}}
-                         }
-                      , #{ range => #{from => {52, 8}, to => {52, 38}}
-                         }
+  ExpectedLocations = [ #{range => #{from => {32, 3}, to => {32, 27}}}
+                      , #{range => #{from => {52, 8}, to => {52, 38}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.
@@ -128,16 +118,13 @@ fun_remote(Config) ->
 -spec export_entry(config()) -> ok.
 export_entry(Config) ->
   Uri = ?config(code_navigation_uri, Config),
-  #{result := Locations} = els_client:document_highlight(Uri, 5, 39),
+  #{result := Locations} = els_client:document_highlight(Uri, 5, 25),
   %% TODO:AZ: I would expect to also see 5,39 to 5,48
-  ExpectedLocations = [ #{ range => #{from => {22, 3}, to => {22, 13}}
-                         }
-                      , #{ range => #{from => {51, 7}, to => {51, 23}}
-                         }
+  ExpectedLocations = [ #{range => #{from => {22, 3}, to => {22, 13}}}
+                      , #{range => #{from => {51, 7}, to => {51, 23}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.
-
 
 %%==============================================================================
 %% Internal functions

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -141,7 +141,7 @@ fun_remote(Config) ->
 -spec export_entry(config()) -> ok.
 export_entry(Config) ->
   Uri = ?config(code_navigation_uri, Config),
-  #{result := Locations} = els_client:references(Uri, 5, 39),
+  #{result := Locations} = els_client:references(Uri, 5, 25),
   ExpectedLocations = [ #{ uri => Uri
                          , range => #{from => {22, 3}, to => {22, 13}}
                          }


### PR DESCRIPTION
### Description

Hovering over export entries shows information.

Fixes #484.
