### PR TITLE
[#514] Register commands with a unique prefix

### DIFF
--- a/src/els_code_action_provider.erl
+++ b/src/els_code_action_provider.erl
@@ -47,11 +47,13 @@ replace_lines_action(Uri, Title, Kind, Lines, Range) ->
    , <<"end">>   := #{ <<"character">> := _EndCol
                      , <<"line">>      := EndLine }
    } = Range,
+  PrefixedCommand
+    = els_execute_command_provider:add_server_prefix(<<"replace-lines">>),
   #{ title => Title
    , kind => Kind
    , command =>
           els_protocol:command( Title
-                              , <<"replace-lines">>
+                              , PrefixedCommand
                               , [#{ uri   => Uri
                                   , lines => Lines
                                   , from  => StartLine

--- a/test/els_code_action_SUITE.erl
+++ b/test/els_code_action_SUITE.erl
@@ -70,6 +70,8 @@ add_underscore_to_unused_var(Config) ->
           , source   => <<"Compiler">>
           },
   Range = els_protocol:range(#{from => {80, 1}, to => {81, 1}}),
+  PrefixedCommand
+    = els_execute_command_provider:add_server_prefix(<<"replace-lines">>),
   #{result := Result} = els_client:document_codeaction(Uri, Range, [Diag]),
   Expected =
     [ #{ command => #{ arguments => [ #{ from  => 79
@@ -78,7 +80,7 @@ add_underscore_to_unused_var(Config) ->
                                        , uri   => Uri
                                        }
                                     ]
-                     , command   => <<"replace-lines">>
+                     , command   => PrefixedCommand
                      , title     => <<"Add '_' to 'A'">>
                      }
        , kind    => <<"quickfix">>

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -94,6 +94,8 @@ initialize_post(#{shutdown := true}, _Args, Res) ->
   assert_invalid_request(Res),
   true;
 initialize_post(_S, _Args, Res) ->
+  PrefixedCommand
+    = els_execute_command_provider:add_server_prefix(<<"replace-lines">>),
   Expected = #{ capabilities =>
                   #{ hoverProvider => true
                    , completionProvider =>
@@ -116,7 +118,7 @@ initialize_post(_S, _Args, Res) ->
                    , documentSymbolProvider  => true
                    , foldingRangeProvider => true
                    , executeCommandProvider =>
-                       #{ commands => [<<"replace-lines">>] }
+                       #{ commands => [PrefixedCommand] }
                    , codeActionProvider => true
                    , workspaceSymbolProvider => true
                    , documentFormattingProvider => true


### PR DESCRIPTION
The LSP executeCommand process requires the commands to be first registered with
the client. Vscode has a single registry of commands, for the entire client, and
shuts down a server if it tries to register a duplicate command.

This diff ensures that all commands used are unique, by prepending the
underlying operating system process id to the command when registered and used.

Fixes #514.
