### PR TITLE
Search configured include_paths

### DIFF
--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -105,6 +105,7 @@ initialize(RootUri, Capabilities, InitOptions) ->
   ok = set( search_paths
           , lists:append([ project_paths(RootPath, AppsDirs, true)
                          , project_paths(RootPath, DepsDirs, true)
+                         , include_paths(RootPath, IncludeDirs, false)
                          , otp_paths(OtpPath, true)
                          ])
           ),


### PR DESCRIPTION
Otherwise dependencies are not found, and thus parse_transforms are
not included when compiling.
