### PR TITLE
[#518] Replace group leader when using stdio transport

### DIFF
--- a/src/els_sup.erl
+++ b/src/els_sup.erl
@@ -40,6 +40,8 @@ init([]) ->
               , period    => 60
               },
   {ok, Transport} = application:get_env(erlang_ls, transport),
+  %% Restrict access to stdio when using that transport
+  (Transport =/= els_stdio) andalso restrict_stdio_access(),
   ChildSpecs = [ #{ id       => els_server
                   , start    => {els_server, start_link, [Transport]}
                   }
@@ -57,3 +59,44 @@ init([]) ->
                   }
                ],
   {ok, {SupFlags, ChildSpecs}}.
+
+%% @doc Restrict access to standard I/O
+%%
+%% Sets the `io_device' application variable to the current group
+%% leaders and replaces the group leader process of this supervisor,
+%% for a fake one. This fake group leader is propagated to all of this
+%% supervisor's children.
+%%
+%% This prevents any library that decides to write anything to
+%% standard output from corrupting the messages sent through JSONRPC.
+%% This problem is happening for example when calling `edoc:get_doc/2',
+%% which can print warnings to standard output.
+-spec restrict_stdio_access() -> ok.
+restrict_stdio_access() ->
+  lager:info("Use group leader as io_device"),
+  case application:get_env(erlang_ls, io_device, standard_io) of
+    standard_io ->
+      application:set_env(erlang_ls, io_device, erlang:group_leader());
+    _ -> ok
+  end,
+
+  lager:info("Replace group leader to avoid unwanted output to stdout"),
+  Pid = erlang:spawn(fun noop_group_leader/0),
+  erlang:group_leader(Pid, self()),
+
+  ok.
+
+%% @doc Simulate a group leader but do nothing
+-spec noop_group_leader() -> no_return().
+noop_group_leader() ->
+  receive
+    Message ->
+      lager:info("noop_group_leader got [message=~p]", [Message]),
+      case Message of
+        {io_request, From, ReplyAs, _} ->
+          From ! {io_reply, ReplyAs, ok};
+        _ ->
+          ok
+      end,
+      noop_group_leader()
+  end.


### PR DESCRIPTION
### Description

Replace group leader when using stdio transport.

Fixes #518.
