### PR TITLE
[#463] Speed up indexing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,6 @@
        , {lager,         "3.6.8"}
        , {yamerl,        "0.7.0"}
        , {docsh,         "0.7.2"}
-       , {worker_pool,   "4.0.1"}
        , {elvis,         "0.5.0", {pkg, elvis_core}}
        , {rebar3_format, "0.2.1"}
        , {ephemeral,     "2.0.4"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -14,7 +14,6 @@
  {<<"rebar3_format">>,{pkg,<<"rebar3_format">>,<<"0.2.1">>},0},
  {<<"redbug">>,{pkg,<<"redbug">>,<<"1.2.1">>},0},
  {<<"tdiff">>,{pkg,<<"tdiff">>,<<"0.1.2">>},0},
- {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"4.0.1">>},0},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0},
  {<<"zipper">>,{pkg,<<"zipper">>,<<"1.0.1">>},1}]}.
 [
@@ -34,7 +33,6 @@
  {<<"rebar3_format">>, <<"5B4745DC885E12E38C5061D58E87C8C3984B4524A5299846A2B6A57ABE748BD3">>},
  {<<"redbug">>, <<"9153EE50E42C39CE3F6EFA65EE746F4A52896DA66862CFB59E7C0F838B7B8414">>},
  {<<"tdiff">>, <<"4E1B30321F1B3D600DF65CD60858EDE1235FE4E5EE042110AB5AD90CD6464AC5">>},
- {<<"worker_pool">>, <<"8CDEBCE7E09ECB4F1EB4BBF78AA99248064AC357077668C011AC600599973723">>},
  {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>},
  {<<"zipper">>, <<"3CCB4F14B97C06B2749B93D8B6C204A1ECB6FAFC6050CACC3B93B9870C05952A">>}]}
 ].

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -1,7 +1,8 @@
 -module(els_config).
 
 %% API
--export([ initialize/3
+-export([ do_initialize/3
+        , initialize/3
         , get/1
         , set/2
         , start_link/0
@@ -71,6 +72,11 @@
 initialize(RootUri, Capabilities, InitOptions) ->
   RootPath = binary_to_list(els_uri:path(RootUri)),
   Config = consult_config(config_paths(RootPath, InitOptions)),
+  do_initialize(RootUri, Capabilities, Config).
+
+-spec do_initialize(uri(), map(), map()) -> ok.
+do_initialize(RootUri, Capabilities, Config) ->
+  RootPath        = binary_to_list(els_uri:path(RootUri)),
   OtpPath         = maps:get("otp_path", Config, code:root_dir()),
   DepsDirs        = maps:get("deps_dirs", Config, []),
   AppsDirs        = maps:get("apps_dirs", Config, ["."]),

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -81,7 +81,8 @@ dump_tables() ->
   %% First dump the content of the .LOG file to the respective .DCL
   %% files, then merge the .DCL files into the .DCD files.
   mnesia:dump_log(),
-  mnesia_controller:snapshot_dcd(tables()).
+  mnesia_controller:snapshot_dcd(tables()),
+  ok.
 
 -spec lookup(atom(), any()) -> {ok, [tuple()]}.
 lookup(Table, Key) ->

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -36,6 +36,7 @@ install(NodeName, BaseDir) ->
   ok = application:set_env(mnesia, dir, DbDir),
   %% Avoid mnesia overload while indexing
   ok = application:set_env(mnesia, dump_log_write_threshold, 50000),
+  ok = application:set_env(mnesia, no_table_loaders, 4),
   ensure_db(DbDir).
 
 -spec stop() -> ok | {error, any()}.

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -76,6 +76,7 @@ delete_object(Item) ->
 
 -spec dump_tables() -> ok.
 dump_tables() ->
+  mnesia:dump_log(),
   mnesia_controller:snapshot_dcd(tables()).
 
 -spec lookup(atom(), any()) -> {ok, [tuple()]}.

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 -define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"3">>).
+-define(DB_SCHEMA_VSN, <<"4">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -36,6 +36,7 @@ install(NodeName, BaseDir) ->
   ok = application:set_env(mnesia, dir, DbDir),
   %% Avoid mnesia overload while indexing
   ok = application:set_env(mnesia, dump_log_write_threshold, 50000),
+  %% We have 4 tables. Let's load them in parallel
   ok = application:set_env(mnesia, no_table_loaders, 4),
   ensure_db(DbDir).
 

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -78,6 +78,8 @@ delete_object(Item) ->
 
 -spec dump_tables() -> ok.
 dump_tables() ->
+  %% First dump the content of the .LOG file to the respective .DCL
+  %% files, then merge the .DCL files into the .DCD files.
   mnesia:dump_log(),
   mnesia_controller:snapshot_dcd(tables()).
 

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -5,20 +5,17 @@
         , clear_tables/0
         , delete/2
         , delete_object/1
+        , dump_tables/0
         , install/2
         , lookup/2
         , match/1
         , stop/0
+        , tables/0
         , transaction/1
         , write/1
         ]).
 
 -define(SERVER, ?MODULE).
--define(TABLES, [ els_dt_document
-                , els_dt_document_index
-                , els_dt_references
-                , els_dt_signatures
-                ]).
 -define(TIMEOUT, infinity).
 -define(DB_SCHEMA_VSN, <<"3">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
@@ -66,7 +63,7 @@ ensure_db(DbDir) ->
 
 -spec ensure_tables() -> ok.
 ensure_tables() ->
-  [els_db_table:ensure(T) || T <- ?TABLES],
+  [els_db_table:ensure(T) || T <- tables()],
   ok.
 
 -spec delete(atom(), any()) -> ok.
@@ -76,6 +73,10 @@ delete(Table, Key) ->
 -spec delete_object(any()) -> ok.
 delete_object(Item) ->
   mnesia:dirty_delete_object(Item).
+
+-spec dump_tables() -> ok.
+dump_tables() ->
+  mnesia_controller:snapshot_dcd(tables()).
 
 -spec lookup(atom(), any()) -> {ok, [tuple()]}.
 lookup(Table, Key) ->
@@ -91,7 +92,7 @@ write(Record) when is_tuple(Record) ->
 
 -spec clear_tables() -> ok.
 clear_tables() ->
-  [ok = clear_table(T) || T <- ?TABLES],
+  [ok = clear_table(T) || T <- tables()],
   ok.
 
 -spec wait_for_tables() -> ok.
@@ -100,12 +101,20 @@ wait_for_tables() ->
 
 -spec wait_for_tables(timeout()) -> ok.
 wait_for_tables(Timeout) ->
-  ok = mnesia:wait_for_tables(?TABLES, Timeout).
+  ok = mnesia:wait_for_tables(tables(), Timeout).
 
 -spec clear_table(atom()) -> ok.
 clear_table(Table) ->
   mnesia:clear_table(Table),
   ok.
+
+-spec tables() -> [atom()].
+tables() ->
+  [ els_dt_document
+  , els_dt_document_index
+  , els_dt_references
+  , els_dt_signatures
+  ].
 
 -spec transaction(function()) -> ok | {ok, any()} | {error, any()}.
 transaction(F) ->

--- a/src/els_dt_document.erl
+++ b/src/els_dt_document.erl
@@ -76,7 +76,7 @@ opts() ->
   , {disc_copies       , [node()]}
   , {index             , []}
   , {type              , set}
-  , {storage_properties, [{ets, [compressed]}]}
+  , {storage_properties, [{ets, []}]}
   ].
 
 %%==============================================================================

--- a/src/els_dt_document_index.erl
+++ b/src/els_dt_document_index.erl
@@ -58,7 +58,7 @@ opts() ->
   , {disc_copies       , [node()]}
   , {index             , [#els_dt_document_index.kind]}
   , {type              , bag}
-  , {storage_properties, [{ets, [compressed]}]}
+  , {storage_properties, [{ets, []}]}
   ].
 
 %%==============================================================================

--- a/src/els_dt_references.erl
+++ b/src/els_dt_references.erl
@@ -58,10 +58,8 @@ opts() ->
   , {disc_copies       , [node()]}
   , {index             , [#els_dt_references.uri]}
   , {type              , bag}
-  , {storage_properties, [{ets, [ compressed
-                                , {write_concurrency, true}
-                                , {read_concurrency, true}
-                                ]}]}
+  , {storage_properties, [{ets, [ {read_concurrency, true}
+                                , {write_concurrency, true} ]}]}
   ].
 
 %%==============================================================================

--- a/src/els_dt_signatures.erl
+++ b/src/els_dt_signatures.erl
@@ -53,7 +53,7 @@ opts() ->
   , {disc_copies       , [node()]}
   , {index             , []}
   , {type              , set}
-  , {storage_properties, [{ets, [compressed]}]}
+  , {storage_properties, [{ets, []}]}
   ].
 
 %%==============================================================================

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -151,6 +151,11 @@ handle_call(_Request, _From, State) ->
 -spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast({start, Dirs, Mode}, State) ->
   [index_dir(Dir, Mode) || Dir <- Dirs],
+  %% Indexing a directory can lead to a huge number of DB transactions
+  %% happening in a very short time window. After indexing, let's
+  %% manually trigger a DB dump. This ensures that the DB can be
+  %% loaded much faster on a restart.
+  els_db:dump_tables(),
   {noreply, State};
 handle_cast(_Msg, State) ->
   {noreply, State}.

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -184,7 +184,7 @@ register_reference(Uri, #{id := {M, F, A}, range := Range}) ->
 
 -spec index_dir(string(), mode()) -> {non_neg_integer(), non_neg_integer()}.
 index_dir(Dir, Mode) ->
-  lager:info("Indexing directory. [dir=~s] [mode=~s]", [Dir, Mode]),
+  lager:debug("Indexing directory. [dir=~s] [mode=~s]", [Dir, Mode]),
   F = fun(FileName, {Succeeded, Failed}) ->
           case try_index_file(list_to_binary(FileName), Mode) of
             ok              -> {Succeeded + 1, Failed};
@@ -204,7 +204,7 @@ index_dir(Dir, Mode) ->
                                           , {0, 0}
                                           ]
                                         ),
-  lager:info("Finished indexing directory. [dir=~s] [mode=~s] [time=~p] "
+  lager:debug("Finished indexing directory. [dir=~s] [mode=~s] [time=~p] "
              "[succeeded=~p] "
              "[failed=~p]", [Dir, Mode, Time/1000/1000, Succeeded, Failed]),
   {Succeeded, Failed}.

--- a/src/els_indexer.erl
+++ b/src/els_indexer.erl
@@ -111,8 +111,7 @@ index_dirs(Dirs, Mode) ->
   %% happening in a very short time window. After indexing, let's
   %% manually trigger a DB dump. This ensures that the DB can be
   %% loaded much faster on a restart.
-  dumped = els_db:dump_tables(),
-  ok.
+  els_db:dump_tables().
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -131,9 +131,7 @@ initialize(Params, State) ->
   els_db:install( node_name(RootUri, list_to_binary(els_config:get(otp_path)))
                 , DbDir
                 ),
-  els_indexer:index_apps(),
-  els_indexer:index_deps(),
-  els_indexer:index_otp(),
+  trigger_indexing(),
   ok = els_provider:initialize(),
   Result =
     #{ capabilities =>
@@ -236,7 +234,7 @@ textdocument_didchange(Params, State) ->
   case ContentChanges of
     []                      -> ok;
     [#{<<"text">> := Text}] ->
-      els_indexer:index(Uri, Text)
+      els_indexer:index(Uri, Text, 'deep')
   end,
   {noresponse, State}.
 
@@ -437,3 +435,9 @@ node_name(RootUri, OtpPath) ->
 -spec default_db_dir() -> string().
 default_db_dir() ->
   filename:basedir(user_cache, "erlang_ls").
+
+-spec trigger_indexing() -> ok.
+trigger_indexing() ->
+  els_indexer:start(els_config:get(apps_paths), 'deep'),
+  els_indexer:start(els_config:get(deps_paths), 'deep'),
+  els_indexer:start(els_config:get(otp_paths), 'shallow').

--- a/src/els_text_synchronization.erl
+++ b/src/els_text_synchronization.erl
@@ -17,7 +17,7 @@ did_open(Params) ->
   TextDocument = maps:get(<<"textDocument">>, Params),
   Uri          = maps:get(<<"uri">>         , TextDocument),
   Text         = maps:get(<<"text">>        , TextDocument),
-  ok           = els_indexer:index(Uri, Text),
+  ok           = els_indexer:index(Uri, Text, 'deep'),
   spawn (?MODULE, generate_diagnostics, [Uri]),
   ok.
 

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -31,7 +31,7 @@ find_header(Id) ->
       {ok, Uri};
     [] ->
       FileName = atom_to_list(Id) ++ ".hrl",
-      els_indexer:find_and_index_file(FileName, sync)
+      els_indexer:find_and_index_file(FileName)
   end.
 
 %% @doc Look for a module in the DB
@@ -43,7 +43,7 @@ find_module(Id) ->
       {ok, Uri};
     [] ->
       FileName = atom_to_list(Id) ++ ".erl",
-      els_indexer:find_and_index_file(FileName, sync)
+      els_indexer:find_and_index_file(FileName)
   end.
 
 %% @doc Look for a document in the DB.
@@ -58,7 +58,7 @@ lookup_document(Uri) ->
       {ok, Document};
     {ok, []} ->
       Path = els_uri:path(Uri),
-      {ok, Uri} = els_indexer:index_file(Path, sync),
+      {ok, Uri} = els_indexer:index_file(Path),
       {ok, [Document]} = els_dt_document:lookup(Uri),
       {ok, Document}
   end.

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -12,7 +12,6 @@
       , lager
       , yamerl
       , docsh
-      , worker_pool
       , elvis
       , ephemeral
       , rebar3_format

--- a/test/els_indexer_SUITE.erl
+++ b/test/els_indexer_SUITE.erl
@@ -74,7 +74,7 @@ index_dir_not_dir(Config) ->
 index_erl_file(Config) ->
   DataDir = ?config(data_dir, Config),
   Path = filename:join(list_to_binary(DataDir), "test.erl"),
-  {ok, Uri} = els_indexer:index_file(Path, sync),
+  {ok, Uri} = els_indexer:index_file(Path),
   {ok, [#{id := test, kind := module}]} = els_dt_document:lookup(Uri),
   ok.
 
@@ -82,7 +82,7 @@ index_erl_file(Config) ->
 index_hrl_file(Config) ->
   DataDir = ?config(data_dir, Config),
   Path = filename:join(list_to_binary(DataDir), "test.hrl"),
-  {ok, Uri} = els_indexer:index_file(Path, sync),
+  {ok, Uri} = els_indexer:index_file(Path),
   {ok, [#{id := test, kind := header}]} = els_dt_document:lookup(Uri),
   ok.
 
@@ -90,6 +90,6 @@ index_hrl_file(Config) ->
 index_unkown_extension(Config) ->
   DataDir = ?config(data_dir, Config),
   Path = filename:join(list_to_binary(DataDir), "test.foo"),
-  {ok, Uri} = els_indexer:index_file(Path, sync),
+  {ok, Uri} = els_indexer:index_file(Path),
   {ok, [#{kind := other}]} = els_dt_document:lookup(Uri),
   ok.

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -42,7 +42,6 @@ end_per_suite(Config) ->
 -spec init_per_testcase(atom(), config()) -> config().
 init_per_testcase(_TestCase, Config) ->
   application:ensure_all_started(erlang_ls),
-  application:set_env(erlang_ls, index_otp, true),
   RootUri = els_uri:uri(list_to_binary(code:root_dir())),
   els_config:initialize(RootUri, [], []),
   Config.
@@ -70,17 +69,5 @@ reindex_otp(Config) ->
 -spec index_otp(atom(), string()) -> ok.
 index_otp(DBName, DBDir) ->
   ok = els_db:install(DBName, DBDir),
-  ok = els_indexer:index_otp(),
-  Entries = mnesia:table_info(els_dt_references, size),
-  Size = mnesia:table_info(els_dt_references, memory) * 8 / 1024 / 1024,
-  ct:comment("Entries: ~p. Size (MB): ~p", [Entries, Size]),
-  %% mnesia_controller:snapshot_dcd(tables()), %% Seems to save 3-4 seconds
+  [els_indexer:index_dir(Dir, 'shallow') || Dir <- els_config:get(otp_paths)],
   ok = els_db:stop().
-
-%% %% TODO: Move to els_db
-%% tables() ->
-%%   [ els_dt_document
-%%   , els_dt_document_index
-%%   , els_dt_references
-%%   , els_dt_signatures
-%%   ].

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -69,5 +69,5 @@ reindex_otp(Config) ->
 -spec index_otp(atom(), string()) -> ok.
 index_otp(DBName, DBDir) ->
   ok = els_db:install(DBName, DBDir),
-  [els_indexer:index_dir(Dir, 'shallow') || Dir <- els_config:get(otp_paths)],
+  els_indexer:index_dirs(els_config:get(otp_paths), 'shallow'),
   ok = els_db:stop().

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -64,16 +64,6 @@ index_otp(Config) ->
 
 -spec reindex_otp(config()) -> ok.
 reindex_otp(Config) ->
-  %% redbug:start(
-  %%   [ "mnesia_log:open_log({els_dt_references,dcd2ets}, _, _, _, _, _)->retur
-  %%   , "mnesia_log:close_log"
-  %%   ]
-  %%              , [ {msgs, 9999999}
-  %%                , {time, 9999999}
-  %%                , {print_file, "/tmp/redbug"}
-  %%                , {arity, false}
-  %%                , {print_return, false}
-  %%                ]),
   index_otp(db, ?config(priv_dir, Config)),
   ok.
 

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -1,0 +1,96 @@
+-module(els_indexing_SUITE).
+
+%% CT Callbacks
+-export([ all/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        ]).
+
+%% Test cases
+-export([ index_otp/1
+        , reindex_otp/1
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec all() -> [atom()].
+all() ->
+  els_test_utils:all(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(_TestCase, Config) ->
+  application:ensure_all_started(erlang_ls),
+  application:set_env(erlang_ls, index_otp, true),
+  RootUri = els_uri:uri(list_to_binary(code:root_dir())),
+  els_config:initialize(RootUri, [], []),
+  Config.
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(_TestCase, _Config) ->
+  %% TODO: The transport should be included in the OTP supervision
+  %% tree, so it can be restarted.
+  ok = ranch:stop_listener(erlang_ls),
+  application:stop(erlang_ls),
+  ok.
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec index_otp(config()) -> ok.
+index_otp(Config) ->
+  index_otp(db, ?config(priv_dir, Config)).
+
+-spec reindex_otp(config()) -> ok.
+reindex_otp(Config) ->
+  %% redbug:start(
+  %%   [ "mnesia_log:open_log({els_dt_references,dcd2ets}, _, _, _, _, _)->retur
+  %%   , "mnesia_log:close_log"
+  %%   ]
+  %%              , [ {msgs, 9999999}
+  %%                , {time, 9999999}
+  %%                , {print_file, "/tmp/redbug"}
+  %%                , {arity, false}
+  %%                , {print_return, false}
+  %%                ]),
+  index_otp(db, ?config(priv_dir, Config)),
+  ok.
+
+-spec index_otp(atom(), string()) -> ok.
+index_otp(DBName, DBDir) ->
+  ok = els_db:install(DBName, DBDir),
+  ok = els_indexer:index_otp(),
+  Entries = mnesia:table_info(els_dt_references, size),
+  Size = mnesia:table_info(els_dt_references, memory) * 8 / 1024 / 1024,
+  ct:comment("Entries: ~p. Size (MB): ~p", [Entries, Size]),
+  %% mnesia_controller:snapshot_dcd(tables()), %% Seems to save 3-4 seconds
+  ok = els_db:stop().
+
+%% %% TODO: Move to els_db
+%% tables() ->
+%%   [ els_dt_document
+%%   , els_dt_document_index
+%%   , els_dt_references
+%%   , els_dt_signatures
+%%   ].

--- a/test/els_rebar3_release_SUITE.erl
+++ b/test/els_rebar3_release_SUITE.erl
@@ -50,11 +50,9 @@ init_per_suite(Config) ->
   AppPath  = src_path(RootPath, "rebar3_release_app.erl"),
   SupPath  = src_path(RootPath, "rebar3_release_sup.erl"),
   application:load(erlang_ls),
-  application:set_env(erlang_ls, index_otp, false),
-  application:set_env(erlang_ls, index_deps, false),
   [ {root_uri, els_uri:uri(RootPath)}
-  , {app_uri, els_uri:uri(AppPath)}
-  , {sup_uri, els_uri:uri(SupPath)}
+  , {app_uri,  els_uri:uri(AppPath)}
+  , {sup_uri,  els_uri:uri(SupPath)}
     | Config
   ].
 
@@ -71,8 +69,8 @@ init_per_testcase(_TestCase, Config) ->
   els_client:initialize(RootUri, []),
   {ok, AppText} = file:read_file(els_uri:path(AppUri)),
   els_client:did_open(AppUri, erlang, 1, AppText),
-  els_indexer:find_and_index_file("rebar3_release_app.erl", sync),
-  els_indexer:find_and_index_file("rebar3_release_sup.erl", sync),
+  els_indexer:find_and_index_file("rebar3_release_app.erl"),
+  els_indexer:find_and_index_file("rebar3_release_sup.erl"),
   [{started, Started}|Config].
 
 -spec end_per_testcase(atom(), config()) -> ok.

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -231,7 +231,7 @@ purge_references(_Config) ->
   Doc0  = els_dt_document:new(Uri, Text0),
   Doc1  = els_dt_document:new(Uri, Text1),
 
-  ok = els_indexer:index(Uri, Text0),
+  ok = els_indexer:index(Uri, Text0, 'deep'),
   ?assertEqual({ok, [Doc0]}, els_dt_document:lookup(Uri)),
   ?assertEqual({ok, [#{ id    => {foo, foo, 1}
                       , range => #{from => {3, 10}, to => {3, 13}}
@@ -240,7 +240,7 @@ purge_references(_Config) ->
               , els_dt_references:find_all()
               ),
 
-  ok = els_indexer:index(Uri, Text1),
+  ok = els_indexer:index(Uri, Text1, 'deep'),
   ?assertEqual({ok, [Doc1]}, els_dt_document:lookup(Uri)),
   ?assertEqual({ok, [#{ id    => {foo, foo, 1}
                       , range => #{from => {4, 10}, to => {4, 13}}

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -120,8 +120,6 @@ init_per_suite(Config) ->
   {ok, Text} = file:read_file(Path),
 
   application:load(erlang_ls),
-  application:set_env(erlang_ls, index_otp, false),
-  application:set_env(erlang_ls, index_deps, false),
 
   Priv = ?config(priv_dir, Config),
   application:set_env(erlang_ls, db_dir, Priv),
@@ -163,15 +161,15 @@ init_per_testcase(_TestCase, Config) ->
   els_client:initialize(RootUri, []),
 
   %% Ensure modules used in test suites are indexed
-  els_indexer:find_and_index_file("behaviour_a", sync),
-  els_indexer:find_and_index_file("code_navigation", sync),
-  els_indexer:find_and_index_file("code_navigation_extra", sync),
-  els_indexer:find_and_index_file("code_navigation_types", sync),
-  els_indexer:find_and_index_file("code_navigation.hrl", sync),
-  els_indexer:find_and_index_file("diagnostics.hrl", sync),
-  els_indexer:find_and_index_file("my_gen_server", sync),
-  els_indexer:find_and_index_file("diagnostics_behaviour", sync),
-  els_indexer:find_and_index_file("diagnostics_behaviour_impl", sync),
+  els_indexer:find_and_index_file("behaviour_a"),
+  els_indexer:find_and_index_file("code_navigation"),
+  els_indexer:find_and_index_file("code_navigation_extra"),
+  els_indexer:find_and_index_file("code_navigation_types"),
+  els_indexer:find_and_index_file("code_navigation.hrl"),
+  els_indexer:find_and_index_file("diagnostics.hrl"),
+  els_indexer:find_and_index_file("my_gen_server"),
+  els_indexer:find_and_index_file("diagnostics_behaviour"),
+  els_indexer:find_and_index_file("diagnostics_behaviour_impl"),
 
   [{started, Started} | Config].
 

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -347,8 +347,6 @@ setup() ->
   HaltFun = fun(_X) -> Self ! halt_called, ok end,
   meck:expect(els_utils, halt, HaltFun),
   application:ensure_all_started(erlang_ls),
-  application:set_env(erlang_ls, index_otp, false),
-  application:set_env(erlang_ls, index_deps, false),
   file:write_file("/tmp/erlang_ls.config", <<"">>),
   lager:set_loglevel(lager_console_backend, warning),
   ok.


### PR DESCRIPTION
### Description

This Pull Request completely revisits the indexing process. In the sample code base I'm experimenting with (~1.5 million lines of code) the "waiting" time on a restart (i.e. with an existing DB which needs to be loaded in memory) went from ~1 minute to ~17 seconds. I would appreciate if you could try it with other code bases too. This PR also gets rid of the worker pool for indexing, preparing for a follow-up PR where we can display indexing progress to the user.

Main changes:

* Remove worker pool for indexing
* Force a DB dump after indexing (so it's done in the background instead of on restart)
* Do not compress tables (with a little loss in terms of memory, we gain a lot in loading speed)
* Introduce `shallow` cloning for OTP libraries (i.e. do not store references for OTP libraries, not required for most use cases, will follow-up with a PR which makes these options configurable)

I plan to write a blog post about the findings, if I ever get the time to do so.

Fixes #463 .
