### PR TITLE
[#516] Use syntax highlighting when using markdown to show information on hover 

### DIFF
--- a/src/els_hover_provider.erl
+++ b/src/els_hover_provider.erl
@@ -61,8 +61,10 @@ get_docs(M, F, A) ->
     {<<>>, <<>>} ->
       <<>>;
     {Specs, Edoc} ->
-      #{ kind => content_kind()
-       , value => <<Specs/binary, "\n\n", Edoc/binary>>
+      ContentKind = content_kind(),
+      FormattedSpecs = format_code(ContentKind, Specs),
+      #{ kind  => ContentKind
+       , value => << FormattedSpecs/binary, "\n", Edoc/binary>>
        }
   end.
 
@@ -72,9 +74,18 @@ get_docs(M, F, A) ->
 -spec specs(atom(), atom(), non_neg_integer()) -> binary().
 specs(M, F, A) ->
   case els_dt_signatures:lookup({M, F, A}) of
-    {ok, [#{tree := Tree}]} -> list_to_binary(erl_prettypr:format(Tree));
-    {ok, []}                -> <<>>
+    {ok, [#{tree := Tree}]} ->
+      Specs = erl_prettypr:format(Tree),
+      unicode:characters_to_binary(Specs);
+    {ok, []} ->
+      <<>>
   end.
+
+-spec format_code(markup_kind(), binary()) -> binary().
+format_code(plaintext, Code) ->
+  Code;
+format_code(markdown, Code) ->
+  <<"```erlang\n", Code/binary, "\n```\n">>.
 
 -spec edoc(atom(), atom(), non_neg_integer()) -> binary().
 edoc(M, F, A) ->
@@ -103,7 +114,7 @@ format(Signature, Desc) when is_map(Desc) ->
   Lang         = <<"en">>,
   Doc          = maps:get(Lang, Desc, <<>>),
   FormattedDoc = list_to_binary(docsh_edoc:format_edoc(Doc, #{})),
-  <<"# ", Signature/binary, "\n", FormattedDoc/binary>>.
+  <<"### ", Signature/binary, "\n", FormattedDoc/binary>>.
 
 -spec content_kind() -> markup_kind().
 content_kind() ->

--- a/test/els_hover_SUITE.erl
+++ b/test/els_hover_SUITE.erl
@@ -64,12 +64,15 @@ end_per_testcase(TestCase, Config) ->
 %% Testcases
 %%==============================================================================
 
--define(FUNCTION_J_DOC, <<"-spec function_j() -> pos_integer()."
-                          "\n\n"
-                          "# code_navigation:function_j/0"
-                          "\n\n"
-                          "Such a wonderful function."
-                          "\n\n">>).
+-define( FUNCTION_J_DOC
+       , <<"```erlang\n"
+           "-spec function_j() -> pos_integer().\n"
+           "```\n\n"
+           "### code_navigation:function_j/0"
+           "\n\n"
+           "Such a wonderful function."
+           "\n\n">>
+       ).
 
 -spec hover_docs(config()) -> ok.
 hover_docs(Config) ->
@@ -91,13 +94,14 @@ hover_docs_local(Config) ->
   ?assertMatch(#{result := #{contents := _}}, Response1),
   #{result := #{contents := Contents1}} = Response1,
   Expected1 = #{ kind  => <<"markdown">>
-               , value => <<"-spec do_4(nat(), opaque_local()) -> {atom(),"
-                           "\n\t\t\t\t"
-                           "      code_navigation_types:opaque_type_a()}."
-                           "\n\n"
-                           "# code_navigation_extra:do_4/2"
-                           "\n\ndo_4 is a local-only function"
-                           "\n\n">>
+               , value => <<"```erlang\n"
+                            "-spec do_4(nat(), opaque_local()) -> {atom(),"
+                            "\n\t\t\t\t"
+                            "      code_navigation_types:opaque_type_a()}.\n"
+                            "```\n\n"
+                            "### code_navigation_extra:do_4/2"
+                            "\n\ndo_4 is a local-only function"
+                            "\n\n">>
                },
   ?assertEqual(Expected1, Contents1),
 


### PR DESCRIPTION
### Description

Use syntax highlighting when using markdown to show information on hover.

Fixes #516.
