### PR TITLE
[#534] Fix off by one in folding ranges

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -80,6 +80,14 @@
                      , character := number()
                      }.
 
+%% This is used for defining folding ranges. It is not possible to just use
+%% positions as this one `{Line + 1, 0}' in a folding range, because of
+%% differences on how clients behave in that case (see [#535]).
+%% According to the protocol "If the character value is greater than the line
+%% length it defaults back to the line length.". So we define a big enough
+%% value that represents the end of the line.
+-define(END_OF_LINE, 9999999).
+
 %%------------------------------------------------------------------------------
 %% Range
 %%------------------------------------------------------------------------------
@@ -93,6 +101,16 @@
 -type location() :: #{ uri   := uri()
                      , range := range()
                      }.
+
+%%------------------------------------------------------------------------------
+%% Folding Range
+%%------------------------------------------------------------------------------
+
+-type folding_range() :: #{ startLine      := pos_integer()
+                          , startCharacter := pos_integer()
+                          , endLine        := pos_integer()
+                          , endCharacter   := pos_integer()
+                          }.
 
 %%------------------------------------------------------------------------------
 %% Diagnostic

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 -define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"4">>).
+-define(DB_SCHEMA_VSN, <<"5">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================

--- a/src/els_folding_range_provider.erl
+++ b/src/els_folding_range_provider.erl
@@ -11,11 +11,7 @@
 %%==============================================================================
 %% Type Definitions
 %%==============================================================================
--type folding_range() :: #{ startLine      := pos_integer()
-                          , startCharacter := pos_integer()
-                          , endLine        := pos_integer()
-                          , endCharacter   := pos_integer()
-                          }.
+
 -type folding_range_result() :: [folding_range()] | null.
 
 %%==============================================================================
@@ -32,7 +28,7 @@ handle_request({document_foldingrange, Params}, State) ->
   #{ <<"textDocument">> := #{<<"uri">> := Uri} } = Params,
   {ok, [Document]} = els_dt_document:lookup(Uri),
   POIs = els_dt_document:pois(Document, [folding_range]),
-  Response = case [folding_range(POI) || POI <- POIs] of
+  Response = case [folding_range(Range) || #{range := Range} <- POIs] of
                []     -> null;
                Ranges -> Ranges
              end,
@@ -42,10 +38,10 @@ handle_request({document_foldingrange, Params}, State) ->
 %% Internal functions
 %%==============================================================================
 
--spec folding_range(poi()) -> folding_range().
-folding_range(#{range := #{from := {FromL, FromC}, to := {ToL, ToC}}}) ->
-  #{ startLine      => FromL
-   , startCharacter => FromC
-   , endLine        => ToL
-   , endCharacter   => ToC
+-spec folding_range(poi_range()) -> folding_range().
+folding_range(#{from := {FromLine, FromCol}, to := {ToLine, ToCol}}) ->
+  #{ startLine      => FromLine - 1
+   , startCharacter => FromCol
+   , endLine        => ToLine - 1
+   , endCharacter   => ToCol
    }.

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -249,16 +249,16 @@ attribute(Tree) ->
   end.
 
 -spec function(tree(), erl_anno:location()) -> [poi()].
-function(Tree, {EndLine, _EndColumn} = _EndLocation) ->
-  {F, A}                   = erl_syntax_lib:analyze_function(Tree),
-  Args                     = function_args(Tree, A),
-  {StartLine, StartColumn} = StartLocation = erl_syntax:get_pos(Tree),
+function(Tree, {EndLine, _} = _EndLocation) ->
+  {F, A}         = erl_syntax_lib:analyze_function(Tree),
+  Args           = function_args(Tree, A),
+  {StartLine, _} = StartLocation = erl_syntax:get_pos(Tree),
   %% It only makes sense to fold a function if the function contains
   %% at least one line apart from its signature.
   FoldingRanges = case EndLine - StartLine > 1 of
                     true ->
-                      Range = #{ from => {StartLine, StartColumn}
-                               , to   => {EndLine - 1, -1}
+                      Range = #{ from => {StartLine, ?END_OF_LINE}
+                               , to   => {EndLine - 1, ?END_OF_LINE}
                                },
                       [ els_poi:new(Range, folding_range, StartLocation) ];
                     false ->

--- a/test/els_foldingrange_SUITE.erl
+++ b/test/els_foldingrange_SUITE.erl
@@ -66,65 +66,65 @@ end_per_testcase(TestCase, Config) ->
 folding_range(Config) ->
   #{result := Result} =
     els_client:folding_range(?config(code_navigation_uri, Config)),
-  Expected = [ #{ endCharacter   => -1
-                , endLine        => 23
-                , startCharacter => 1
-                , startLine      => 21
+  Expected = [ #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 22
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 20
                 }
-             , #{ endCharacter   => -1
-                , endLine        => 26
-                , startCharacter => 1
-                , startLine      => 25
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 25
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 24
                 }
-             , #{ endCharacter   => -1
-                , endLine        => 29
-                , startCharacter => 1
-                , startLine      => 28
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 28
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 27
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 35
-                , startCharacter => 1
-                , startLine      => 31
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 34
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 30
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 40
-                , startCharacter => 1
-                , startLine      => 39
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 39
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 38
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 43
-                , startCharacter => 1
-                , startLine      => 42
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 42
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 41
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 48
-                , startCharacter => 1
-                , startLine      => 47
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 47
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 46
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 53
-                , startCharacter => 1
-                , startLine      => 50
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 52
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 49
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 57
-                , startCharacter => 1
-                , startLine      => 56
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 56
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 55
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 68
-                , startCharacter => 1
-                , startLine      => 67
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 67
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 66
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 76
-                , startCharacter => 1
-                , startLine      => 74
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 75
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 73
                 }
-             , #{ endCharacter    => -1
-                , endLine        => 81
-                , startCharacter => 1
-                , startLine      => 79
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 80
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 78
                 }
              ],
   ?assertEqual(Expected, Result),


### PR DESCRIPTION
### Description

Fix off by one in folding ranges.

Fixes #534.

### Emacs
<img width="830" alt="Screenshot 2020-03-07 at 23 42 38" src="https://user-images.githubusercontent.com/1522569/76153536-783c4780-60cd-11ea-9076-3e1ae9c1df42.png">

### VS Code
<img width="800" alt="Screenshot 2020-03-07 at 23 44 30" src="https://user-images.githubusercontent.com/1522569/76153548-9efa7e00-60cd-11ea-92e3-3f193d8768fc.png">
