### PR TITLE
[#458] Auto complete types

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -76,8 +76,10 @@
 %%------------------------------------------------------------------------------
 %% Position
 %%------------------------------------------------------------------------------
--type position() :: #{ line      := number()
-                     , character := number()
+-type line()     :: number().
+-type column()   :: number().
+-type position() :: #{ line      := line()
+                     , character := column()
                      }.
 
 %% This is used for defining folding ranges. It is not possible to just use
@@ -618,7 +620,10 @@
                    | behaviour
                    | define
                    | export
-                   | exports_entry
+                   | export_entry
+                   | export_type
+                   | export_type_entry
+                   | folding_range
                    | function
                    | implicit_fun
                    | import_entry

--- a/priv/code_navigation/include/code_navigation.hrl
+++ b/priv/code_navigation/include/code_navigation.hrl
@@ -1,3 +1,5 @@
 -record(included_record_a, {included_field_a, included_field_b}).
 
 -define(INCLUDED_MACRO_A, included_macro_a).
+
+-type included_type_a() :: ok.

--- a/priv/code_navigation/src/code_navigation.erl
+++ b/priv/code_navigation/src/code_navigation.erl
@@ -52,7 +52,7 @@ function_g(X) ->
   G = {fun code_navigation_extra:do/1, X#included_record_a.field_b},
   {?INCLUDED_MACRO_A, #included_record_a{}, F, G}.
 
--spec function_h() -> type_a() | undefined_type_a().
+-spec function_h() -> type_a() | undefined_type_a() | file:fd().
 function_h() ->
   function_i().
 

--- a/src/els_dt_signatures.erl
+++ b/src/els_dt_signatures.erl
@@ -35,7 +35,7 @@
                            }).
 -type els_dt_signatures() :: #els_dt_signatures{}.
 
--type item() :: #{ mfa      := mfa()
+-type item() :: #{ mfa  := mfa()
                  , tree := tree()
                  }.
 -export_type([ item/0 ]).


### PR DESCRIPTION
### Description

Auto complete types when in a `spec` or `export_types` context.

Fixes #458.
