### PR TITLE
[#539] Run github actions on push of any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
-on: 
+on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Title should speak for itself but https://github.com/erlang-ls/erlang_ls/commit/3701764fbbd81c0374dd3f72999c1f266bf9426e had the side effect of no longer running Github Actions for branches but only on pull request or for `master`

Fixes #539
