### PR TITLE
476 use getopt for cli arg parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Usage: Erlang LS [-v] [-t [<transport>]] [-p [<port>]] [-d [<log_dir>]]
   -t, --transport  Specifies the transport the server will use for the
                    connection with the client. [default: tcp]
   -p, --port       Used when the transport is tcp. [default: 10000]
-  -d, --log-dir    Directory where logs will be written. [default: <user_log>/erlang_ls/log]
+  -d, --log-dir    Directory where logs will be written.
+                   [default: filename:basedir(user_log, "erlang_ls")]
   -l, --log-level  The log level that should be used. [default: info]
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,17 @@ Compile the project:
 These are the command-line arguments that can be provided to the
 `erlang_ls` escript:
 
-| Argument                | Description                                                                                     |
-|-------------------------|-------------------------------------------------------------------------------------------------|
-| --transport tcp / stdio | Specifies the transport the server will use for the connection with the client (default: `tcp`) |
-| --port PORT             | Used when the transport is `tcp` (default: `10000`)                                             |
-| --log-dir DIR           | Directory where logs will be written. When not provided no logs are generated.                  |
+``` shell
+Usage: Erlang LS [-v] [-t [<transport>]] [-p [<port>]] [-d [<log_dir>]]
+                 [-l [<log_level>]] [<port_old>]
+
+  -v, --version    Print the current version of Erlang LS
+  -t, --transport  Specifies the transport the server will use for the
+                   connection with the client. [default: tcp]
+  -p, --port       Used when the transport is tcp. [default: 10000]
+  -d, --log-dir    Directory where logs will be written. [default: <user_log>/erlang_ls/log]
+  -l, --log-level  The log level that should be used. [default: info]
+```
 
 ### Emacs Setup
 

--- a/elvis.config
+++ b/elvis.config
@@ -47,6 +47,7 @@
                                                                    , {left , "=/="}
                                                                    ]}}
                       , {elvis_style, function_naming_convention, #{ignore => [els_client]}}
+                      , {elvis_style, no_debug_call, #{ignore => [erlang_ls]}}
                       ]
          , ignore => [els_dodger]
          }

--- a/src/erlang_ls.app.src
+++ b/src/erlang_ls.app.src
@@ -16,6 +16,7 @@
       , ephemeral
       , rebar3_format
       , tdiff
+      , getopt
       ]
     }
   , { env

--- a/test/erlang_ls_SUITE.erl
+++ b/test/erlang_ls_SUITE.erl
@@ -105,6 +105,10 @@ lager_config(_Config) ->
   ?assertEqual(false, application:get_env(lager, crash_log, undefined)),
 
   application:set_env(erlang_ls, logging_enabled, true),
+  application:set_env(erlang_ls, log_level, "info"),
+  application:set_env(erlang_ls,
+                      log_dir,
+                      filename:basedir(user_log, "erlang_ls")),
   erlang_ls:lager_config(),
   ?assertEqual(1, length(application:get_env(lager, handlers, []))),
   ?assertEqual("crash.log", application:get_env(lager, crash_log, undefined)),
@@ -117,6 +121,7 @@ log_handlers(_Config) ->
   meck:new(filelib, [unstick]),
   meck:expect(filelib, ensure_dir, fun(_) -> ok end),
 
+  application:set_env(erlang_ls, log_level, "info"),
   Handlers = erlang_ls:lager_handlers("/some/directory"),
   ExpectedHandlers = [ { lager_file_backend
                        , [ {file, "/some/directory/server.log"}


### PR DESCRIPTION
### Description
Using getopt allows us to get some nice features for free like an easy utility function for getting out the version from Erlang LS and getting a `help` to keep the arguments to Erlang LS and the documentation of them in one place.

Fixes #476 

Thanks [@sgillis](https://github.com/sgillis) and [@libanomarsweden](https://github.com/libanomarsweden) for helping out! :+1: 

Edit: Can someone restart the Github action for me? It passed on my Github account when I had https://github.com/erlang-ls/erlang_ls/pull/540 on top of this branch so it seems like a Github problem to me 