### PR TITLE
[#542] Bump checkout action to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       image: erlang:${{ matrix.otp-version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Cache Hex packages
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
### Description

Based on thee discussion [here](https://github.com/actions/checkout/issues/23#issuecomment-572688577) it seems `actions/checkout@v2` has solved this issue.

Fixes #542.
