### PR TITLE
Do not make large node groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ all:
 	@ echo "Building escript..."
 	@ rebar3 escriptize
 
+debug:
+	rebar3 as debug escriptize
+
 ci:
 	rebar3 do compile, ct, proper --cover --constraint_tries 100, dialyzer, xref, cover, edoc
 

--- a/rebar.config
+++ b/rebar.config
@@ -29,6 +29,8 @@
 
 {minimum_otp_vsn, "21.0"}.
 
+{escript_emu_args, "%%! -connect_all false \n" }.
+
 {profiles, [ { debug
              , [ { deps
                    %% The upstream version of redbug does not support
@@ -41,7 +43,7 @@
                    ]
                  }
                , { escript_emu_args
-                 , "%%! -erlang_ls logging_enabled true \n"
+                 , "%%! -connect_all false -erlang_ls logging_enabled true \n"
                  }
                  %% For some reason we need to explicitly include redbug,
                  %% even if it already is a dependency.


### PR DESCRIPTION
By default erlang nodes will try to make a fully connected net of all
erlang nodes discovered. We don't want that 'erlang_ls' nodes interfer
with other testing nodes on the same machine.

Also avoids confusing mnesia when several different schemas might
exist in the same group of nodes. Mnesia wants the same schema on all
nodes in the group.

An alternative solution is to make the nodes hidden, but that
might make connecting and inspecting the nodes harder.

If we later want to create a mesh of nodes this needs to be
revised, maybe use global_groups?

### Description

Enter a description of your changes here.

Fixes # .
