### PR TITLE
[#110] Add auto-completion for atoms

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -617,6 +617,7 @@
 -type pos()       :: {integer(), integer()}.
 -type uri()       :: binary().
 -type poi_kind()  :: application
+                   | atom
                    | behaviour
                    | define
                    | export

--- a/priv/code_navigation/src/code_navigation_extra.erl
+++ b/priv/code_navigation/src/code_navigation_extra.erl
@@ -3,7 +3,7 @@
 -export([ do/1, do_2/0 ]).
 
 do(_Config) ->
-  do_4(1,foo).
+  do_4(1, foo).
 
 do_2() ->
   code_navigation:function_h().

--- a/src/els_completion_provider.erl
+++ b/src/els_completion_provider.erl
@@ -132,6 +132,7 @@ find_completion( Prefix
       NameBinary = atom_to_binary(Name, utf8),
       {ExportFormat, POIKind} = completion_context(Document, Line, Column),
       keywords()
+      ++ atoms(Document, NameBinary)
       ++ modules(NameBinary)
       ++ definitions(Document, POIKind, ExportFormat);
     _ ->
@@ -139,6 +140,24 @@ find_completion( Prefix
   end;
 find_completion(_Prefix, _TriggerKind, _Opts) ->
   null.
+
+%%==============================================================================
+%% Atoms
+%%==============================================================================
+
+-spec atoms(els_dt_document:item(), binary()) -> [map()].
+atoms(Document, Prefix) ->
+  POIs   = local_and_included_pois(Document, atom),
+  Atoms  = [Id || #{id := Id} <- POIs],
+  Unique = lists:usort(Atoms),
+  filter_by_prefix(Prefix, Unique, fun to_binary/1, fun item_kind_atom/1).
+
+-spec item_kind_atom(binary()) -> map().
+item_kind_atom(Module) ->
+  #{ label            => Module
+   , kind             => ?COMPLETION_ITEM_KIND_CONSTANT
+   , insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+   }.
 
 %%==============================================================================
 %% Modules

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -32,6 +32,9 @@ range(Pos, import_entry, {_M, F, A}, _Data) ->
   get_entry_range(Pos, F, A);
 range({Line, Column}, export_type_entry, {F, A}, _Data) ->
   get_entry_range({Line, Column}, F, A);
+range({_Line, _Column} = From, atom, Name, _Data) ->
+  To = plus(From, atom_to_list(Name)),
+  #{ from => From, to => To };
 range({Line, Column}, application, {M, F, _A}, _Data) ->
   %% Column indicates the position of the :
   CFrom = Column - length(atom_to_list(M)),

--- a/test/els_completion_SUITE.erl
+++ b/test/els_completion_SUITE.erl
@@ -13,7 +13,7 @@
         ]).
 
 %% Test cases
--export([ atom_completions/1
+-export([ default_completions/1
         , empty_completions/1
         , exported_functions/1
         , exported_functions_arity/1
@@ -77,46 +77,62 @@ end_per_testcase(TestCase, Config) ->
 %% Testcases
 %%==============================================================================
 
--spec atom_completions(config()) -> ok.
-atom_completions(Config) ->
+-spec default_completions(config()) -> ok.
+default_completions(Config) ->
   TriggerKind = ?COMPLETION_TRIGGER_KIND_INVOKED,
   Uri = ?config(code_navigation_extra_uri, Config),
-  Expected = [ #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
-                , kind             => ?COMPLETION_ITEM_KIND_MODULE
-                , label            => <<"code_navigation_extra">>
-                }
-             , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
-                , kind             => ?COMPLETION_ITEM_KIND_MODULE
-                , label            => <<"code_navigation">>
-                }
-             , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
-                , kind             => ?COMPLETION_ITEM_KIND_MODULE
-                , label            => <<"code_navigation_types">>
-                }
-             , #{ insertText => <<"do_4(${1:Arg1}, ${2:Arg2})">>
-                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
-                , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
-                  label => <<"do_4/2">>
-                }
-             , #{ insertText => <<"do_3(${1:Arg1}, ${2:Arg2})">>
-                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
-                , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
-                  label => <<"do_3/2">>
-                }
-             , #{ insertText => <<"do_2()">>
-                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
-                , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
-                  label => <<"do_2/0">>
-                }
-             , #{ insertText => <<"do(${1:_Config})">>
-                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
-                , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
-                  label => <<"do/1">>
-                }
-             ] ++ els_completion_provider:keywords(),
-  #{ result := Completion
-   } = els_client:completion(Uri, 9, 6, TriggerKind, <<"d">>),
-  ?assertEqual(lists:sort(Expected), lists:sort(Completion)),
+  Functions = [ #{ insertText => <<"do_3(${1:Arg1}, ${2:Arg2})">>
+                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                 , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
+                   label => <<"do_3/2">>
+                 }
+              , #{ insertText => <<"do_2()">>
+                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                 , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
+                   label => <<"do_2/0">>
+                 }
+              , #{ insertText => <<"do(${1:_Config})">>
+                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                 , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
+                   label => <<"do/1">>
+                 }
+              , #{ insertText => <<"do_4(${1:Arg1}, ${2:Arg2})">>
+                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                 , kind             => ?COMPLETION_ITEM_KIND_FUNCTION,
+                   label => <<"do_4/2">>
+                 }
+              ],
+
+  Expected1 = [ #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                 , kind             => ?COMPLETION_ITEM_KIND_MODULE
+                 , label            => <<"code_navigation_extra">>
+                 }
+              , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                 , kind             => ?COMPLETION_ITEM_KIND_MODULE
+                 , label            => <<"code_navigation">>
+                 }
+              , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                 , kind             => ?COMPLETION_ITEM_KIND_MODULE
+                 , label            => <<"code_navigation_types">>
+                 }
+              | Functions ++ els_completion_provider:keywords()
+              ],
+
+  #{ result := Completion1
+   } = els_client:completion(Uri, 9, 6, TriggerKind, <<"">>),
+  ?assertEqual(lists:sort(Expected1), lists:sort(Completion1)),
+
+  Expected2 = [ #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                 , kind             => ?COMPLETION_ITEM_KIND_CONSTANT
+                 , label            => <<"foo">>
+                 }
+              | Functions ++ els_completion_provider:keywords()
+              ],
+
+  #{ result := Completion2
+   } = els_client:completion(Uri, 6, 14, TriggerKind, <<"">>),
+  ?assertEqual(lists:sort(Expected2), lists:sort(Completion2)),
+
   ok.
 
 -spec empty_completions(config()) -> ok.
@@ -125,7 +141,7 @@ empty_completions(Config) ->
   Uri = ?config(code_navigation_extra_uri, Config),
 
   #{ result := Completion
-   } = els_client:completion(Uri, 5, 1, TriggerKind, <<"d">>),
+   } = els_client:completion(Uri, 5, 1, TriggerKind, <<"">>),
   ?assertEqual([], Completion),
   ok.
 

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -189,7 +189,6 @@ module(Config) ->
   assert_locations(Locations, ExpectedLocations),
   ok.
 
-
 -spec record(config()) -> ok.
 record(Config) ->
   Uri = ?config(code_navigation_uri, Config),


### PR DESCRIPTION
### Description

This PR introduces an adaptation of the `erl_syntax_lib:fold/3` function, so that only some of the subtrees are processed for specific types of syntax tree nodes.

Fixes #110.
