### PR TITLE
Fix corner case in els_utils:is_symlink

### DIFF
--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -197,7 +197,8 @@ contains_symlink(Path, RootPath) ->
     [] -> false;
     ParentParts ->
       Parent = filename:join(ParentParts),
-      is_symlink(Parent) orelse contains_symlink(Parent, RootPath)
+      ((not (Parent == RootPath)) and (is_symlink(Parent)))
+        orelse contains_symlink(Parent, RootPath)
   end.
 
 %%==============================================================================


### PR DESCRIPTION
If the top level directory (`RootPath`) is symlinked, then checking the parent of
the immediately descendent of the root should not fail for the symlink.

Fixes #520.
