### PR TITLE
[#106] Auto-complete built-in functions and types

### DIFF
--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -259,10 +259,9 @@ attribute(Tree) ->
       end;
     {record, {Record, Fields}} ->
       [poi(Pos, record, Record, Fields)];
-    {type, {type, {Type, _, Args}}} ->
+    {Name, {Name, {Type, _, Args}}} when Name =:= type;
+                                         Name =:= opaque ->
       [poi(Pos, type_definition, {Type, length(Args)}, type_args(Args))];
-    {opaque, {opaque, {Type, _, Args}}} ->
-      [poi(Pos, type_definition, {Type, length(Args)})];
     _ ->
       []
   catch throw:syntax_error ->

--- a/src/els_provider.erl
+++ b/src/els_provider.erl
@@ -15,6 +15,7 @@
         ]).
 
 -callback is_enabled() -> boolean().
+-callback handle_request(request(), state()) -> {any(), state()}.
 
 -type config()   :: any().
 -type provider() :: els_completion_provider
@@ -34,6 +35,7 @@
 
 -export_type([ config/0
              , provider/0
+             , request/0
              , state/0
              ]).
 

--- a/test/els_completion_SUITE.erl
+++ b/test/els_completion_SUITE.erl
@@ -115,7 +115,9 @@ default_completions(Config) ->
                  , kind             => ?COMPLETION_ITEM_KIND_MODULE
                  , label            => <<"code_navigation_types">>
                  }
-              | Functions ++ els_completion_provider:keywords()
+              | Functions
+                ++ els_completion_provider:keywords()
+                ++ els_completion_provider:bifs(function, false)
               ],
 
   #{ result := Completion1
@@ -126,7 +128,9 @@ default_completions(Config) ->
                  , kind             => ?COMPLETION_ITEM_KIND_CONSTANT
                  , label            => <<"foo">>
                  }
-              | Functions ++ els_completion_provider:keywords()
+              | Functions
+                ++ els_completion_provider:keywords()
+                ++ els_completion_provider:bifs(function, false)
               ],
 
   #{ result := Completion2
@@ -229,7 +233,7 @@ functions_arity(Config) ->
                           , insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
                           }
                          || FunName <- ExportedFunctions
-                       ],
+                       ] ++ els_completion_provider:bifs(function, true),
 
   #{result := Completion} =
     els_client:completion(Uri, 51, 17, TriggerKind, <<"">>),
@@ -258,7 +262,9 @@ functions_export_list(Config) ->
                           , kind             => ?COMPLETION_ITEM_KIND_FUNCTION
                           , label            => <<"do_4/2">>
                           }
-                       ] ++ els_completion_provider:keywords(),
+                       | els_completion_provider:keywords()
+                         ++ els_completion_provider:bifs(function, true)
+                       ],
 
   #{result := Completion} =
     els_client:completion(Uri, 3, 13, TriggerKind, <<"">>),
@@ -408,6 +414,7 @@ types(Config) ->
                 , label            => <<"included_type_a/0">>
                 }
              | els_completion_provider:keywords()
+               ++ els_completion_provider:bifs(type_definition, false)
              ],
 
   ct:comment("Types defined both in the current file and in includes"),
@@ -430,6 +437,7 @@ types_export_list(Config) ->
                 , label            => <<"opaque_type_a/0">>
                 }
              | els_completion_provider:keywords()
+               ++ els_completion_provider:bifs(type_definition, true)
              ],
 
   ct:comment("Types in an export_type section is provided with arity"),

--- a/test/els_fake_stdio.erl
+++ b/test/els_fake_stdio.erl
@@ -87,6 +87,8 @@ handle_request({get_line, _Encoding, _Prompt}, State0) ->
     _ ->
       {noreply, State0}
   end;
+handle_request({get_chars, Encoding, _Prompt, Count}, State) ->
+  handle_request({get_chars, Encoding, Count}, State);
 handle_request({get_chars, _Encoding, Count}, State0) ->
   case State0#state.buffer of
     <<Data:Count/binary, Rest/binary>> ->


### PR DESCRIPTION
### Description

Implements auto-completion for Erlang built-in functions and types. 

There's one caveat which is that the built-in functions are resolved dynamically based on the Erlang/OTP release in which **Erlang LS is running** and not the Erlang/OTP release specified in the **erlang_ls.config**. 

I considered trying to figure out what the were BIFs by parsing the clauses from source code in `erl_internal:bif/2`, but decided against it. It seemed overkill given that even though BIFs get added, they don't change that much.

A possible improvement would be to resolve them only once when the provider is initialized instead of resolving on every completion.

The list of built-in type is a hardcoded list taken from the information [here](https://erlang.org/doc/reference_manual/typespec.html).

Fixes #106.
