### PR TITLE
Use open_port to spawn epmd

### DIFF
--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -136,7 +136,7 @@ transaction(F) ->
 
 -spec start_epmd() -> ok.
 start_epmd() ->
-  [] = os:cmd(epmd_path() ++ " -daemon"),
+  0 = els_utils:cmd(epmd_path(), ["-daemon"]),
   ok.
 
 -spec epmd_path() -> string().


### PR DESCRIPTION
This ensures that spaces in the path are treated correctly.

### Description

Exchange `os:cmd` for a call to `open_port({spawn_executable ...`, adjusted from https://stackoverflow.com/a/2249387/542190.

Fixes https://github.com/erlang-ls/vscode/issues/24.
