### PR TITLE
[#560] Remove separation between debug and default mode

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,9 @@
 {deps, [ {ranch,         "1.7.1"}
        , {jsx,           "2.9.0"}
        , {cowlib,        "2.3.0"}
-       , {redbug,        "1.2.1"}
+         %% The latest tagged version of redbug does not support
+         %% debugging escriptized code, so fetching it from git.
+       , {redbug,        {git, "https://github.com/massemanet/redbug.git", {ref, "60fb6e17c164f153a792985a88ac5c67a2364220"}}}
        , {lager,         "3.6.8"}
        , {yamerl,        "0.7.0"}
        , {docsh,         "0.7.2"}
@@ -29,21 +31,14 @@
 
 {minimum_otp_vsn, "21.0"}.
 
-{escript_emu_args, "%%! -connect_all false \n" }.
+{escript_emu_args, "%%! -connect_all false\n" }.
+%% For some reason we need to explicitly include redbug,
+%% even if it already is a dependency.
+{escript_incl_apps, [redbug]}.
 
-{profiles, [ { debug
-             , [ { deps
-                 , [ {redbug, {git, "https://github.com/massemanet/redbug.git", {ref, "8dd853154799da973b20be3a33fc8da9618e6393"}}}
-                   ]
-                 }
-               , { escript_emu_args
-                 , "%%! -connect_all false -erlang_ls logging_enabled true \n"
-                 }
-                 %% For some reason we need to explicitly include redbug,
-                 %% even if it already is a dependency.
-               , {escript_incl_apps, [redbug]}
-               ]
-             }
+%% Keeping the debug profile as an alias, since many clients were
+%% relying on it when starting the server.
+{profiles, [ { debug, [] }
            , { test
              , [ { erl_opts, [ nowarn_export_all
                              , nowarn_missing_spec_all

--- a/src/erlang_ls.erl
+++ b/src/erlang_ls.erl
@@ -111,7 +111,6 @@ set(transport, Name) ->
 set(port, Port) ->
   application:set_env(?APP, port, Port);
 set(log_dir, Dir) ->
-  application:set_env(?APP, logging_enabled, true),
   application:set_env(?APP, log_dir, Dir);
 set(log_level, Level) ->
   application:set_env(?APP, log_level, Level);
@@ -125,7 +124,7 @@ set(port_old, Port) ->
 
 -spec lager_config() -> ok.
 lager_config() ->
-  LoggingEnabled = application:get_env(?APP, logging_enabled, false),
+  LoggingEnabled = application:get_env(?APP, logging_enabled, true),
   case LoggingEnabled of
     true ->
       LogRoot   = log_root(),


### PR DESCRIPTION
### Description

* Remove `debug` mode, keeping the alias
* Enable logging by default

Fixes #560 .
