### PR TITLE
[#486] Find references for types

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -640,8 +640,12 @@
                    | type_definition
                    | variable.
 -type poi_range() :: #{ from := pos(), to := pos() }.
+-type poi_id()    :: atom()
+                   | string() %% include, include_lib
+                   | {atom(), arity()}
+                   | {module(), atom(), arity()}.
 -type poi()       :: #{ kind  := poi_kind()
-                      , id    := any()
+                      , id    := poi_id()
                       , data  := any()
                       , range := poi_range()
                       }.

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 -define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"5">>).
+-define(DB_SCHEMA_VSN, <<"6">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================

--- a/src/els_document_highlight_provider.erl
+++ b/src/els_document_highlight_provider.erl
@@ -45,20 +45,17 @@ find_highlights(Uri, #{ kind := Kind
                       }) when Kind =:= application;
                               Kind =:= implicit_fun;
                               Kind =:= function;
-                              Kind =:= variable;
                               Kind =:= export_entry ->
   Key = case Id of
           {F, A}    -> {els_uri:module(Uri), F, A};
-          {M, F, A} -> {M, F, A};
-          V         -> {els_uri:module(Uri), V, 0}
+          {M, F, A} -> {M, F, A}
         end,
-  case els_dt_references:find_by_id(Key) of
+  case els_dt_references:find_by_id(Kind, Key) of
     {ok, []} ->
       null;
     {ok, Refs} ->
       R = [ document_highlight(R) ||
-            #{uri := U, range := R} <- ordsets:to_list(Refs)
-              , Uri == U
+            #{uri := U, range := R} <- ordsets:to_list(Refs), Uri =:= U
           ],
       R
   end;

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -104,16 +104,16 @@ range({Line, Column}, record, Record, _Data) ->
   To = plus(From, atom_to_list(Record)),
   #{ from => From, to => To };
 range({Line, Column}, type_application, {F, _A}, _Data) ->
-  From = {Line, Column - 1},
+  From = {Line, Column},
   To = plus(From, atom_to_list(F)),
   #{ from => From, to => To };
 range({Line, Column}, type_application, {M, F, _A}, _Data) ->
-  From = {Line, Column - 1},
+  From = {Line, Column},
   To = {Line, Column + length(atom_to_list(M)) + length(atom_to_list(F))},
   #{ from => From, to => To };
-range({Line, Column}, type_definition, _Type, _Data) ->
-  From = {Line, Column},
-  To = From,
+range({Line, Column}, type_definition, {Name, _}, _Data) ->
+  From = plus({Line, Column}, "type "),
+  To = plus(From, atom_to_list(Name)),
   #{ from => From, to => To };
 range({Line, Column}, variable, Name, _Data) ->
   From = {Line, Column},

--- a/src/els_references_provider.erl
+++ b/src/els_references_provider.erl
@@ -50,21 +50,24 @@ find_references(Uri, #{ kind := Kind
                       }) when Kind =:= application;
                               Kind =:= implicit_fun;
                               Kind =:= function;
-                              Kind =:= export_entry ->
+                              Kind =:= export_entry;
+                              Kind =:= export_type_entry;
+                              Kind =:= type_application;
+                              Kind =:= type_definition ->
   Key = case Id of
           {F, A}    -> {els_uri:module(Uri), F, A};
           {M, F, A} -> {M, F, A}
         end,
-  find_references_for_id(Key);
+  find_references_for_id(Kind, Key);
 find_references(_Uri, #{kind := Kind, id := Name})
   when Kind =:= record_expr;
        Kind =:= record;
        Kind =:= record_access ->
-  find_references_for_id({record, Name});
+  find_references_for_id(Kind, Name);
 find_references(_Uri, #{kind := Kind, id := Name})
   when Kind =:= macro;
        Kind =:= define ->
-  find_references_for_id({macro, Name});
+  find_references_for_id(Kind, Name);
 find_references(Uri, #{kind := module}) ->
   case els_utils:lookup_document(Uri) of
     {ok, Doc} ->
@@ -79,9 +82,9 @@ find_references(Uri, #{kind := module}) ->
 find_references(_Uri, _POI) ->
   [].
 
--spec find_references_for_id(any()) -> [location()].
-find_references_for_id(Id) ->
-  {ok, Refs} = els_dt_references:find_by_id(Id),
+-spec find_references_for_id(poi_kind(), any()) -> [location()].
+find_references_for_id(Kind, Id) ->
+  {ok, Refs} = els_dt_references:find_by_id(Kind, Id),
   [location(U, R) || #{uri := U, range := R} <- Refs].
 
 -spec location(uri(), poi_range()) -> location().

--- a/test/els_definition_SUITE.erl
+++ b/test/els_definition_SUITE.erl
@@ -323,7 +323,7 @@ type_application_remote(Config) ->
   Def = els_client:definition(ExtraUri, 11, 38),
   #{result := #{range := Range, uri := DefUri}} = Def,
   ?assertEqual(TypesUri, DefUri),
-  ?assertEqual( els_protocol:range(#{from => {3, 2}, to => {3, 2}})
+  ?assertEqual( els_protocol:range(#{from => {3, 7}, to => {3, 13}})
               , Range),
   ok.
 
@@ -341,7 +341,7 @@ type_application_user(Config) ->
   Def = els_client:definition(Uri, 55, 25),
   #{result := #{range := Range, uri := DefUri}} = Def,
   ?assertEqual(Uri, DefUri),
-  ?assertEqual( els_protocol:range(#{from => {37, 2}, to => {37, 2}})
+  ?assertEqual( els_protocol:range(#{from => {37, 7}, to => {37, 13}})
               , Range),
   ok.
 
@@ -352,7 +352,7 @@ opaque_application_remote(Config) ->
   Def = els_client:definition(ExtraUri, 16, 61),
   #{result := #{range := Range, uri := DefUri}} = Def,
   ?assertEqual(TypesUri, DefUri),
-  ?assertEqual( els_protocol:range(#{from => {7, 2}, to => {7, 2}})
+  ?assertEqual( els_protocol:range(#{from => {7, 7}, to => {7, 20}})
               , Range),
   ok.
 
@@ -362,6 +362,6 @@ opaque_application_user(Config) ->
   Def      = els_client:definition(ExtraUri, 16, 24),
   #{result := #{range := Range, uri := DefUri}} = Def,
   ?assertEqual(ExtraUri, DefUri),
-  ?assertEqual( els_protocol:range(#{from => {20, 2}, to => {20, 2}})
+  ?assertEqual( els_protocol:range(#{from => {20, 7}, to => {20, 19}})
               , Range),
   ok.

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -21,6 +21,8 @@
         , module/1
         , record/1
         , purge_references/1
+        , type_local/1
+        , type_remote/1
         ]).
 
 %%==============================================================================
@@ -247,6 +249,45 @@ purge_references(_Config) ->
                       }]}
               , els_dt_references:find_all()
               ),
+  ok.
+
+-spec type_local(config()) -> ok.
+type_local(Config) ->
+  Uri = ?config(code_navigation_uri, Config),
+  ExpectedLocations = [ #{ uri => Uri
+                         , range => #{from => {55, 23}, to => {55, 29}}
+                         }
+                      ],
+
+  ct:comment("Find references type_a from its definition"),
+  #{result := Locations} = els_client:references(Uri, 37, 9),
+  ct:comment("Find references type_a from a usage"),
+  #{result := Locations} = els_client:references(Uri, 55, 23),
+  ct:comment("Find references type_a from beginning of definition"),
+  #{result := Locations} = els_client:references(Uri, 37, 7),
+  ct:comment("Find references type_a from end of definition"),
+  #{result := Locations} = els_client:references(Uri, 37, 12),
+
+  assert_locations(Locations, ExpectedLocations),
+
+  ok.
+
+-spec type_remote(config()) -> ok.
+type_remote(Config) ->
+  UriTypes = ?config(code_navigation_types_uri, Config),
+  Uri = ?config(code_navigation_extra_uri, Config),
+  ExpectedLocations = [ #{ uri   => Uri
+                         , range => #{from => {11, 38}, to => {11, 65}}
+                         }
+                      ],
+
+  ct:comment("Find references for type_a from a remote usage"),
+  #{result := Locations} = els_client:references(Uri, 11, 45),
+  ct:comment("Find references type_a from definition"),
+  #{result := Locations} = els_client:references(UriTypes, 3, 8),
+
+  assert_locations(Locations, ExpectedLocations),
+
   ok.
 
 %%==============================================================================


### PR DESCRIPTION
### Description

Implements finding references for types. Tightens the `id` field type definition for `poi()`s.

Fixes #486. Fixes #368.
