### PR TITLE
[#581] Bump lager from 3.6.8 to 3.8.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
          %% The latest tagged version of redbug does not support
          %% debugging escriptized code, so fetching it from git.
        , {redbug,        {git, "https://github.com/massemanet/redbug.git", {ref, "60fb6e17c164f153a792985a88ac5c67a2364220"}}}
-       , {lager,         "3.6.8"}
+       , {lager,         "3.8.0"}
        , {yamerl,        "0.7.0"}
        , {docsh,         "0.7.2"}
        , {elvis_core,    "0.6.0"}


### PR DESCRIPTION
### Description

The current version of lager is from 22 December 2018. No big reason for the bump, except avoiding falling too much behind.

Fixes #581 .
