### PR TITLE
[#306] Handle non-unicode as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ all:
 	@ echo "Building escript..."
 	@ rebar3 escriptize
 
-debug:
-	rebar3 as debug escriptize
+install: all
+	@ echo "Installing escript..."
+	@ cp _build/default/bin/erlang_ls /usr/local/bin
 
 ci:
 	rebar3 do compile, ct, proper --cover --constraint_tries 100, dialyzer, xref, cover, edoc

--- a/src/els_code_action_provider.erl
+++ b/src/els_code_action_provider.erl
@@ -85,10 +85,10 @@ make_unused_variable_action(Uri, Range, UnusedVariable) ->
    } = Range,
   %% processing messages like "variable 'Foo' is unused"
   {ok, #{text := Bin}} = els_utils:lookup_document(Uri),
-  Line = unicode:characters_to_list(els_text:line(Bin, StartLine)),
+  Line = els_utils:to_list(els_text:line(Bin, StartLine)),
 
   {ok, Tokens, _} = erl_scan:string(Line, 1, [return, text]),
-  UnusedString = unicode:characters_to_list(UnusedVariable),
+  UnusedString = els_utils:to_list(UnusedVariable),
   Replace =
         fun(Tok) ->
             case Tok of
@@ -102,7 +102,7 @@ make_unused_variable_action(Uri, Range, UnusedVariable) ->
     [ replace_lines_action( Uri
                       , <<"Add '_' to '", UnusedVariable/binary, "'">>
                       , ?CODE_ACTION_KIND_QUICKFIX
-                      , unicode:characters_to_binary(UpdatedLine)
+                      , els_utils:to_binary(UpdatedLine)
                       , Range)].
 
 %%------------------------------------------------------------------------------

--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -65,7 +65,7 @@ source() ->
 -spec compile(uri()) -> [diagnostic()].
 compile(Uri) ->
   Dependencies = els_diagnostics_utils:dependencies(Uri),
-  Path = unicode:characters_to_list(els_uri:path(Uri)),
+  Path = els_utils:to_list(els_uri:path(Uri)),
   case compile_file(Path, Dependencies) of
     {ok, _, WS} ->
       diagnostics(Path, WS, ?DIAGNOSTIC_WARNING);
@@ -76,7 +76,7 @@ compile(Uri) ->
 
 -spec parse(uri()) -> [diagnostic()].
 parse(Uri) ->
-  FileName = unicode:characters_to_list(els_uri:path(Uri)),
+  FileName = els_utils:to_list(els_uri:path(Uri)),
   {ok, Epp} = epp:open([ {name, FileName}
                        , {includes, els_config:get(include_paths)}
                        ]),
@@ -87,7 +87,7 @@ parse(Uri) ->
 
 -spec parse_escript(uri()) -> [diagnostic()].
 parse_escript(Uri) ->
-  FileName = unicode:characters_to_list(els_uri:path(Uri)),
+  FileName = els_utils:to_list(els_uri:path(Uri)),
   case els_escript:extract(FileName) of
     {ok, WS} ->
       diagnostics(FileName, WS, ?DIAGNOSTIC_WARNING);
@@ -106,7 +106,7 @@ parse_escript(Uri) ->
 %% the file inclusion happens.
 -spec diagnostics(list(), [compiler_msg()], severity()) -> [diagnostic()].
 diagnostics(Path, List, Severity) ->
-  Uri = els_uri:uri(unicode:characters_to_binary(Path)),
+  Uri = els_uri:uri(els_utils:to_binary(Path)),
   {ok, [Document]} = els_dt_document:lookup(Uri),
   lists:flatten([[ diagnostic( Path
                              , MessagePath
@@ -141,7 +141,7 @@ diagnostic(_Path, MessagePath, Range, Document, Module, Desc0, Severity) ->
   diagnostic().
 diagnostic(Range, Module, Desc, Severity) ->
   Message0 = lists:flatten(Module:format_error(Desc)),
-  Message  = unicode:characters_to_binary(Message0),
+  Message  = els_utils:to_binary(Message0),
   #{ range    => els_protocol:range(Range)
    , message  => Message
    , severity => Severity
@@ -247,7 +247,7 @@ load_dependency(Module) ->
   Old = code:get_object_code(Module),
   case els_utils:find_module(Module) of
     {ok, Uri} ->
-      Path = unicode:characters_to_list(els_uri:path(Uri)),
+      Path = els_utils:to_list(els_uri:path(Uri)),
       Opts = lists:append([macro_options(), include_options(), [binary]]),
       case compile:file(Path, Opts) of
         {ok, Module, Binary} ->

--- a/src/els_completion_provider.erl
+++ b/src/els_completion_provider.erl
@@ -366,7 +366,7 @@ completion_item(#{kind := Kind, id := {F, A}, data := ArgsNames}, false)
   when Kind =:= function;
        Kind =:= type_definition ->
   Label = io_lib:format("~p/~p", [F, A]),
-  #{ label            => unicode:characters_to_binary(Label)
+  #{ label            => els_utils:to_binary(Label)
    , kind             => completion_item_kind(Kind)
    , insertText       => snippet_function_call(F, ArgsNames)
    , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
@@ -375,7 +375,7 @@ completion_item(#{kind := Kind, id := {F, A}}, true)
   when Kind =:= function;
        Kind =:= type_definition ->
   Label = io_lib:format("~p/~p", [F, A]),
-  #{ label            => unicode:characters_to_binary(Label)
+  #{ label            => els_utils:to_binary(Label)
    , kind             => completion_item_kind(Kind)
    , insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
    };
@@ -392,7 +392,7 @@ snippet_function_call(Function, Args0) ->
               || {N, A} <- Args0
             ],
   Snippet = [atom_to_list(Function), "(", string:join(Args, ", "), ")"],
-  unicode:characters_to_binary(Snippet).
+  els_utils:to_binary(Snippet).
 
 -spec is_in(els_dt_document:item(), line(), column(), [poi_kind()]) ->
   boolean().

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -70,13 +70,13 @@
 
 -spec initialize(uri(), map(), map()) -> ok.
 initialize(RootUri, Capabilities, InitOptions) ->
-  RootPath = unicode:characters_to_list(els_uri:path(RootUri)),
+  RootPath = els_utils:to_list(els_uri:path(RootUri)),
   Config = consult_config(config_paths(RootPath, InitOptions)),
   do_initialize(RootUri, Capabilities, Config).
 
 -spec do_initialize(uri(), map(), map()) -> ok.
 do_initialize(RootUri, Capabilities, Config) ->
-  RootPath        = unicode:characters_to_list(els_uri:path(RootUri)),
+  RootPath        = els_utils:to_list(els_uri:path(RootUri)),
   OtpPath         = maps:get("otp_path", Config, code:root_dir()),
   DepsDirs        = maps:get("deps_dirs", Config, []),
   AppsDirs        = maps:get("apps_dirs", Config, ["."]),
@@ -158,7 +158,7 @@ handle_cast(_Msg, State) -> {noreply, State}.
 -spec config_paths(path(), map()) -> [path()].
 config_paths( RootPath
             , #{<<"erlang">> := #{<<"config_path">> := ConfigPath0}}) ->
-  ConfigPath = unicode:characters_to_list(ConfigPath0),
+  ConfigPath = els_utils:to_list(ConfigPath0),
   lists:append([ possible_config_paths(ConfigPath)
                , possible_config_paths(filename:join([RootPath, ConfigPath]))
                , default_config_paths(RootPath)]);

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -74,8 +74,8 @@ initialize(RootUri, Capabilities, InitOptions) ->
   Config = consult_config(config_paths(RootPath, InitOptions)),
   do_initialize(RootUri, Capabilities, Config).
 
--spec do_initialize(uri(), map(), map()) -> ok.
-do_initialize(RootUri, Capabilities, Config) ->
+-spec do_initialize(uri(), map(), {undefined|path(), map()}) -> ok.
+do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   RootPath        = els_utils:to_list(els_uri:path(RootUri)),
   OtpPath         = maps:get("otp_path", Config, code:root_dir()),
   DepsDirs        = maps:get("deps_dirs", Config, []),

--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -30,7 +30,7 @@ diagnostics(Uri) ->
     undefined -> [];
     DialyzerPltPath ->
       Deps  = [dep_path(X) || X <- els_diagnostics_utils:dependencies(Uri)],
-      Files = [unicode:characters_to_list(Path) | Deps],
+      Files = [els_utils:to_list(Path) | Deps],
       WS = try dialyzer:run([ {files, Files}
                             , {from, src_code}
                             , {include_dirs, els_config:get(include_paths)}
@@ -58,7 +58,7 @@ diagnostic({_, {_, Line}, _} = Warning) ->
                                  , to   => {Line + 1, 1}
                                  }),
   Message0 = lists:flatten(dialyzer:format_warning(Warning)),
-  Message  = unicode:characters_to_binary(Message0),
+  Message  = els_utils:to_binary(Message0),
   #{ range    => Range
    , message  => Message
    , severity => ?DIAGNOSTIC_WARNING
@@ -68,4 +68,4 @@ diagnostic({_, {_, Line}, _} = Warning) ->
 -spec dep_path(module()) -> string().
 dep_path(Module) ->
   {ok, Uri} = els_utils:find_module(Module),
-  unicode:characters_to_list(els_uri:path(Uri)).
+  els_utils:to_list(els_uri:path(Uri)).

--- a/src/els_document_symbol_provider.erl
+++ b/src/els_document_symbol_provider.erl
@@ -42,4 +42,4 @@ functions(Uri) ->
 
 -spec function_name(atom(), non_neg_integer()) -> binary().
 function_name(F, A) ->
-  unicode:characters_to_binary(io_lib:format("~p/~p", [F, A])).
+  els_utils:to_binary(io_lib:format("~p/~p", [F, A])).

--- a/src/els_elvis_diagnostics.erl
+++ b/src/els_elvis_diagnostics.erl
@@ -77,7 +77,7 @@ format_item(_File, _Name, []) ->
 diagnostic(_File, Name, Msg, Ln, Info) ->
   FMsg    = io_lib:format(Msg, Info),
   Range   = els_protocol:range(#{from => {Ln, 1}, to => {Ln + 1, 1}}),
-  Message = unicode:characters_to_binary(FMsg),
+  Message = els_utils:to_binary(FMsg),
   [#{ range    => Range
     , severity => ?DIAGNOSTIC_WARNING
     , code     => Name

--- a/src/els_execute_command_provider.erl
+++ b/src/els_execute_command_provider.erl
@@ -70,4 +70,4 @@ add_server_prefix(Command) ->
 %% same time against a single client.
 -spec server_prefix() -> binary().
 server_prefix() ->
-   unicode:characters_to_binary(os:getpid()).
+   els_utils:to_binary(os:getpid()).

--- a/src/els_hover_provider.erl
+++ b/src/els_hover_provider.erl
@@ -83,7 +83,7 @@ get_docs(M, F, A) ->
           docs_from_src(M, F, A);
         FuncDoc ->
           #{ kind => content_kind()
-           , value => unicode:characters_to_binary(FuncDoc)
+           , value => els_utils:to_binary(FuncDoc)
            }
       end;
     _R1 ->
@@ -117,7 +117,7 @@ specs(M, F, A) ->
   case els_dt_signatures:lookup({M, F, A}) of
     {ok, [#{tree := Tree}]} ->
       Specs = erl_prettypr:format(Tree),
-      unicode:characters_to_binary(Specs);
+      els_utils:to_binary(Specs);
     {ok, []} ->
       <<>>
   end.
@@ -133,7 +133,7 @@ edoc(M, F, A) ->
   try
     {ok, Uri} = els_utils:find_module(M),
     Path      = els_uri:path(Uri),
-    {M, EDoc} = edoc:get_doc( unicode:characters_to_list(Path)
+    {M, EDoc} = edoc:get_doc( els_utils:to_list(Path)
                             , [{private, true}]
                             ),
     Internal  = xmerl:export_simple([EDoc], docsh_edoc_xmerl),
@@ -156,7 +156,7 @@ format(_Signature, none) ->
 format(Signature, Desc) when is_map(Desc) ->
   Lang         = <<"en">>,
   Doc          = maps:get(Lang, Desc, <<>>),
-  FormattedDoc = unicode:characters_to_binary(docsh_edoc:format_edoc(Doc, #{})),
+  FormattedDoc = els_utils:to_binary(docsh_edoc:format_edoc(Doc, #{})),
   <<"### ", Signature/binary, "\n", FormattedDoc/binary>>.
 
 -spec content_kind() -> markup_kind().

--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -35,7 +35,7 @@
 find_and_index_file(FileName) ->
   SearchPaths = els_config:get(search_paths),
   case file:path_open( SearchPaths
-                     , unicode:characters_to_binary(FileName)
+                     , els_utils:to_binary(FileName)
                      , [read]
                      )
   of
@@ -165,7 +165,7 @@ register_reference(Uri, #{kind := Kind, id := Id, range := Range})
 index_dir(Dir, Mode) ->
   lager:debug("Indexing directory. [dir=~s] [mode=~s]", [Dir, Mode]),
   F = fun(FileName, {Succeeded, Failed}) ->
-          case try_index_file(unicode:characters_to_binary(FileName), Mode) of
+          case try_index_file(els_utils:to_binary(FileName), Mode) of
             ok              -> {Succeeded + 1, Failed};
             {error, _Error} -> {Succeeded, Failed + 1}
           end

--- a/src/els_io_string.erl
+++ b/src/els_io_string.erl
@@ -18,7 +18,7 @@
 
 -spec new(string() | binary()) -> pid().
 new(Str) when is_binary(Str) ->
-  new(unicode:characters_to_list(Str));
+  new(els_utils:to_list(Str));
 new(Str) ->
   start_link(Str).
 

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -111,7 +111,7 @@ method_to_function_name(<<"$/", Method/binary>>) ->
 method_to_function_name(Method) ->
   Replaced = string:replace(Method, <<"/">>, <<"_">>),
   Lower    = string:lowercase(Replaced),
-  Binary   = unicode:characters_to_binary(Lower),
+  Binary   = els_utils:to_binary(Lower),
   binary_to_atom(Binary, utf8).
 
 %%==============================================================================
@@ -128,14 +128,14 @@ initialize(Params, State) ->
   RootUri = case RootUri0 of
               null ->
                 {ok, Cwd} = file:get_cwd(),
-                els_uri:uri(unicode:characters_to_binary(Cwd));
+                els_uri:uri(els_utils:to_binary(Cwd));
               _ -> RootUri0
             end,
   InitOptions = maps:get(<<"initializationOptions">>, Params, #{}),
   ok = els_config:initialize(RootUri, Capabilities, InitOptions),
   DbDir = application:get_env(erlang_ls, db_dir, default_db_dir()),
   OtpPath = els_config:get(otp_path),
-  els_db:install( node_name(RootUri, unicode:characters_to_binary(OtpPath))
+  els_db:install( node_name(RootUri, els_utils:to_binary(OtpPath))
                 , DbDir
                 ),
   case application:get_env(?APP, indexing_enabled) of
@@ -192,7 +192,7 @@ initialized(_Params, State) ->
   %% Report to the user the server version
   {ok, Version} = application:get_key(?APP, vsn),
   lager:info("initialized: [App=~p] [Version=~p]", [?APP, Version]),
-  BinVersion = unicode:characters_to_binary(Version),
+  BinVersion = els_utils:to_binary(Version),
   Root = filename:basename(els_uri:path(els_config:get(root_uri))),
   Message = <<"Erlang LS (in ", Root/binary, "), version: "
              , BinVersion/binary>>,

--- a/src/els_stdio_client.erl
+++ b/src/els_stdio_client.erl
@@ -35,4 +35,4 @@ start_link(#{io_device := IoDevice}) ->
 
 -spec send(pid(), iolist()) -> ok.
 send(Server, Payload) ->
-  io:format(Server, unicode:characters_to_binary(Payload), []).
+  io:format(Server, els_utils:to_binary(Payload), []).

--- a/src/els_text.erl
+++ b/src/els_text.erl
@@ -29,7 +29,7 @@ line(Text, LineNum, ColumnNum) ->
 %% @doc Return tokens from text.
 -spec tokens(text()) -> [any()].
 tokens(Text) ->
-  case erl_scan:string(unicode:characters_to_list(Text)) of
+  case erl_scan:string(els_utils:to_list(Text)) of
     {ok, Tokens, _} -> Tokens;
     {error, _, _} -> []
   end.

--- a/src/els_text_edit.erl
+++ b/src/els_text_edit.erl
@@ -49,14 +49,14 @@ make_text_edits([{del, Del}, {ins, Ins}|T], Line, Acc) ->
     Pos1 = #{ line => Line,       character => 0 },
     Pos2 = #{ line => Line + Len, character => 0 },
     Edit = #{ range => #{ start => Pos1, 'end' => Pos2 }
-            , newText => unicode:characters_to_binary(lists:concat(Ins))
+            , newText => els_utils:to_binary(lists:concat(Ins))
             },
     make_text_edits(T, Line + Len, [Edit|Acc]);
 
 make_text_edits([{ins, Data}|T], Line, Acc) ->
     Pos = #{ line => Line, character => 0 },
     Edit = #{ range => #{ start => Pos, 'end' => Pos }
-            , newText => unicode:characters_to_binary(lists:concat(Data))
+            , newText => els_utils:to_binary(lists:concat(Data))
             },
     make_text_edits(T, Line, [Edit|Acc]);
 
@@ -75,7 +75,7 @@ make_text_edits([], _Line, Acc) -> lists:reverse(Acc).
 edit_insert_text(Uri, Data, Line) ->
     Pos  = #{ line    => Line, character => 0 },
     Edit = #{ range   => #{ start => Pos, 'end' => Pos }
-            , newText => unicode:characters_to_binary(Data)
+            , newText => els_utils:to_binary(Data)
             },
     #{ changes => #{ Uri => [Edit] }}.
 
@@ -84,6 +84,6 @@ edit_replace_text(Uri, Data, LineFrom, LineTo) ->
     Pos1 = #{ line    => LineFrom, character => 0 },
     Pos2 = #{ line    => LineTo,   character => 0 },
     Edit = #{ range   => #{ start => Pos1, 'end' => Pos2 }
-            , newText => unicode:characters_to_binary(Data)
+            , newText => els_utils:to_binary(Data)
             },
     #{ changes => #{ Uri => [Edit] }}.

--- a/src/els_text_synchronization.erl
+++ b/src/els_text_synchronization.erl
@@ -79,7 +79,7 @@ handle_rpc_result({ok, Module}, _) ->
   Msg = io_lib:format("code_reload success for: ~s", [Module]),
   els_server:send_notification(<<"window/showMessage">>,
                                #{ type => ?MESSAGE_TYPE_INFO,
-                                  message => unicode:characters_to_binary(Msg)
+                                  message => els_utils:to_binary(Msg)
                                 });
 handle_rpc_result(Err, Module) ->
   lager:info("[code_reload] code_reload using c:c/1 crashed with: ~p",
@@ -88,5 +88,5 @@ handle_rpc_result(Err, Module) ->
                       [Module, Err]),
   els_server:send_notification(<<"window/showMessage">>,
                                #{ type => ?MESSAGE_TYPE_ERROR,
-                                  message => unicode:characters_to_binary(Msg)
+                                  message => els_utils:to_binary(Msg)
                                 }).

--- a/test/els_fake_stdio.erl
+++ b/test/els_fake_stdio.erl
@@ -75,7 +75,7 @@ handle_request({put_chars, Encoding, M, F, Args}, State0) ->
   handle_request({put_chars, Encoding, Chars}, State0);
 handle_request({put_chars, Encoding, Chars}, State0) ->
   EncodedChars = unicode:characters_to_list(Chars, Encoding),
-  CharsBin     = unicode:characters_to_binary(EncodedChars),
+  CharsBin     = els_utils:to_binary(EncodedChars),
   Buffer       = State0#state.buffer,
   State        = State0#state{buffer = <<Buffer/binary, CharsBin/binary>>},
   {reply, ok, State};

--- a/test/els_indexer_SUITE.erl
+++ b/test/els_indexer_SUITE.erl
@@ -73,7 +73,7 @@ index_dir_not_dir(Config) ->
 -spec index_erl_file(config()) -> ok.
 index_erl_file(Config) ->
   DataDir = ?config(data_dir, Config),
-  Path = filename:join(unicode:characters_to_binary(DataDir), "test.erl"),
+  Path = filename:join(els_utils:to_binary(DataDir), "test.erl"),
   {ok, Uri} = els_indexing:index_file(Path),
   {ok, [#{id := test, kind := module}]} = els_dt_document:lookup(Uri),
   ok.
@@ -81,7 +81,7 @@ index_erl_file(Config) ->
 -spec index_hrl_file(config()) -> ok.
 index_hrl_file(Config) ->
   DataDir = ?config(data_dir, Config),
-  Path = filename:join(unicode:characters_to_binary(DataDir), "test.hrl"),
+  Path = filename:join(els_utils:to_binary(DataDir), "test.hrl"),
   {ok, Uri} = els_indexing:index_file(Path),
   {ok, [#{id := test, kind := header}]} = els_dt_document:lookup(Uri),
   ok.
@@ -89,7 +89,7 @@ index_hrl_file(Config) ->
 -spec index_unkown_extension(config()) -> ok.
 index_unkown_extension(Config) ->
   DataDir = ?config(data_dir, Config),
-  Path = filename:join(unicode:characters_to_binary(DataDir), "test.foo"),
+  Path = filename:join(els_utils:to_binary(DataDir), "test.foo"),
   {ok, Uri} = els_indexing:index_file(Path),
   {ok, [#{kind := other}]} = els_dt_document:lookup(Uri),
   ok.

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -43,7 +43,7 @@ end_per_suite(Config) ->
 init_per_testcase(_TestCase, Config) ->
   {ok, Started} = application:ensure_all_started(erlang_ls),
   RootDir = code:root_dir(),
-  RootUri = els_uri:uri(unicode:characters_to_binary(RootDir)),
+  RootUri = els_uri:uri(els_utils:to_binary(RootDir)),
   %% Do not index the entire list of OTP apps in the pipelines.
   Cfg = #{"otp_apps_exclude" => otp_apps_exclude()},
   els_config:do_initialize(RootUri, [], Cfg),

--- a/test/els_proper_gen.erl
+++ b/test/els_proper_gen.erl
@@ -36,7 +36,7 @@ tokens() ->
       , vector(10, token())
       , begin
           Concatenated = [string:join(Tokens, ","), "."],
-          unicode:characters_to_binary(Concatenated)
+          els_utils:to_binary(Concatenated)
         end
       ).
 

--- a/test/els_rebar3_release_SUITE.erl
+++ b/test/els_rebar3_release_SUITE.erl
@@ -101,7 +101,7 @@ code_navigation(Config) ->
 -spec root_path() -> binary().
 root_path() ->
   RootPath = filename:join([code:priv_dir(erlang_ls), ?TEST_APP]),
-  unicode:characters_to_binary(RootPath).
+  els_utils:to_binary(RootPath).
 
 -spec src_path(binary(), [any()]) -> binary().
 src_path(RootPath, FileName) ->

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -49,7 +49,7 @@ all(Module, Functions) ->
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
   PrivDir = code:priv_dir(erlang_ls),
-  RootPath = filename:join([ unicode:characters_to_binary(PrivDir)
+  RootPath = filename:join([ els_utils:to_binary(PrivDir)
                            , ?TEST_APP]),
   RootUri = els_uri:uri(RootPath),
   application:load(erlang_ls),


### PR DESCRIPTION
### Description

The previous PR assumed all string were always unicode, this is not the case. This PR also remove the `debug` target from the `Makefile` and adds an `install` target which can be evolved as needed (e.g. to support Windows).

Fixes #306.
