### PR TITLE
Implement file URI handling for Windows

### DIFF
--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -226,7 +226,7 @@ record(Config) ->
 -spec purge_references(config()) -> ok.
 purge_references(_Config) ->
   els_db:clear_tables(),
-  Uri   = <<"file://tmp/foo.erl">>,
+  Uri   = <<"file:////tmp/foo.erl">>,
   Text0 = "-spec foo(integer()) -> ok.\nfoo(_X) -> ok.\nbar() -> foo(1).",
   Text1 = "\n-spec foo(integer()) -> ok.\nfoo(_X)-> ok.\nbar() -> foo(1).",
   Doc0  = els_dt_document:new(Uri, Text0),
@@ -236,7 +236,7 @@ purge_references(_Config) ->
   ?assertEqual({ok, [Doc0]}, els_dt_document:lookup(Uri)),
   ?assertEqual({ok, [#{ id    => {foo, foo, 1}
                       , range => #{from => {3, 10}, to => {3, 13}}
-                      , uri   => <<"file://tmp/foo.erl">>
+                      , uri   => <<"file:////tmp/foo.erl">>
                       }]}
               , els_dt_references:find_all()
               ),
@@ -245,7 +245,7 @@ purge_references(_Config) ->
   ?assertEqual({ok, [Doc1]}, els_dt_document:lookup(Uri)),
   ?assertEqual({ok, [#{ id    => {foo, foo, 1}
                       , range => #{from => {4, 10}, to => {4, 13}}
-                      , uri   => <<"file://tmp/foo.erl">>
+                      , uri   => <<"file:////tmp/foo.erl">>
                       }]}
               , els_dt_references:find_all()
               ),


### PR DESCRIPTION
Windows `file://` URIs are quite a bit different than Unix `file://` in that they can contain a host (for UNC paths like `\\some_server\some_share` and that the `/` prefix has to be stripped in `file:///c:/some_path`. Also, the colon usually gets URI-encoded which needs to be undone.