### PR TITLE
[#527] Add 'imported' flag to auto-imported built-in functions

### DIFF
--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -35,6 +35,8 @@ range({Line, Column}, export_type_entry, {F, A}, _Data) ->
 range({_Line, _Column} = From, atom, Name, _Data) ->
   To = plus(From, atom_to_list(Name)),
   #{ from => From, to => To };
+range({Line, Column}, application, {_, F, A}, #{imported := true} = Data) ->
+  range({Line, Column}, application, {F, A}, Data);
 range({Line, Column}, application, {M, F, _A}, _Data) ->
   %% Column indicates the position of the :
   CFrom = Column - length(atom_to_list(M)),

--- a/test/els_document_highlight_SUITE.erl
+++ b/test/els_document_highlight_SUITE.erl
@@ -13,6 +13,7 @@
 %% Test cases
 -export([ application_local/1
         , application_remote/1
+        , application_imported/1
         , function_definition/1
         , fun_local/1
         , fun_remote/1
@@ -80,6 +81,15 @@ application_remote(Config) ->
   #{result := Locations} = els_client:document_highlight(Uri, 32, 13),
   ExpectedLocations = [ #{range => #{from => {32, 3}, to => {32, 27}}}
                       , #{range => #{from => {52, 8}, to => {52, 38}}}
+                      ],
+  assert_locations(ExpectedLocations, Locations),
+  ok.
+
+-spec application_imported(config()) -> ok.
+application_imported(Config) ->
+  Uri = ?config(code_navigation_uri, Config),
+  #{result := Locations} = els_client:document_highlight(Uri, 35, 4),
+  ExpectedLocations = [ #{range => #{from => {35, 3}, to => {35, 9}}}
                       ],
   assert_locations(ExpectedLocations, Locations),
   ok.


### PR DESCRIPTION
### Description

Add 'imported' flag to auto-imported built-in functions.

Fixes #527.
