### PR TITLE
[#604] Add run-ct-test code lens, refactor code lens behaviour

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -115,29 +115,13 @@
                           }.
 
 %%------------------------------------------------------------------------------
-%% Diagnostic
+%% Diagnostics
 %%------------------------------------------------------------------------------
--type diagnostic() :: #{ range              := range()
-                       , severity           => severity()
-                       , code               => number() | binary()
-                       , source             => binary()
-                       , message            := binary()
-                       , relatedInformation => [related_info()]
-                       }.
 
 -define(DIAGNOSTIC_ERROR   , 1).
 -define(DIAGNOSTIC_WARNING , 2).
 -define(DIAGNOSTIC_INFO    , 3).
 -define(DIAGNOSTIC_HINT    , 4).
-
--type severity() :: ?DIAGNOSTIC_ERROR
-                  | ?DIAGNOSTIC_WARNING
-                  | ?DIAGNOSTIC_INFO
-                  | ?DIAGNOSTIC_HINT.
-
--type related_info() :: #{ location := location()
-                         , message  := binary()
-                         }.
 
 %%------------------------------------------------------------------------------
 %% Insert Text Format
@@ -587,7 +571,7 @@
 -define(CODE_ACTION_KIND_QUICKFIX, <<"quickfix">>).
 -type code_action_kind() :: binary().
 
--type code_action_context() :: #{ diagnostics := [diagnostic()]
+-type code_action_context() :: #{ diagnostics := [els_diagnostics:diagnostic()]
                                 , only        => [code_action_kind()]
                                 }.
 
@@ -598,7 +582,7 @@
 
 -type code_action() :: #{ title       := string()
                         , kind        => code_action_kind()
-                        , diagnostics => [diagnostic()]
+                        , diagnostics => [els_diagnostics:diagnostic()]
                         , edit        => workspace_edit()
                         , command     => els_command:command()
                         }.

--- a/priv/code_navigation/test/sample_SUITE.erl
+++ b/priv/code_navigation/test/sample_SUITE.erl
@@ -1,0 +1,60 @@
+-module(sample_SUITE).
+
+%% CT Callbacks
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , all/0
+        ]).
+
+%% Test cases
+-export([ one/1 ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+  [{timetrap, {seconds, 30}}].
+
+-spec all() -> [{group, atom()}].
+all() ->
+  [ one ].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  Config.
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  Config.
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(_TestCase, Config) ->
+  Config.
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(_TestCase, _Config) ->
+  ok.
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+
+-spec one(config()) -> ok.
+one(_Config) ->
+  ?assertEqual([1, 2, 3], lists:seq(1, 3)),
+  ok.

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,7 @@
 
 {dialyzer, [ {warnings, [unknown]}
            , {plt_apps, all_deps}
-           , {plt_extra_apps, [dialyzer, mnesia]}
+           , {plt_extra_apps, [dialyzer, mnesia, common_test]}
            ]}.
 
 {xref_checks, [ undefined_function_calls

--- a/src/els_client.erl
+++ b/src/els_client.erl
@@ -129,7 +129,7 @@ references(Uri, Line, Char) ->
 document_highlight(Uri, Line, Char) ->
   gen_server:call(?SERVER, {document_highlight, {Uri, Line, Char}}).
 
--spec document_codeaction(uri(), range(), [diagnostic()]) -> ok.
+-spec document_codeaction(uri(), range(), [els_diagnostics:diagnostic()]) -> ok.
 document_codeaction(Uri, Range, Diagnostics) ->
   gen_server:call(?SERVER, {document_codeaction, {Uri, Range, Diagnostics}}).
 

--- a/src/els_code_action_provider.erl
+++ b/src/els_code_action_provider.erl
@@ -58,7 +58,7 @@ replace_lines_action(Uri, Title, Kind, Lines, Range) ->
                                    , to    => EndLine }])
    }.
 
--spec make_code_action(uri(), diagnostic()) -> [map()].
+-spec make_code_action(uri(), els_diagnostics:diagnostic()) -> [map()].
 make_code_action(Uri, #{ <<"message">> := Message
                        , <<"range">>   := Range } = _Diagnostic) ->
   unused_variable_action(Uri, Range, Message).

--- a/src/els_code_lens_ct_run_test.erl
+++ b/src/els_code_lens_ct_run_test.erl
@@ -1,0 +1,61 @@
+%%==============================================================================
+%% Code Lens: ct_run_test
+%%==============================================================================
+
+-module(els_code_lens_ct_run_test).
+
+-behaviour(els_code_lens).
+-export([ command/1
+        , command_args/2
+        , is_default/0
+        , pois/1
+        , precondition/1
+        , title/1
+        ]).
+
+-include("erlang_ls.hrl").
+
+-spec command(poi()) -> els_command:command_id().
+command(_POI) ->
+  <<"ct-run-test">>.
+
+-spec command_args(els_dt_document:item(), poi()) -> [any()].
+command_args( #{uri := Uri} = _Document
+            , #{id := {F, A}, range := #{from := {Line, _}}} = _POI) ->
+  [#{ module => els_uri:module(Uri)
+    , function => F
+    , arity => A
+    , uri => Uri
+    , line => Line
+    }].
+
+-spec is_default() -> boolean().
+is_default() ->
+  true.
+
+-spec pois(els_dt_document:item()) -> [poi()].
+pois(Document) ->
+  Functions = els_dt_document:pois(Document, [function]),
+  [POI || #{id := {F, 1}} = POI <- Functions, not is_blacklisted(F)].
+
+-spec precondition(els_dt_document:item()) -> boolean().
+precondition(Document) ->
+  Includes = els_dt_document:pois(Document, [include_lib]),
+  case [POI || #{id := "common_test/include/ct.hrl"} = POI <- Includes] of
+    [] ->
+      false;
+    _ ->
+      true
+  end.
+
+-spec title(poi()) -> binary().
+title(_POI) ->
+  <<"Run test">>.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+
+-spec is_blacklisted(atom()) -> boolean().
+is_blacklisted(Function) ->
+  lists:member(Function, [init_per_suite, end_per_suite]).

--- a/src/els_code_lens_ct_run_test.erl
+++ b/src/els_code_lens_ct_run_test.erl
@@ -58,4 +58,4 @@ title(_POI) ->
 
 -spec is_blacklisted(atom()) -> boolean().
 is_blacklisted(Function) ->
-  lists:member(Function, [init_per_suite, end_per_suite]).
+  lists:member(Function, [init_per_suite, end_per_suite, group]).

--- a/src/els_code_lens_server_info.erl
+++ b/src/els_code_lens_server_info.erl
@@ -4,26 +4,39 @@
 
 -module(els_code_lens_server_info).
 
--export([ command/0
+-behaviour(els_code_lens).
+-export([ command/1
+        , command_args/2
         , is_default/0
-        , lenses/1
+        , pois/1
+        , precondition/1
+        , title/1
         ]).
 
--behaviour(els_code_lens).
+-include("erlang_ls.hrl").
 
--spec command() -> els_command:command_id().
-command() ->
+-spec command(poi()) -> els_command:command_id().
+command(_POI) ->
   <<"server-info">>.
+
+-spec command_args(els_dt_document:item(), poi()) -> [any()].
+command_args(_Document, _POI) ->
+  [].
 
 -spec is_default() -> boolean().
 is_default() ->
   false.
 
-%% @doc Given a Document, returns the available lenses
--spec lenses(els_dt_document:item()) -> [els_code_lens:lens()].
-lenses(_Document) ->
+-spec precondition(els_dt_document:item()) -> boolean().
+precondition(_Document) ->
+  true.
+
+-spec pois(els_dt_document:item()) -> [poi()].
+pois(_Document) ->
+  %% Return a dummy POI on the first line
+  [els_poi:new(#{from => {1, 1}, to => {2, 1}}, dummy, dummy)].
+
+-spec title(poi()) -> binary().
+title(_POI) ->
   Root = filename:basename(els_uri:path(els_config:get(root_uri))),
-  Title = <<"Erlang LS (in ", Root/binary, ") info">>,
-  Range = els_range:line(1),
-  Command = els_command:make_command(Title, command(), []),
-  [ els_code_lens:make_lens(Range, Command, []) ].
+  <<"Erlang LS (in ", Root/binary, ") info">>.

--- a/src/els_command.erl
+++ b/src/els_command.erl
@@ -51,7 +51,7 @@ without_prefix(Id0) ->
 %% Constructors
 %%==============================================================================
 
--spec make_command(binary(), command_id(), [any()]) -> command().
+-spec make_command(binary(), command_id(), [map()]) -> command().
 make_command(Title, CommandId, Args) ->
   #{ title     => Title
    , command   => with_prefix(CommandId)

--- a/src/els_command_ct_run_test.erl
+++ b/src/els_command_ct_run_test.erl
@@ -1,0 +1,59 @@
+-module(els_command_ct_run_test).
+
+-export([ execute/1 ]).
+
+%% Invoked from the Common Test Hook
+-export([ publish_result/4, run_test/1, ct_run_test/1 ]).
+
+-include("erlang_ls.hrl").
+
+-spec execute(map()) -> ok.
+execute(#{ <<"module">>   := M
+         , <<"function">> := F
+         , <<"arity">>    := A
+         , <<"line">>     := Line
+         , <<"uri">>      := Uri
+         }) ->
+  Msg = io_lib:format("Running Common Test [mfa=~s:~s/~p]", [M, F, A]),
+  lager:info(Msg, []),
+  Title = unicode:characters_to_binary(Msg),
+  Config = #{ task        => fun ?MODULE:run_test/1
+            , entries     => [{Uri, Line, F}]
+            , title       => Title
+            },
+  {ok, _Pid} = els_background_job:new(Config),
+  ok.
+
+-spec run_test({uri(), pos_integer(), binary()}) -> ok.
+run_test({Uri, Line, TestCase}) ->
+  Opts = [ {suite,        [binary_to_list(els_uri:path(Uri))]}
+         , {testcase,     [binary_to_atom(TestCase, utf8)]}
+         , {include,      els_config:get(include_paths)}
+         , {auto_compile, true}
+         , {ct_hooks,     [{els_cth, #{uri => Uri, line => Line}}]}
+         ],
+  Result = ?MODULE:ct_run_test(Opts),
+  lager:info("CT Result: ~p", [Result]),
+  case Result of
+    {N, 0, {0, 0}} when N > 0 ->
+      publish_result(Uri, Line, ?DIAGNOSTIC_INFO, <<"Test passed!">>);
+    _ ->
+      %% In case of skipped or failed tests, the result is published
+      %% by the Common Test hook, so nothing to do here.
+      ok
+  end.
+
+-spec publish_result( uri()
+                    , pos_integer()
+                    , els_diagnostics:severity()
+                    , binary()) -> ok.
+publish_result(Uri, Line, Severity, Message) ->
+  Range = els_protocol:range(#{from => {Line, 1}, to => {Line + 1, 1}}),
+  Source = <<"Common Test">>,
+  D = els_diagnostics:make_diagnostic(Range, Message, Severity, Source),
+  els_diagnostics:publish(Uri, [D]),
+  ok.
+
+-spec ct_run_test([any()]) -> any().
+ct_run_test(Opts) ->
+  ct:run_test(Opts).

--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -32,7 +32,7 @@
 %%==============================================================================
 %% Callback Functions
 %%==============================================================================
--spec diagnostics(uri()) -> [diagnostic()].
+-spec diagnostics(uri()) -> [els_diagnostics:diagnostic()].
 diagnostics(Uri) ->
   case filename:extension(Uri) of
     <<".erl">> ->
@@ -62,7 +62,7 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec compile(uri()) -> [diagnostic()].
+-spec compile(uri()) -> [els_diagnostics:diagnostic()].
 compile(Uri) ->
   Dependencies = els_diagnostics_utils:dependencies(Uri),
   Path = els_utils:to_list(els_uri:path(Uri)),
@@ -74,7 +74,7 @@ compile(Uri) ->
         diagnostics(Path, ES, ?DIAGNOSTIC_ERROR)
   end.
 
--spec parse(uri()) -> [diagnostic()].
+-spec parse(uri()) -> [els_diagnostics:diagnostic()].
 parse(Uri) ->
   FileName = els_utils:to_list(els_uri:path(Uri)),
   {ok, Epp} = epp:open([ {name, FileName}
@@ -85,7 +85,7 @@ parse(Uri) ->
   epp:close(Epp),
   Res.
 
--spec parse_escript(uri()) -> [diagnostic()].
+-spec parse_escript(uri()) -> [els_diagnostics:diagnostic()].
 parse_escript(Uri) ->
   FileName = els_utils:to_list(els_uri:path(Uri)),
   case els_escript:extract(FileName) of
@@ -104,7 +104,8 @@ parse_escript(Uri) ->
 %% Compiler messages related to included files are grouped together
 %% and they are presented to the user by highlighting the line where
 %% the file inclusion happens.
--spec diagnostics(list(), [compiler_msg()], severity()) -> [diagnostic()].
+-spec diagnostics(list(), [compiler_msg()], els_diagnostics:severity()) ->
+        [els_diagnostics:diagnostic()].
 diagnostics(Path, List, Severity) ->
   Uri = els_uri:uri(els_utils:to_binary(Path)),
   {ok, [Document]} = els_dt_document:lookup(Uri),
@@ -124,7 +125,7 @@ diagnostics(Path, List, Severity) ->
                 , els_dt_document:item()
                 , module()
                 , string()
-                , integer()) -> diagnostic().
+                , integer()) -> els_diagnostics:diagnostic().
 diagnostic(Path, Path, Range, _Document, Module, Desc, Severity) ->
   %% The compiler message is related to the same .erl file, so
   %% preserve the location information.
@@ -138,7 +139,7 @@ diagnostic(_Path, MessagePath, Range, Document, Module, Desc0, Severity) ->
   diagnostic(InclusionRange, Module, Desc, Severity).
 
 -spec diagnostic(poi_range(), module(), string(), integer()) ->
-  diagnostic().
+        els_diagnostics:diagnostic().
 diagnostic(Range, Module, Desc, Severity) ->
   Message0 = lists:flatten(Module:format_error(Desc)),
   Message  = els_utils:to_binary(Message0),

--- a/src/els_cth.erl
+++ b/src/els_cth.erl
@@ -33,5 +33,5 @@ on_tc_skip(_Suite, _TestCase, {_ReasonType, Reason}, State) ->
 
 -spec publish_result(reason(), state()) -> ok.
 publish_result(Reason, #{options := #{uri := Uri, line := Line}}) ->
-  Message = unicode:characters_to_binary(io_lib:format("~p", [Reason])),
+  Message = els_utils:to_binary(io_lib:format("~p", [Reason])),
   els_command_ct_run_test:publish_result(Uri, Line, ?DIAGNOSTIC_ERROR, Message).

--- a/src/els_cth.erl
+++ b/src/els_cth.erl
@@ -1,0 +1,37 @@
+-module(els_cth).
+
+-export([init/2]).
+
+-export([ on_tc_fail/4
+        , on_tc_skip/4
+        ]).
+
+-include("erlang_ls.hrl").
+
+-type id() :: any().
+-type options() :: #{uri := uri(), line := pos_integer()}.
+-type suite() :: atom().
+-type testcase() :: atom() | tuple().
+-type state() :: #{options := options()}.
+-type skip_reason() :: {tc_auto_skip | tc_user_skip, any()}.
+-type fail_reason() :: any().
+-type reason() :: skip_reason() | fail_reason().
+
+-spec init(id(), options()) -> {ok, state()}.
+init(_Id, Opts) ->
+  {ok, #{options => Opts}}.
+
+-spec on_tc_fail(suite(), testcase(), fail_reason(), state()) -> state().
+on_tc_fail(_Suite, _TestCase, Reason, State) ->
+  publish_result(Reason, State),
+  State.
+
+-spec on_tc_skip(suite(), testcase(), skip_reason(), state()) -> state().
+on_tc_skip(_Suite, _TestCase, {_ReasonType, Reason}, State) ->
+  publish_result(Reason, State),
+  State.
+
+-spec publish_result(reason(), state()) -> ok.
+publish_result(Reason, #{options := #{uri := Uri, line := Line}}) ->
+  Message = unicode:characters_to_binary(io_lib:format("~p", [Reason])),
+  els_command_ct_run_test:publish_result(Uri, Line, ?DIAGNOSTIC_ERROR, Message).

--- a/src/els_diagnostics.erl
+++ b/src/els_diagnostics.erl
@@ -1,5 +1,5 @@
 %%==============================================================================
-%% An Erlang Behaviour to report diagnostics
+%% Behaviour and API to report diagnostics
 %%==============================================================================
 -module(els_diagnostics).
 
@@ -9,7 +9,55 @@
 -include("erlang_ls.hrl").
 
 %%==============================================================================
+%% Types
+%%==============================================================================
+-type diagnostic() :: #{ range              := range()
+                       , severity           => severity()
+                       , code               => number() | binary()
+                       , source             => binary()
+                       , message            := binary()
+                       , relatedInformation => [related_info()]
+                       }.
+-type related_info() :: #{ location := location()
+                         , message  := binary()
+                         }.
+-type severity() :: ?DIAGNOSTIC_ERROR
+                  | ?DIAGNOSTIC_WARNING
+                  | ?DIAGNOSTIC_INFO
+                  | ?DIAGNOSTIC_HINT.
+-export_type([ diagnostic/0
+             , severity/0
+             ]).
+
+%%==============================================================================
 %% Callback Functions Definitions
 %%==============================================================================
 -callback diagnostics(uri()) -> [diagnostic()].
 -callback source()           -> binary().
+
+%%==============================================================================
+%% API
+%%==============================================================================
+-export([ make_diagnostic/4
+        , publish/2
+        ]).
+
+%%==============================================================================
+%% API
+%%==============================================================================
+
+-spec make_diagnostic(range(), binary(), severity(), binary()) -> diagnostic().
+make_diagnostic(Range, Message, Severity, Source) ->
+  #{ range    => Range
+   , message  => Message
+   , severity => Severity
+   , source   => Source
+   }.
+
+-spec publish(uri(), [diagnostic()]) -> ok.
+publish(Uri, Diagnostics) ->
+  Method = <<"textDocument/publishDiagnostics">>,
+  Params = #{ uri         => Uri
+            , diagnostics => Diagnostics
+            },
+  els_server:send_notification(Method, Params).

--- a/src/els_dialyzer_diagnostics.erl
+++ b/src/els_dialyzer_diagnostics.erl
@@ -23,7 +23,7 @@
 %%==============================================================================
 %% Callback Functions
 %%==============================================================================
--spec diagnostics(uri()) -> [diagnostic()].
+-spec diagnostics(uri()) -> [els_diagnostics:diagnostic()].
 diagnostics(Uri) ->
   Path = els_uri:path(Uri),
   case els_config:get(plt_path) of
@@ -52,7 +52,8 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec diagnostic({any(), {any(), integer()}, any()}) -> diagnostic().
+-spec diagnostic({any(), {any(), integer()}, any()}) ->
+        els_diagnostics:diagnostic().
 diagnostic({_, {_, Line}, _} = Warning) ->
   Range    = els_protocol:range(#{ from => {Line, 1}
                                  , to   => {Line + 1, 1}

--- a/src/els_elvis_diagnostics.erl
+++ b/src/els_elvis_diagnostics.erl
@@ -23,7 +23,7 @@
 %%==============================================================================
 %% Callback Functions
 %%==============================================================================
--spec diagnostics(uri()) -> [diagnostic()].
+-spec diagnostics(uri()) -> [els_diagnostics:diagnostic()].
 diagnostics(Uri) ->
   case els_utils:project_relative(Uri) of
     {error, not_relative} -> [];

--- a/src/els_execute_command_provider.erl
+++ b/src/els_execute_command_provider.erl
@@ -19,7 +19,9 @@ is_enabled() -> true.
 -spec options() -> map().
 options() ->
   #{ commands => [ els_command:with_prefix(<<"replace-lines">>)
-                 , els_command:with_prefix(<<"server-info">>)] }.
+                 , els_command:with_prefix(<<"server-info">>)
+                 , els_command:with_prefix(<<"ct-run-test">>)
+                 ] }.
 
 -spec handle_request(any(), els_provider:state()) ->
   {any(), els_provider:state()}.
@@ -39,7 +41,7 @@ execute_command(<<"replace-lines">>
                , [#{ <<"uri">>   := Uri
                    , <<"lines">> := Lines
                    , <<"from">>  := LineFrom
-                   , <<"to">>    := LineTo }] = _Arguments) ->
+                   , <<"to">>    := LineTo }]) ->
   Method = <<"workspace/applyEdit">>,
   Params = #{ edit =>
                   els_text_edit:edit_replace_text(Uri, Lines, LineFrom, LineTo)
@@ -63,6 +65,9 @@ execute_command(<<"server-info">>, _Arguments) ->
                                #{ type => ?MESSAGE_TYPE_INFO,
                                   message => Message
                                 }),
+  [];
+execute_command(<<"ct-run-test">>, [Params]) ->
+  els_command_ct_run_test:execute(Params),
   [];
 execute_command(Command, Arguments) ->
   lager:info("Unsupported command: [Command=~p] [Arguments=~p]"

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -3,7 +3,6 @@
 -include("erlang_ls.hrl").
 
 -export([ compare/2
-        , line/1
         , range/4
         ]).
 
@@ -17,12 +16,6 @@ compare( #{from := FromA, to := ToA}
   true;
 compare(_, _) ->
   false.
-
-%% @doc Return a range data structure for a given line number
--spec line(non_neg_integer()) -> range().
-line(Line) ->
-  Range = #{from => {Line, 1}, to => {Line + 1, 1}},
-  els_protocol:range(Range).
 
 -spec range(pos() | {pos(), pos()}, poi_kind(), any(), any()) -> poi_range().
 range({{Line, Column}, {ToLine, ToColumn}}, Name, _, _Data)

--- a/src/els_text_synchronization.erl
+++ b/src/els_text_synchronization.erl
@@ -47,7 +47,8 @@ generate_diagnostics(Uri) ->
   erlang:spawn(?MODULE, diagnostics, [Uri, Async, Diagnostics]),
   ok.
 
--spec diagnostics(uri(), [module()], [diagnostic()]) -> [diagnostic()].
+-spec diagnostics(uri(), [module()], [els_diagnostics:diagnostic()]) ->
+        [els_diagnostics:diagnostic()].
 diagnostics(Uri, Modules, Previous) ->
   Diagnostics = [apply(M, diagnostics, [Uri]) || M <- Modules],
   AllDiagnostics = lists:append([Previous | Diagnostics]),
@@ -58,7 +59,7 @@ diagnostics(Uri, Modules, Previous) ->
   els_server:send_notification(Method, Params),
   AllDiagnostics.
 
--spec maybe_compile_and_load(uri(), [diagnostic()]) -> ok.
+-spec maybe_compile_and_load(uri(), [els_diagnostics:diagnostic()]) -> ok.
 maybe_compile_and_load(Uri, [] = _CDiagnostics) ->
   case els_config:get(code_reload) of
     #{"node" := NodeStr} ->

--- a/test/els_code_lens_SUITE.erl
+++ b/test/els_code_lens_SUITE.erl
@@ -13,6 +13,7 @@
 %% Test cases
 -export([ default_lenses/1
         , server_info/1
+        , ct_run_test/1
         ]).
 
 %%==============================================================================
@@ -93,5 +94,29 @@ server_info(Config) ->
              start => #{character => 0, line => 0}}
        }
     ],
+  ?assertEqual(Expected, Result),
+  ok.
+
+-spec ct_run_test(config()) -> ok.
+ct_run_test(Config) ->
+  Uri = ?config(sample_SUITE_uri, Config),
+  PrefixedCommand = els_command:with_prefix(<<"ct-run-test">>),
+  #{result := Result} = els_client:document_codelens(Uri),
+  Expected = [ #{ command => #{ arguments => [ #{ arity => 1
+                                                , function => <<"one">>
+                                                , line => 58
+                                                , module => <<"sample_SUITE">>
+                                                , uri => Uri
+                                                }]
+                              , command => PrefixedCommand
+                              , title => <<"Run test">>
+                              }
+                , data => []
+                , range => #{ 'end' => #{ character => 3
+                                        , line => 57
+                                        }
+                            , start => #{ character => 0
+                                        , line => 57
+                                        }}}],
   ?assertEqual(Expected, Result),
   ok.

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -26,7 +26,7 @@
 %% Types
 %%==============================================================================
 -type config() :: [{atom(), any()}].
--type file_type() :: src | include | escript.
+-type file_type() :: src | test | include | escript.
 
 %%==============================================================================
 %% API
@@ -74,11 +74,14 @@ init_per_testcase(_TestCase, Config) ->
   application:set_env(erlang_ls, indexing_enabled, false),
   SrcConfig = lists:flatten(
                 [index_file(RootPath, src, S) || S <- sources()]),
+  TestConfig = lists:flatten(
+                 [index_file(RootPath, test, S) || S <- tests()]),
   EscriptConfig = lists:flatten(
                     [index_file(RootPath, escript, S) || S <- escripts()]),
   IncludeConfig = lists:flatten(
                     [index_file(RootPath, include, S) || S <- includes()]),
   lists:append( [ SrcConfig
+                , TestConfig
                 , EscriptConfig
                 , IncludeConfig
                 , [ {started, Started}
@@ -152,6 +155,10 @@ sources() ->
   , my_gen_server
   ].
 
+tests() ->
+  [ sample_SUITE
+  ].
+
 -spec escripts() -> [atom()].
 escripts() ->
   [ diagnostics
@@ -187,12 +194,15 @@ index_file(RootPath, Type, Id) ->
 
 -spec config_id(atom(), file_type()) -> atom().
 config_id(Id, src) -> Id;
+config_id(Id, test) -> Id;
 config_id(Id, include) -> list_to_atom(atom_to_list(Id) ++ "_h");
 config_id(Id, escript) -> list_to_atom(atom_to_list(Id) ++ "_escript").
 
 -spec directory(file_type()) -> binary().
 directory(src) ->
   <<"src">>;
+directory(test) ->
+  <<"test">>;
 directory(include) ->
   <<"include">>;
 directory(escript) ->
@@ -200,6 +210,8 @@ directory(escript) ->
 
 -spec extension(file_type()) -> binary().
 extension(src) ->
+  <<".erl">>;
+extension(test) ->
   <<".erl">>;
 extension(include) ->
   <<".hrl">>;

--- a/test/prop_statem.erl
+++ b/test/prop_statem.erl
@@ -96,7 +96,9 @@ initialize_post(#{shutdown := true}, _Args, Res) ->
 initialize_post(_S, _Args, Res) ->
   PrefixedCommands
     = [ els_command:with_prefix(<<"replace-lines">>)
-      , els_command:with_prefix(<<"server-info">>)],
+      , els_command:with_prefix(<<"server-info">>)
+      , els_command:with_prefix(<<"ct-run-test">>)
+      ],
   Expected = #{ capabilities =>
                   #{ hoverProvider => true
                    , completionProvider =>


### PR DESCRIPTION
### Description

This PR introduces a new _Code Lens_ and a _Command_, named "ct-run-test", through which is now possible to run Common Test testcases by clicking on a button from a test suite.

The code lens is activated automatically whenever the `ct.hrl` header is included in a module. The lens will be enabled for all functions of arity `1` in the test suite and a _blacklist_ avoids functions such as `init_per_suite/1` or `end_per_suite/` to be included.

The CT test is executed as a _background job_ and a CT hook is used to report diagnostics in case of failed or skipped tests.

I used this opportunity to refine the _code lens_ behaviour, introducing some extra callbacks that should hopefully simplify the creation of new code lenses. I will document the behaviour properly once the API is settled.

More things need to be implemented or fixed, but I believe this PR can give us a starting point.

Finally, I moved some more type definitions away from the `erlang_ls.hrl`. Having them as part of individual modules give us a nicer way to interact with types (e.g. via type completion) and avoids collisions between names. I plan to go in this direction for the whole project.

Fixes #604 .
