### PR TITLE
[#606] Precalculate specs

### DIFF
--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 -define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"6">>).
+-define(DB_SCHEMA_VSN, <<"7">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================

--- a/src/els_dt_signatures.erl
+++ b/src/els_dt_signatures.erl
@@ -31,12 +31,12 @@
 %%==============================================================================
 
 -record(els_dt_signatures, { mfa  :: mfa()  | '_'
-                           , tree :: tree()
+                           , spec :: binary()
                            }).
 -type els_dt_signatures() :: #els_dt_signatures{}.
 
 -type item() :: #{ mfa  := mfa()
-                 , tree := tree()
+                 , spec := binary()
                  }.
 -export_type([ item/0 ]).
 
@@ -61,13 +61,13 @@ opts() ->
 %%==============================================================================
 
 -spec from_item(item()) -> els_dt_signatures().
-from_item(#{ mfa := MFA, tree := Tree }) ->
-  #els_dt_signatures{ mfa = MFA, tree = Tree }.
+from_item(#{ mfa := MFA, spec := Spec }) ->
+  #els_dt_signatures{ mfa = MFA, spec = Spec }.
 
 -spec to_item(els_dt_signatures()) -> item().
-to_item(#els_dt_signatures{ mfa = MFA, tree = Tree }) ->
+to_item(#els_dt_signatures{ mfa = MFA, spec = Spec }) ->
   #{ mfa  => MFA
-   , tree => Tree
+   , spec => Spec
    }.
 
 -spec insert(item()) -> ok | {error, any()}.

--- a/src/els_hover_provider.erl
+++ b/src/els_hover_provider.erl
@@ -115,9 +115,8 @@ docs_from_src(M, F, A) ->
 -spec specs(atom(), atom(), non_neg_integer()) -> binary().
 specs(M, F, A) ->
   case els_dt_signatures:lookup({M, F, A}) of
-    {ok, [#{tree := Tree}]} ->
-      Specs = erl_prettypr:format(Tree),
-      els_utils:to_binary(Specs);
+    {ok, [#{spec := Spec}]} ->
+      Spec;
     {ok, []} ->
       <<>>
   end.

--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -77,10 +77,9 @@ do_index(#{uri := Uri, id := Id, kind := Kind} = Document, Mode) ->
 
 -spec index_signatures(els_dt_document:item()) -> ok.
 index_signatures(#{id := Id} = Document) ->
-  %% Signatures
   Specs  = els_dt_document:pois(Document, [spec]),
-  [ els_dt_signatures:insert(#{mfa => {Id, F, A}, tree => Tree})
-    || #{id := {F, A}, data := Tree} <- Specs
+  [ els_dt_signatures:insert(#{ mfa => {Id, F, A}, spec => Spec})
+    || #{id := {F, A}, data := Spec} <- Specs
   ],
   ok.
 

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -88,7 +88,7 @@ find_attribute_pois(Tree, Tokens) ->
         {spec, {spec, {{F, A}, FTs}}} ->
           From = erl_syntax:get_pos(Tree),
           To   = erl_scan:location(lists:last(Tokens)),
-          Data = els_utils:to_binary(erl_prettypr:format(Tree)),
+          Data = pretty_print_spec(Tree),
           [ poi({From, To}, spec, {F, A}, Data)
           | lists:flatten([find_spec_points_of_interest(FT) || FT <- FTs])
           ];
@@ -472,3 +472,12 @@ subtrees(Tree, attribute) ->
   end;
 subtrees(Tree, _) ->
   erl_syntax:subtrees(Tree).
+
+-spec pretty_print_spec(tree()) -> binary().
+pretty_print_spec(Tree) ->
+  try
+    els_utils:to_binary(erl_prettypr:format(Tree))
+ catch
+   _:_:_ ->
+     <<>>
+ end.

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -88,7 +88,7 @@ find_attribute_pois(Tree, Tokens) ->
         {spec, {spec, {{F, A}, FTs}}} ->
           From = erl_syntax:get_pos(Tree),
           To   = erl_scan:location(lists:last(Tokens)),
-          [ poi({From, To}, spec, {F, A}, Tree)
+          [ poi({From, To}, spec, {F, A})
           | lists:flatten([find_spec_points_of_interest(FT) || FT <- FTs])
           ];
         {export_type, {export_type, Exports}} ->

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -88,7 +88,8 @@ find_attribute_pois(Tree, Tokens) ->
         {spec, {spec, {{F, A}, FTs}}} ->
           From = erl_syntax:get_pos(Tree),
           To   = erl_scan:location(lists:last(Tokens)),
-          [ poi({From, To}, spec, {F, A})
+          Data = els_utils:to_binary(erl_prettypr:format(Tree)),
+          [ poi({From, To}, spec, {F, A}, Data)
           | lists:flatten([find_spec_points_of_interest(FT) || FT <- FTs])
           ];
         {export_type, {export_type, Exports}} ->


### PR DESCRIPTION
### Description

In this PR we pre-calculate the pretty-printed version of the specs during indexing. This avoids to store (sometimes huge) syntax trees in the DB and un-necessary recalculation of those specs. I realized we store the specs twice, both in the _document_ table and the _signatures_ table. For the time being I'm leaving things as they are (after all the _signatures_ table is just an index), but we should consider storing them once.

I tried this change both in the `erlang_ls` codebase and in a bigger codebase (1.5 millions lines of code). Here are some number.

#### Erlang LS

|               | Before | After  |
|---------------|--------|--------|
| Document DB   | 195 MB | 165 MB |
| Signatures DB | 31 MB  | 1MB    |

#### Bigger Code Base

|               | Before | After  |
|---------------|--------|--------|
| Document DB   | 577 MB | 505 MB |
| Signatures DB | 97 MB  | 4 MB   |

Not entirely sure why, for the larger code base, the Signatures DB shrinked more than the document. Number of table entries is the same before/after.
There were no significant difference in the indexing time.
 
Fixes #606 .
