### PR TITLE
[#589] Produce and publish edoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: rebar3 do cover, coveralls send
+    - name: Produce Documentation
+      run: rebar3 edoc
+    - name: Publish Documentation
+      uses: actions/upload-artifact@v1
+      with:
+        name: edoc
+        path: doc


### PR DESCRIPTION
### Description

For now let's at least build and publish the docs as an artifact. We can publish the `master` docs as a static website later on, if we want.

Fixes #589 .
