### PR TITLE
[#156] Xref diagnostics

### DIFF
--- a/priv/code_navigation/src/diagnostics_xref.erl
+++ b/priv/code_navigation/src/diagnostics_xref.erl
@@ -3,4 +3,8 @@
 -export([ main/0 ]).
 
 main() ->
-  lists:map(1, 2, 3).
+  lists:map(1, 2, 3),
+  non_existing() ++ existing().
+
+existing() ->
+  lists:seq(1, 3).

--- a/priv/code_navigation/src/diagnostics_xref.erl
+++ b/priv/code_navigation/src/diagnostics_xref.erl
@@ -1,0 +1,6 @@
+-module(diagnostics_xref).
+
+-export([ main/0 ]).
+
+main() ->
+  lists:map(1, 2, 3).

--- a/src/els_diagnostics.erl
+++ b/src/els_diagnostics.erl
@@ -59,6 +59,7 @@ available_diagnostics() ->
   [ <<"compiler">>
   , <<"dialyzer">>
   , <<"elvis">>
+  , <<"xref">>
   ].
 
 -spec default_diagnostics() -> [diagnostic_id()].

--- a/src/els_xref_diagnostics.erl
+++ b/src/els_xref_diagnostics.erl
@@ -47,8 +47,14 @@ source() ->
 %% Internal Functions
 %%==============================================================================
 -spec make_diagnostic(poi()) -> els_diagnostics:diagnostic().
-make_diagnostic(#{range := Range}) ->
-  Message = <<"Cannot find definition for this function">>,
+make_diagnostic(#{range := Range, id := Id}) ->
+  Function = case Id of
+               {F, A} -> lists:flatten(io_lib:format("~p/~p", [F, A]));
+               {M, F, A} -> lists:flatten(io_lib:format("~p:~p/~p", [M, F, A]))
+             end,
+  Message = els_utils:to_binary(
+              io_lib:format( "Cannot find definition for function ~s"
+                           , [Function])),
   Severity = ?DIAGNOSTIC_ERROR,
   els_diagnostics:make_diagnostic( els_protocol:range(Range)
                                  , Message

--- a/src/els_xref_diagnostics.erl
+++ b/src/els_xref_diagnostics.erl
@@ -1,0 +1,65 @@
+%%==============================================================================
+%% Xref diagnostics
+%%==============================================================================
+-module(els_xref_diagnostics).
+
+%%==============================================================================
+%% Behaviours
+%%==============================================================================
+-behaviour(els_diagnostics).
+
+%%==============================================================================
+%% Exports
+%%==============================================================================
+-export([ is_default/0
+        , run/1
+        , source/0
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("erlang_ls.hrl").
+
+%%==============================================================================
+%% Callback Functions
+%%==============================================================================
+
+-spec is_default() -> boolean().
+is_default() ->
+  true.
+
+-spec run(uri()) -> [els_diagnostics:diagnostic()].
+run(Uri) ->
+  {ok, [Document]} = els_dt_document:lookup(Uri),
+  POIs = els_dt_document:pois(Document, [ application
+                                        , implicit_fun
+                                        , import_entry
+                                        , export_entry
+                                        ]),
+  [make_diagnostic(POI) || POI <- POIs, not has_definition(POI, Document)].
+
+-spec source() -> binary().
+source() ->
+  <<"XRef">>.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+-spec make_diagnostic(poi()) -> els_diagnostics:diagnostic().
+make_diagnostic(#{range := Range}) ->
+  Message = <<"Cannot find definition for this function">>,
+  Severity = ?DIAGNOSTIC_ERROR,
+  els_diagnostics:make_diagnostic( els_protocol:range(Range)
+                                 , Message
+                                 , Severity
+                                 , source()).
+
+-spec has_definition(poi(), els_dt_document:item()) -> boolean().
+has_definition(POI, #{uri := Uri}) ->
+  case els_code_navigation:goto_definition(Uri, POI) of
+    {ok, _Uri, _POI} ->
+      true;
+    {error, _Error} ->
+      false
+  end.

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -286,19 +286,22 @@ xref(Config) ->
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
   Diagnostics = els_mock_diagnostics:wait_until_complete(),
-  Expected = [ #{ message => <<"Cannot find definition for this function">>
+  Expected = [ #{ message =>
+                    <<"Cannot find definition for function lists:map/3">>
+                , range =>
+                    #{ 'end' => #{character => 11, line => 5}
+                     , start => #{character => 2, line => 5}}
+                , severity => 1, source => <<"XRef">>}
+             , #{ message =>
+                    <<"Cannot find definition for function non_existing/0">>
                 , range =>
                     #{ 'end' => #{character => 14, line => 6}
                      , start => #{character => 2, line => 6}}
                 , severity => 1
                 , source => <<"XRef">>
                 }
-             , #{ message => <<"Cannot find definition for this function">>
-                , range =>
-                    #{ 'end' => #{character => 11, line => 5}
-                     , start => #{character => 2, line => 5}}
-                , severity => 1, source => <<"XRef">>},
-               #{ message => <<"function non_existing/0 undefined">>
+             , #{ message =>
+                    <<"function non_existing/0 undefined">>
                 , range =>
                     #{ 'end' => #{character => 0, line => 7}
                      , start => #{character => 0, line => 6}}
@@ -306,7 +309,8 @@ xref(Config) ->
                 , source => <<"Compiler">>
                 }
              ],
-  ?assertEqual(Expected, Diagnostics),
+  F = fun(#{message := M1}, #{message := M2}) -> M1 =< M2 end,
+  ?assertEqual(Expected, lists:sort(F, Diagnostics)),
   ok.
 
 %%==============================================================================

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -286,10 +286,26 @@ xref(Config) ->
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
   Diagnostics = els_mock_diagnostics:wait_until_complete(),
-  Expected = [#{ message => <<"Cannot find definition for this function">>
-               , range => #{ 'end' => #{character => 11, line => 5}
-                           , start => #{character => 2, line => 5}}
-               , severity => 1, source => <<"XRef">>}],
+  Expected = [ #{ message => <<"Cannot find definition for this function">>
+                , range =>
+                    #{ 'end' => #{character => 14, line => 6}
+                     , start => #{character => 2, line => 6}}
+                , severity => 1
+                , source => <<"XRef">>
+                }
+             , #{ message => <<"Cannot find definition for this function">>
+                , range =>
+                    #{ 'end' => #{character => 11, line => 5}
+                     , start => #{character => 2, line => 5}}
+                , severity => 1, source => <<"XRef">>},
+               #{ message => <<"function non_existing/0 undefined">>
+                , range =>
+                    #{ 'end' => #{character => 0, line => 7}
+                     , start => #{character => 0, line => 6}}
+                , severity => 1
+                , source => <<"Compiler">>
+                }
+             ],
   ?assertEqual(Expected, Diagnostics),
   ok.
 

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -149,6 +149,7 @@ sources() ->
   , diagnostics_parse_transform
   , diagnostics_parse_transform_usage
   , diagnostics_parse_transform_usage_included
+  , diagnostics_xref
   , elvis_diagnostics
   , format_input
   , my_gen_server


### PR DESCRIPTION
### Description

_Xref_ diagnostics will report an error for all those cases where a function _application_, an _implicit fun_, an _import_ or _export_ entry does not have a corresponding definition in the server, resembling what `xref` would do. The advantage, compared to `xref`, is that these diagnostics operate on the POI/DB level and don't require _binaries_ or `debug_info`.

Based on top of  #616 , which should be merged first (and this one rebased on top of the latest master).

Fixes #156.