### PR TITLE
[#622] Use general provider consistently

### DIFF
--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -28,6 +28,15 @@
                                                        | null
                               }.
 -type initialize_result() :: #{ capabilities => server_capabilities() }.
+-type initialized_request() :: {initialized, initialized_params()}.
+-type initialized_params() :: #{}.
+-type initialized_result() :: null.
+-type shutdown_request() :: {shutdown, shutdown_params()}.
+-type shutdown_params() :: #{}.
+-type shutdown_result() :: null.
+-type exit_request() :: {exit, exit_params()}.
+-type exit_params() :: #{status => atom()}.
+-type exit_result() :: null.
 -type state() :: any().
 
 %%==============================================================================
@@ -37,8 +46,17 @@
 -spec is_enabled() -> boolean().
 is_enabled() -> true.
 
--spec handle_request(initialize_request(), state()) ->
-        {initialize_result(), state()}.
+-spec handle_request( initialize_request()
+                    | initialized_request()
+                    | shutdown_request()
+                    | exit_request()
+                    , state()) ->
+        { initialize_result()
+        | initialized_result()
+        | shutdown_result()
+        | exit_result()
+        , state()
+        }.
 handle_request({initialize, Params}, State) ->
   #{ <<"rootUri">> := RootUri0
    , <<"capabilities">> := Capabilities
@@ -65,7 +83,19 @@ handle_request({initialize, Params}, State) ->
     true  -> els_indexing:start();
     false -> lager:info("Skipping Indexing (disabled via InitOptions)")
   end,
-  {server_capabilities(), State}.
+  {server_capabilities(), State};
+handle_request({initialized, _Params}, State) ->
+  {null, State};
+handle_request({shutdown, _Params}, State) ->
+  {null, State};
+handle_request({exit, #{status := Status}}, State) ->
+  lager:info("Language server stopping..."),
+  ExitCode = case Status of
+               shutdown -> 0;
+               _        -> 1
+             end,
+  els_utils:halt(ExitCode),
+  {null, State}.
 
 %%==============================================================================
 %% API

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -5,12 +5,11 @@
 -export([ dispatch/4
         ]).
 
--export([ initialized/2
+-export([ exit/2
+        , initialize/2
+        , initialized/2
         , shutdown/2
-        , exit/2
-        ]).
-
--export([ textdocument_completion/2
+        , textdocument_completion/2
         , textdocument_didopen/2
         , textdocument_didchange/2
         , textdocument_didsave/2
@@ -85,10 +84,7 @@ do_dispatch(_Function, _Params, #{status := shutdown} = State) ->
              },
   {error, Result, State};
 do_dispatch(initialize, Params, State) ->
-  Provider = els_general_provider,
-  Request  = {initialize, Params},
-  Response = els_provider:handle_request(Provider, Request),
-  {response, Response, State#{status => initialized}};
+  els_methods:initialize(Params, State);
 do_dispatch(Function, Params, #{status := initialized} = State) ->
   els_methods:Function(Params, State);
 do_dispatch(_Function, _Params, State) ->
@@ -118,11 +114,25 @@ method_to_function_name(Method) ->
   binary_to_atom(Binary, utf8).
 
 %%==============================================================================
+%% Initialize
+%%==============================================================================
+
+-spec initialize(params(), state()) -> result().
+initialize(Params, State) ->
+  Provider = els_general_provider,
+  Request  = {initialize, Params},
+  Response = els_provider:handle_request(Provider, Request),
+  {response, Response, State#{status => initialized}}.
+
+%%==============================================================================
 %% Initialized
 %%==============================================================================
 
 -spec initialized(params(), state()) -> result().
-initialized(_Params, State) ->
+initialized(Params, State) ->
+  Provider = els_general_provider,
+  Request  = {initialized, Params},
+  _Response = els_provider:handle_request(Provider, Request),
   %% Report to the user the server version
   {ok, Version} = application:get_key(?APP, vsn),
   lager:info("initialized: [App=~p] [Version=~p]", [?APP, Version]),
@@ -141,8 +151,11 @@ initialized(_Params, State) ->
 %%==============================================================================
 
 -spec shutdown(params(), state()) -> result().
-shutdown(_Params, State) ->
-  {response, null, State#{status => shutdown}}.
+shutdown(Params, State) ->
+  Provider = els_general_provider,
+  Request  = {shutdown, Params},
+  Response = els_provider:handle_request(Provider, Request),
+  {response, Response, State#{status => shutdown}}.
 
 %%==============================================================================
 %% exit
@@ -150,12 +163,9 @@ shutdown(_Params, State) ->
 
 -spec exit(params(), state()) -> no_return().
 exit(_Params, State) ->
-  lager:info("Language server stopping..."),
-  ExitCode = case maps:get(status, State, undefined) of
-               shutdown -> 0;
-               _        -> 1
-             end,
-  els_utils:halt(ExitCode),
+  Provider = els_general_provider,
+  Request  = {exit, #{status => maps:get(status, State, undefined)}},
+  _Response = els_provider:handle_request(Provider, Request),
   {noresponse, #{}}.
 
 %%==============================================================================


### PR DESCRIPTION
### Description

The major advantage of this PR (apart from having a more consistent codebase in the `els_methods` module) is to serialize _general_ requests via the dedicated provider. After moving only the `initialize` request, I noticed some flakyness in the proper tests which was due to these messages being handled in the wrong order.

Fixes #622 .
