### PR TITLE
Unify ElsClient:send/2, ElsTransport:send/2 types

### DIFF
--- a/src/els_client.erl
+++ b/src/els_client.erl
@@ -4,7 +4,7 @@
 -module(els_client).
 
 -callback start_link(any())     -> {ok, pid()}.
--callback send(pid(), iolist()) -> ok.
+-callback send(pid(), binary()) -> ok.
 
 %%==============================================================================
 %% Behaviours

--- a/src/els_protocol.erl
+++ b/src/els_protocol.erl
@@ -25,7 +25,7 @@
 %%==============================================================================
 %% Messaging API
 %%==============================================================================
--spec notification(binary(), any()) -> iolist().
+-spec notification(binary(), any()) -> binary().
 notification(Method, Params) ->
   Message = #{ jsonrpc => ?JSONRPC_VSN
              , method  => Method
@@ -33,7 +33,7 @@ notification(Method, Params) ->
              },
   content(jsx:encode(Message)).
 
--spec request(number(), binary(), any()) -> iolist().
+-spec request(number(), binary(), any()) -> binary().
 request(RequestId, Method, Params) ->
   Message = #{ jsonrpc => ?JSONRPC_VSN
              , method  => Method
@@ -42,7 +42,7 @@ request(RequestId, Method, Params) ->
              },
   content(jsx:encode(Message)).
 
--spec response(number(), any()) -> iolist().
+-spec response(number(), any()) -> binary().
 response(RequestId, Result) ->
   Message = #{ jsonrpc => ?JSONRPC_VSN
              , id      => RequestId
@@ -51,7 +51,7 @@ response(RequestId, Result) ->
   lager:debug("[Response] [message=~p]", [Message]),
   content(jsx:encode(Message)).
 
--spec error(number(), any()) -> iolist().
+-spec error(number(), any()) -> binary().
 error(RequestId, Error) ->
   Message = #{ jsonrpc => ?JSONRPC_VSN
              , id      => RequestId
@@ -72,9 +72,9 @@ range(#{ from := {FromL, FromC}, to := {ToL, ToC} }) ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec content(binary()) -> iolist().
+-spec content(binary()) -> binary().
 content(Body) ->
-  [headers(Body), "\r\n", Body].
+els_utils:to_binary([headers(Body), "\r\n", Body]).
 
 -spec headers(binary()) -> iolist().
 headers(Body) ->

--- a/src/els_server.erl
+++ b/src/els_server.erl
@@ -180,6 +180,6 @@ do_send_request(Method, Params, #state{request_id = RequestId0} = State0) ->
   send(Request, State0),
   State0#state{request_id = RequestId}.
 
--spec send(iolist(), state()) -> ok.
+-spec send(binary(), state()) -> ok.
 send(Payload, #state{transport = T, connection = C}) ->
   T:send(C, Payload).

--- a/src/els_stdio_client.erl
+++ b/src/els_stdio_client.erl
@@ -33,6 +33,6 @@ start_link(#{io_device := IoDevice}) ->
   _Pid = proc_lib:spawn_link(els_stdio, loop, Args),
   {ok, IoDevice}.
 
--spec send(pid(), iolist()) -> ok.
+-spec send(pid(), binary()) -> ok.
 send(Server, Payload) ->
-  io:format(Server, els_utils:to_binary(Payload), []).
+  io:format(Server, Payload, []).

--- a/src/els_tcp_client.erl
+++ b/src/els_tcp_client.erl
@@ -49,7 +49,7 @@ init(#{host := Host, port := Port}) ->
   {ok, Socket} = gen_tcp:connect(Host, Port, default_tcp_opts()),
   {ok, #{socket => Socket, buffer => <<>>}}.
 
--spec send(pid(), iolist()) -> ok.
+-spec send(pid(), binary()) -> ok.
 send(Server, Payload) ->
   gen_server:call(Server, {send, Payload}).
 


### PR DESCRIPTION

### Description

Enter a description of your changes here.

Fixes #613.


Them not being the same causes confusion - both `els_client` and `els_server` use the protocol, but their message sending callbacks have slightly different type signatures. This difference is typically unimportant, but in the case of OTP21.0 `io:format` (used by `els_stdio`) it crashes, and "rightfully", as its spec does not include `iolist()`.

It's been pointed out that in practice the code does work in most other OTP versions but the disparity is still incorrect in its own right.