### PR TITLE
[#626] Add code lens which shows behaviour usages

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -565,6 +565,7 @@
 -type poi_kind()  :: application
                    | atom
                    | behaviour
+                   | callback
                    | define
                    | export
                    | export_entry

--- a/src/els_code_lens.erl
+++ b/src/els_code_lens.erl
@@ -52,6 +52,7 @@
 available_lenses() ->
   [ <<"ct-run-test">>
   , <<"server-info">>
+  , <<"show-behaviour-usages">>
   ].
 
 -spec default_lenses() -> [lens_id()].

--- a/src/els_code_lens_show_behaviour_usages.erl
+++ b/src/els_code_lens_show_behaviour_usages.erl
@@ -1,0 +1,46 @@
+%%==============================================================================
+%% Code Lens: show_behaviour_usages
+%%==============================================================================
+
+-module(els_code_lens_show_behaviour_usages).
+
+-behaviour(els_code_lens).
+-export([ command/1
+        , command_args/2
+        , is_default/0
+        , pois/1
+        , precondition/1
+        , title/1
+        ]).
+
+-include("erlang_ls.hrl").
+
+-spec command(poi()) -> els_command:command_id().
+command(_POI) ->
+  <<"show-behaviour-usages">>.
+
+-spec command_args(els_dt_document:item(), poi()) -> [any()].
+command_args(_Document, _POI) ->
+  [].
+
+-spec is_default() -> boolean().
+is_default() ->
+  true.
+
+-spec precondition(els_dt_document:item()) -> boolean().
+precondition(Document) ->
+  %% A behaviour is defined by the presence of one more callback
+  %% attributes.
+  Callbacks = els_dt_document:pois(Document, [callback]),
+  length(Callbacks) > 0.
+
+-spec pois(els_dt_document:item()) -> [poi()].
+pois(Document) ->
+  els_dt_document:pois(Document, [module]).
+
+-spec title(poi()) -> binary().
+title(#{ id := Id }) ->
+  {ok, Refs} = els_dt_references:find_by_id(behaviour, Id),
+  Count = length(Refs),
+  Msg = io_lib:format("Behaviour used in ~p place(s)", [Count]),
+  els_utils:to_binary(Msg).

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 -define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"7">>).
+-define(DB_SCHEMA_VSN, <<"8">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================

--- a/src/els_dt_references.erl
+++ b/src/els_dt_references.erl
@@ -124,4 +124,6 @@ kind_to_category(Kind) when Kind =:= macro;
 kind_to_category(Kind) when Kind =:= record_expr;
                             Kind =:= record;
                             Kind =:= record_access ->
-  record.
+  record;
+kind_to_category(Kind) when Kind =:= behaviour ->
+  behaviour.

--- a/src/els_execute_command_provider.erl
+++ b/src/els_execute_command_provider.erl
@@ -23,6 +23,7 @@ options() ->
   #{ commands => [ els_command:with_prefix(<<"replace-lines">>)
                  , els_command:with_prefix(<<"server-info">>)
                  , els_command:with_prefix(<<"ct-run-test">>)
+                 , els_command:with_prefix(<<"show-behaviour-usages">>)
                  ] }.
 
 -spec handle_request(any(), state()) -> {any(), state()}.
@@ -69,6 +70,8 @@ execute_command(<<"server-info">>, _Arguments) ->
   [];
 execute_command(<<"ct-run-test">>, [Params]) ->
   els_command_ct_run_test:execute(Params),
+  [];
+execute_command(<<"show-behaviour-usages">>, [_Params]) ->
   [];
 execute_command(Command, Arguments) ->
   lager:info("Unsupported command: [Command=~p] [Arguments=~p]"

--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -87,6 +87,7 @@ index_signatures(#{id := Id} = Document) ->
 index_references(#{uri := Uri} = Document, 'deep') ->
   %% References
   POIs  = els_dt_document:pois(Document, [ application
+                                         , behaviour
                                          , implicit_fun
                                          , macro
                                          , record_access
@@ -155,7 +156,9 @@ register_reference(Uri, #{kind := Kind, id := Id, range := Range})
        Kind =:= application;
        Kind =:= implicit_fun;
        %% Type
-       Kind =:= type_application ->
+       Kind =:= type_application;
+       %% Behaviour
+       Kind =:= behaviour ->
   els_dt_references:insert( Kind
                           , #{id => Id, uri => Uri, range => Range}
                           ).

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -247,6 +247,8 @@ attribute(Tree) ->
       [poi(Pos, behaviour, Behaviour)];
     {behaviour, {behaviour, Behaviour}} ->
       [poi(Pos, behaviour, Behaviour)];
+    {callback, {callback, {{F, A}, _}}} ->
+      [poi(Pos, callback, {F, A})];
     {compile, {compile, {parse_transform, ParseTransform}}} ->
       [poi(Pos, parse_transform, ParseTransform)];
     {module, {Module, _Args}} ->

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -65,6 +65,10 @@ range({Line, Column}, behaviour, Behaviour, _Data) ->
   From = {Line, Column - 1},
   To = {Line, Column + length("behaviour") + length(atom_to_list(Behaviour))},
   #{ from => From, to => To };
+range({Line, Column}, callback, {F, _A}, _Data) ->
+  From = {Line, Column},
+  To = plus(From, atom_to_list(F)),
+  #{ from => From, to => To };
 range({Line, Column}, function, {F, _A}, _Data) ->
   From = {Line, Column},
   To = plus(From, atom_to_list(F)),

--- a/src/els_references_provider.erl
+++ b/src/els_references_provider.erl
@@ -83,6 +83,9 @@ find_references(Uri, #{kind := module}) ->
       Refs = lists:flatmap(fun(E) -> find_references(Uri, E) end, Exports),
       lists:filter(ExcludeLocalRefs, Refs)
   end;
+find_references(_Uri, #{kind := Kind, id := Name})
+  when Kind =:= behaviour ->
+  find_references_for_id(Kind, Name);
 find_references(_Uri, _POI) ->
   [].
 

--- a/test/els_code_lens_SUITE.erl
+++ b/test/els_code_lens_SUITE.erl
@@ -14,6 +14,7 @@
 -export([ default_lenses/1
         , server_info/1
         , ct_run_test/1
+        , show_behaviour_usages/1
         ]).
 
 %%==============================================================================
@@ -118,5 +119,23 @@ ct_run_test(Config) ->
                             , start => #{ character => 0
                                         , line => 57
                                         }}}],
+  ?assertEqual(Expected, Result),
+  ok.
+
+-spec show_behaviour_usages(config()) -> ok.
+show_behaviour_usages(Config) ->
+  Uri = ?config(behaviour_a_uri, Config),
+  PrefixedCommand = els_command:with_prefix(<<"show-behaviour-usages">>),
+  #{result := Result} = els_client:document_codelens(Uri),
+  Expected = [#{ command =>
+                   #{ arguments => []
+                    , command => PrefixedCommand
+                    , title => <<"Behaviour used in 1 place(s)">>
+                    }
+               , data => []
+               , range =>
+                   #{ 'end' => #{character => 19, line => 0}
+                    , start => #{character => 8, line => 0}
+                    }}],
   ?assertEqual(Expected, Result),
   ok.


### PR DESCRIPTION
### Description

Whenever opening a _behaviour_ module (defined as an Erlang module defining one or more callback functions), shows the number of usages of such a behaviour (defined by the presence of a `-behaviour` attribute) in the code base.

Fixes #626.
