### PR TITLE
Handle initializationOptions being empty string and fix timeout

### DIFF
--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -50,10 +50,9 @@ handle_request({initialize, Params}, State) ->
               _ -> RootUri0
             end,
   InitOptions = case maps:get(<<"initializationOptions">>, Params, #{}) of
-                  null ->
-                    #{};
-                  InitOptions0 ->
-                    InitOptions0
+                  InitOptions0 when is_map(InitOptions0) ->
+                    InitOptions0;
+                  _ -> #{}
                 end,
   ok = els_config:initialize(RootUri, Capabilities, InitOptions),
   DbDir = application:get_env(erlang_ls, db_dir, default_db_dir()),

--- a/src/els_provider.erl
+++ b/src/els_provider.erl
@@ -56,7 +56,7 @@ start_link(Provider) ->
 
 -spec handle_request(provider(), request()) -> any().
 handle_request(Provider, Request) ->
-  gen_server:call(Provider, {handle_request, Provider, Request}).
+  gen_server:call(Provider, {handle_request, Provider, Request}, infinity).
 
 %%==============================================================================
 %% gen_server callbacks


### PR DESCRIPTION
### Description

This addresses some issues trying to use erlang_ls with vim/coc. Specifically vim was sending the initialization options as an empty string and the general provider init was timing out.

Fixes # .
