### PR TITLE
[#641] do not report xref errors for pseudo functions

### DIFF
--- a/priv/code_navigation/src/diagnostics_xref_pseudo.erl
+++ b/priv/code_navigation/src/diagnostics_xref_pseudo.erl
@@ -9,4 +9,24 @@ main() ->
   module_info(),
   module_info(module),
   ?MODULE:behaviour_info(callbacks),
+  lager:debug("log message", []),
+  lager:info("log message", []),
+  lager:notice("log message", []),
+  lager:warning("log message", []),
+  lager:error("log message", []),
+  lager:critical("log message", []),
+  lager:alert("log message", []),
+  lager:emergency("log message", []),
+
+  lager:debug("log message"),
+  lager:info("log message"),
+  lager:notice("log message"),
+  lager:warning("log message"),
+  lager:error("log message"),
+  lager:critical("log message"),
+  lager:alert("log message"),
+  lager:emergency("log message"),
+
+  % At lease one failure so we know the diagnostic is running
+  unknown_module:nonexistent(),
   ok.

--- a/priv/code_navigation/src/diagnostics_xref_pseudo.erl
+++ b/priv/code_navigation/src/diagnostics_xref_pseudo.erl
@@ -8,4 +8,5 @@ main() ->
   record_info(fields, person),
   module_info(),
   module_info(module),
+  ?MODULE:behaviour_info(callbacks),
   ok.

--- a/priv/code_navigation/src/diagnostics_xref_pseudo.erl
+++ b/priv/code_navigation/src/diagnostics_xref_pseudo.erl
@@ -1,0 +1,11 @@
+-module(diagnostics_xref_pseudo).
+
+-export([ main/0 ]).
+
+-record(person, {name, phone, address}).
+
+main() ->
+  record_info(fields, person),
+  module_info(),
+  module_info(module),
+  ok.

--- a/src/els_xref_diagnostics.erl
+++ b/src/els_xref_diagnostics.erl
@@ -67,13 +67,16 @@ make_diagnostic(#{range := Range, id := Id}) ->
 
 -spec has_definition(poi(), els_dt_document:item()) -> boolean().
 has_definition(#{ kind := application
-                , id := {erlang, module_info, 0} }, _) -> true;
+                , id := {module_info, 0} }, _) -> true;
 has_definition(#{ kind := application
-                , id := {erlang, module_info, 1} }, _) -> true;
+                , id := {module_info, 1} }, _) -> true;
 has_definition(#{ kind := application
                 , id := {record_info, 2} }, _) -> true;
 has_definition(#{ kind := application
                 , id := {behaviour_info, 1} }, _) -> true;
+has_definition(#{ kind := application
+                , id := {lager, Level, Arity} }, _) ->
+  lager_definition(Level, Arity);
 has_definition(POI, #{uri := Uri}) ->
   case els_code_navigation:goto_definition(Uri, POI) of
     {ok, _Uri, _POI} ->
@@ -81,3 +84,12 @@ has_definition(POI, #{uri := Uri}) ->
     {error, _Error} ->
       false
   end.
+
+-spec lager_definition(atom(), integer()) -> boolean().
+lager_definition(Level, Arity) when Arity =:= 1 orelse Arity =:= 2 ->
+  lists:member(Level, lager_levels());
+lager_definition(_, _) -> false.
+
+-spec lager_levels() -> [atom()].
+lager_levels() ->
+ [debug, info, notice, warning, error, critical, alert, emergency].

--- a/src/els_xref_diagnostics.erl
+++ b/src/els_xref_diagnostics.erl
@@ -66,6 +66,12 @@ make_diagnostic(#{range := Range, id := Id}) ->
                                  , source()).
 
 -spec has_definition(poi(), els_dt_document:item()) -> boolean().
+has_definition(#{ kind := application
+                , id := {erlang, module_info, 0} }, _) -> true;
+has_definition(#{ kind := application
+                , id := {erlang, module_info, 1} }, _) -> true;
+has_definition(#{ kind := application
+                , id := {record_info, 2} }, _) -> true;
 has_definition(POI, #{uri := Uri}) ->
   case els_code_navigation:goto_definition(Uri, POI) of
     {ok, _Uri, _POI} ->

--- a/src/els_xref_diagnostics.erl
+++ b/src/els_xref_diagnostics.erl
@@ -72,6 +72,8 @@ has_definition(#{ kind := application
                 , id := {erlang, module_info, 1} }, _) -> true;
 has_definition(#{ kind := application
                 , id := {record_info, 2} }, _) -> true;
+has_definition(#{ kind := application
+                , id := {behaviour_info, 1} }, _) -> true;
 has_definition(POI, #{uri := Uri}) ->
   case els_code_navigation:goto_definition(Uri, POI) of
     {ok, _Uri, _POI} ->

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -27,6 +27,7 @@
         , escript_warnings/1
         , escript_errors/1
         , xref/1
+        , xref_pseudo_functions/1
         ]).
 
 %%==============================================================================
@@ -412,6 +413,18 @@ xref(Config) ->
                 , source => <<"Compiler">>
                 }
              ],
+  F = fun(#{message := M1}, #{message := M2}) -> M1 =< M2 end,
+  ?assertEqual(Expected, lists:sort(F, Diagnostics)),
+  ok.
+
+%% #641
+-spec xref_pseudo_functions(config()) -> ok.
+xref_pseudo_functions(Config) ->
+  Uri = ?config(diagnostics_xref_pseudo_uri, Config),
+  els_mock_diagnostics:subscribe(),
+  ok = els_client:did_save(Uri),
+  Diagnostics = els_mock_diagnostics:wait_until_complete(),
+  Expected = [],
   F = fun(#{message := M1}, #{message := M2}) -> M1 =< M2 end,
   ?assertEqual(Expected, lists:sort(F, Diagnostics)),
   ok.

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -160,6 +160,7 @@ sources() ->
   , diagnostics_parse_transform_usage_broken
   , diagnostics_parse_transform_usage_included
   , diagnostics_xref
+  , diagnostics_xref_pseudo
   , elvis_diagnostics
   , format_input
   , my_gen_server


### PR DESCRIPTION
The functions

    record_info/2
    module_info/0
    module_info/1

are pseudo functions generated and processed by the erlang compiler. Do not
report xref errors if they are encountered, as they are always valid.

Closes #641.
Closes #644.

