### PR TITLE
Add all subdirs to search path

### DIFF
--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -118,10 +118,10 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = set(code_lenses    , CodeLenses),
   ok = set(diagnostics    , Diagnostics),
   %% All (including subdirs) paths used to search files with file:path_open/3
+  ProjectDirs = els_utils:resolve_paths( [[ RootPath ]], RootPath, true),
+
   ok = set( search_paths
-          , lists:append([ project_paths(RootPath, AppsDirs, true)
-                         , project_paths(RootPath, DepsDirs, true)
-                         , include_paths(RootPath, IncludeDirs, false)
+          , lists:append([ ProjectDirs
                          , otp_paths(OtpPath, true)
                          ])
           ),

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -187,16 +187,24 @@ is_symlink(Path) ->
 
 -spec resolve_path([path()], path(), boolean()) -> [path()].
 resolve_path(PathSpec, RootPath, Recursive) ->
-  Path  = filename:join(PathSpec),
-  Paths = filelib:wildcard(Path),
-
+  RPath = filename:join(PathSpec),
+  Paths = filelib:wildcard(RPath),
+  RecAdd = fun(Path) ->
+               SubDirs = [P || P <- subdirs(Paths),
+                               contains_src_files(P)],
+               case contains_src_files(Path) of
+                 true  -> [make_normalized_path(Path) | SubDirs];
+                 false -> SubDirs
+               end
+             end,
   case Recursive of
     true  ->
-      lists:append([ [make_normalized_path(P) | subdirs(P)]
-                     || P <- Paths, not contains_symlink(P, RootPath)
-                   ]);
+      lists:append([ RecAdd(P) || P <- Paths,
+                                  not contains_symlink(P, RootPath)]);
     false ->
-      [make_normalized_path(P) || P <- Paths, not contains_symlink(P, RootPath)]
+      [make_normalized_path(P) || P <- Paths,
+                                  not contains_symlink(P, RootPath),
+                                  contains_src_files(P)]
   end.
 
 %% Returns all subdirectories for the provided path
@@ -224,6 +232,10 @@ subdirs_(Path, Files, Subdirs) ->
              end
          end,
   lists:foldl(Fold, Subdirs, Files).
+
+-spec contains_src_files(path()) -> boolean().
+contains_src_files(P) ->
+  [] /= filelib:wildcard(filename:join(P, "*.?rl")).
 
 -spec contains_symlink(path(), path()) -> boolean().
 contains_symlink(RootPath, RootPath) ->


### PR DESCRIPTION
All erlang files in a subdir of RootUri should be found,
not only files below 'src', 'test' or 'include'.
