### PR TITLE
Prioritize Uris

### DIFF
--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -60,7 +60,10 @@ find_header(Id) ->
 find_module(Id) ->
   {ok, Candidates} = els_dt_document_index:lookup(Id),
   case [Uri || #{kind := module, uri := Uri} <- Candidates] of
-    [Uri | _] ->
+    [Uri] ->
+      {ok, Uri};
+    [_|_] = Uris ->
+      [Uri|_] = prioritize_uris(Uris),
       {ok, Uri};
     [] ->
       FileName = atom_to_list(Id) ++ ".erl",
@@ -248,6 +251,21 @@ cmd_receive(Port) ->
     {Port, _} ->
       cmd_receive(Port)
   end.
+
+%% @doc Prioritize files
+%% Prefer files below root and prefer files in src dir.
+-spec prioritize_uris([uri()]) -> [uri()].
+prioritize_uris(Uris) ->
+  Root = els_config:get(root_uri),
+  Order = fun(nomatch) -> 3;
+             (Cont) ->
+              case string:find(Cont, "/src/") of
+                nomatch -> 1;
+                _ -> 0
+              end
+          end,
+  Prio = [{Order(string:prefix(Uri, Root)), Uri} || Uri <- Uris],
+  [Uri || {_, Uri} <- lists:sort(Prio)].
 
 %%==============================================================================
 %% This section excerpted from the rebar3 sources, rebar_dir.erl


### PR DESCRIPTION
If a module have several Uris prioritize them.

Search for project related Uri first and prioritize modules in src dir.

When working OTP reposiory we get at least two uris per module, one
in src tree and one in otp release tree, when jumping to definition
we want to jump to the one in the src tree and not to the release tree.

Also some modules names are duplicated in tests dir, avoid these too.

Now that the indexing is parallel the order is random, so it's not
given where to go.

