### PR TITLE
[#650] Allow configuration of diagnostics providers

### DIFF
--- a/priv/code_navigation/erlang_ls_diagnostic.config
+++ b/priv/code_navigation/erlang_ls_diagnostic.config
@@ -1,0 +1,10 @@
+macros:
+  - name: DEFINED_WITHOUT_VALUE
+  - name: DEFINED_WITH_VALUE
+    value: 1
+diagnostics:
+  - compiler
+  - dialyzer
+  - elvis
+  # - xref
+  - nonexist

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -93,7 +93,9 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
                             ),
   CodeLenses = maps:get("code_lenses", Config, els_code_lens:default_lenses()),
   Diagnostics =
-    maps:get("diagnostics", Config, els_diagnostics:default_diagnostics()),
+    maps:get("diagnostics", Config,
+             [els_utils:to_list(D)
+              || D <- els_diagnostics:default_diagnostics()]),
   ExcludePathsSpecs = [[OtpPath, "lib", P ++ "*"] || P <- OtpAppsExclude],
   ExcludePaths = els_utils:resolve_paths(ExcludePathsSpecs, RootPath, true),
   lager:info("Excluded OTP Applications: ~p", [OtpAppsExclude]),
@@ -116,7 +118,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = set(include_paths  , include_paths(RootPath, IncludeDirs, false)),
   ok = set(otp_paths      , otp_paths(OtpPath, false) -- ExcludePaths),
   ok = set(code_lenses    , CodeLenses),
-  ok = set(diagnostics    , Diagnostics),
+  ok = set(diagnostics    , [els_utils:to_binary(D) || D <- Diagnostics]),
   %% All (including subdirs) paths used to search files with file:path_open/3
   ok = set( search_paths
           , lists:append([ project_paths(RootPath, AppsDirs, true)

--- a/test/els_initialization_SUITE.erl
+++ b/test/els_initialization_SUITE.erl
@@ -16,6 +16,8 @@
 -export([ initialize_default/1
         , initialize_custom_relative/1
         , initialize_custom_absolute/1
+        , initialize_enable_diagnostics_normal/1
+        , initialize_enable_diagnostics_custom/1
         ]).
 
 %%==============================================================================
@@ -99,4 +101,32 @@ initialize_custom_absolute(Config) ->
   Result = els_config:get(macros),
   Expected = [#{"name" => "DEFINED_FOR_RELATIVE_TEST"}],
   ?assertEqual(Expected, Result),
+  ok.
+
+-spec initialize_enable_diagnostics_normal(config()) -> ok.
+initialize_enable_diagnostics_normal(Config) ->
+  RootUri  = ?config(root_uri, Config),
+  els_client:initialize(RootUri),
+  Result = els_config:get(diagnostics),
+  Expected = els_diagnostics:available_diagnostics(),
+  ?assertEqual(Expected, Result),
+  Result2 = els_diagnostics:enabled_diagnostics(),
+  Expected2 = [<<"compiler">>, <<"dialyzer">>, <<"elvis">>, <<"xref">>],
+  ?assertEqual(Expected2, Result2),
+  ok.
+
+-spec initialize_enable_diagnostics_custom(config()) -> ok.
+initialize_enable_diagnostics_custom(Config) ->
+  RootUri  = ?config(root_uri, Config),
+  ConfigPath = filename:join( els_uri:path(RootUri)
+                            , "erlang_ls_diagnostic.config"),
+  InitOpts = #{ <<"erlang">>
+              => #{ <<"config_path">> => ConfigPath }},
+  els_client:initialize(RootUri, InitOpts),
+  Result = els_config:get(diagnostics),
+  Expected = [<<"compiler">>, <<"dialyzer">>, <<"elvis">>, <<"nonexist">>],
+  ?assertEqual(Expected, Result),
+  Result2 = els_diagnostics:enabled_diagnostics(),
+  Expected2 = [<<"compiler">>, <<"dialyzer">>, <<"elvis">>],
+  ?assertEqual(Expected2, Result2),
   ok.


### PR DESCRIPTION
Via erlang_ls.config

Also validate that the enabled providers actually exist.

### Description

Enter a description of your changes here.

Fixes #650.
