### PR TITLE
[#633] Follow up on #598: Do not consider all exports from erlang module as bifs

### DIFF
--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -184,7 +184,7 @@ application(Tree) ->
     undefined -> [];
     {F, A} ->
       Pos = erl_syntax:get_pos(Tree),
-      case is_erlang_bif(F, A) of
+      case erl_internal:bif(F, A) of
         %% Call to a function from the `erlang` module
         true -> [poi(Pos, application, {erlang, F, A}, #{imported => true})];
         %% Local call
@@ -193,10 +193,6 @@ application(Tree) ->
     MFA ->
       [poi(erl_syntax:get_pos(Tree), application, MFA)]
   end.
-
--spec is_erlang_bif(atom(), arity()) -> boolean().
-is_erlang_bif(F, A) ->
-  lists:member({F, A}, erlang:module_info(exports)).
 
 -spec application_mfa(tree()) ->
   {module(), atom(), arity()} | {atom(), arity()} | undefined.


### PR DESCRIPTION
Fixes #633 

**TIL**, when taking all functions that are listed as bifs in `erl_internal:bif/2` and checking if they're part of the `erlang`-module, I found that `is_bitstr/1` and `monitor/3` are not. I cannot find a trace of `is_bitstr/1` other than it was introduced in R11 by the looks of it nor `monitor/3`. My guess is that they were removed a long time ago but simple not removed from the `erlang_internal:bif/2` list. 