### PR TITLE
[#657] Be able to configure lenses via config file

### DIFF
--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -36,12 +36,12 @@
 -type key()   :: apps_dirs
                | apps_paths
                | capabilities
-               | code_lenses
                | diagnostics
                | deps_dirs
                | deps_paths
                | include_dirs
                | include_paths
+               | lenses
                | otp_path
                | otp_paths
                | otp_apps_exclude
@@ -53,7 +53,7 @@
 -type path()  :: file:filename().
 -type state() :: #{ apps_dirs        => [path()]
                   , apps_paths       => [path()]
-                  , code_lenses      => [els_code_lens:lens_id()]
+                  , lenses           => [els_code_lens:lens_id()]
                   , diagnostics      => [els_diagnostics:diagnostic_id()]
                   , deps_dirs        => [path()]
                   , deps_paths       => [path()]
@@ -91,7 +91,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
                             , Config
                             , ?DEFAULT_EXCLUDED_OTP_APPS
                             ),
-  CodeLenses = maps:get("code_lenses", Config, els_code_lens:default_lenses()),
+  Lenses = maps:get("lenses", Config, #{}),
   Diagnostics = maps:get("diagnostics", Config, #{}),
   ExcludePathsSpecs = [[OtpPath, "lib", P ++ "*"] || P <- OtpAppsExclude],
   ExcludePaths = els_utils:resolve_paths(ExcludePathsSpecs, RootPath, true),
@@ -114,7 +114,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = set(deps_paths     , project_paths(RootPath, DepsDirs, false)),
   ok = set(include_paths  , include_paths(RootPath, IncludeDirs, false)),
   ok = set(otp_paths      , otp_paths(OtpPath, false) -- ExcludePaths),
-  ok = set(code_lenses    , CodeLenses),
+  ok = set(lenses         , Lenses),
   ok = set(diagnostics    , Diagnostics),
   %% All (including subdirs) paths used to search files with file:path_open/3
   ok = set( search_paths

--- a/test/els_initialization_SUITE.erl
+++ b/test/els_initialization_SUITE.erl
@@ -19,6 +19,9 @@
         , initialize_diagnostics_default/1
         , initialize_diagnostics_custom/1
         , initialize_diagnostics_invalid/1
+        , initialize_lenses_default/1
+        , initialize_lenses_custom/1
+        , initialize_lenses_invalid/1
         ]).
 
 %%==============================================================================
@@ -137,5 +140,43 @@ initialize_diagnostics_invalid(Config) ->
   els_client:initialize(RootUri, InitOpts),
   Result = els_diagnostics:enabled_diagnostics(),
   Expected = [<<"compiler">>, <<"dialyzer">>, <<"elvis">>, <<"xref">>],
+  ?assertEqual(Expected, Result),
+  ok.
+
+-spec initialize_lenses_default(config()) -> ok.
+initialize_lenses_default(Config) ->
+  RootUri = ?config(root_uri, Config),
+  DataDir = ?config(data_dir, Config),
+  ConfigPath = filename:join(DataDir, "lenses_default.config"),
+  InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
+  els_client:initialize(RootUri, InitOpts),
+  Expected = els_code_lens:default_lenses(),
+  Result = els_code_lens:enabled_lenses(),
+  ?assertEqual(Expected, Result),
+  ok.
+
+-spec initialize_lenses_custom(config()) -> ok.
+initialize_lenses_custom(Config) ->
+  RootUri = ?config(root_uri, Config),
+  DataDir = ?config(data_dir, Config),
+  ConfigPath = filename:join(DataDir, "lenses_custom.config"),
+  InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
+  els_client:initialize(RootUri, InitOpts),
+  Expected = [<<"ct-run-test">>, <<"server-info">>],
+  Result = els_code_lens:enabled_lenses(),
+  ?assertEqual(Expected, Result),
+  ok.
+
+-spec initialize_lenses_invalid(config()) -> ok.
+initialize_lenses_invalid(Config) ->
+  RootUri = ?config(root_uri, Config),
+  DataDir = ?config(data_dir, Config),
+  ConfigPath = filename:join(DataDir, "lenses_invalid.config"),
+  InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
+  els_client:initialize(RootUri, InitOpts),
+  Result = els_code_lens:enabled_lenses(),
+  Expected = [ <<"ct-run-test">>
+             , <<"server-info">>
+             , <<"show-behaviour-usages">>],
   ?assertEqual(Expected, Result),
   ok.

--- a/test/els_initialization_SUITE_data/diagnostics_invalid.config
+++ b/test/els_initialization_SUITE_data/diagnostics_invalid.config
@@ -2,4 +2,4 @@ diagnostics:
   enabled:
     - xref
   disabled:
-    - elviss
+    - elviss # Typo intentional

--- a/test/els_initialization_SUITE_data/lenses_custom.config
+++ b/test/els_initialization_SUITE_data/lenses_custom.config
@@ -1,0 +1,5 @@
+lenses:
+  enabled:
+    - server-info
+  disabled:
+    - show-behaviour-usages

--- a/test/els_initialization_SUITE_data/lenses_invalid.config
+++ b/test/els_initialization_SUITE_data/lenses_invalid.config
@@ -1,0 +1,5 @@
+lenses:
+  enabled:
+    - server-info
+  disabled:
+    - ct-run-tests # Typo intentional


### PR DESCRIPTION
### Description

Fixes #657 .

Please notice how the configuration option has been renamed to `lenses` for simplicity.