### PR TITLE
Change default transport to stdio

### DIFF
--- a/src/erlang_ls.erl
+++ b/src/erlang_ls.erl
@@ -57,7 +57,7 @@ opt_spec_list() ->
   , { transport
     , $t
     , "transport"
-    , {string, "tcp"}
+    , {string, "stdio"}
     , "Specifies the transport the server will use for "
       "the connection with the client, either \"tcp\" or \"stdio\"."
     }


### PR DESCRIPTION
This is the most common case, and in general if specifying tcp transport a port
needs to be specified too, as clients will launch multiple instances under some
circumstances.


