### PR TITLE
[#666] 😈 Disable ct-run-test lens by default

### DIFF
--- a/src/els_code_lens_ct_run_test.erl
+++ b/src/els_code_lens_ct_run_test.erl
@@ -31,7 +31,7 @@ command_args( #{uri := Uri} = _Document
 
 -spec is_default() -> boolean().
 is_default() ->
-  true.
+  false.
 
 -spec pois(els_dt_document:item()) -> [poi()].
 pois(Document) ->

--- a/test/els_code_lens_SUITE.erl
+++ b/test/els_code_lens_SUITE.erl
@@ -56,6 +56,10 @@ init_per_testcase(server_info, Config) ->
   meck:new(els_code_lens_server_info, [passthrough, no_link]),
   meck:expect(els_code_lens_server_info, is_default, 0, true),
   els_test_utils:init_per_testcase(server_info, Config);
+init_per_testcase(ct_run_test, Config) ->
+  meck:new(els_code_lens_ct_run_test, [passthrough, no_link]),
+  meck:expect(els_code_lens_ct_run_test, is_default, 0, true),
+  els_test_utils:init_per_testcase(server_info, Config);
 init_per_testcase(TestCase, Config) ->
   els_test_utils:init_per_testcase(TestCase, Config).
 
@@ -63,6 +67,10 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(server_info, Config) ->
   els_test_utils:end_per_testcase(server_info, Config),
   meck:unload(els_code_lens_server_info),
+  ok;
+end_per_testcase(ct_run_test, Config) ->
+  els_test_utils:end_per_testcase(ct_run_test, Config),
+  meck:unload(els_code_lens_ct_run_test),
   ok;
 end_per_testcase(TestCase, Config) ->
   els_test_utils:end_per_testcase(TestCase, Config).

--- a/test/els_initialization_SUITE.erl
+++ b/test/els_initialization_SUITE.erl
@@ -162,7 +162,7 @@ initialize_lenses_custom(Config) ->
   ConfigPath = filename:join(DataDir, "lenses_custom.config"),
   InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
   els_client:initialize(RootUri, InitOpts),
-  Expected = [<<"ct-run-test">>, <<"server-info">>],
+  Expected = [<<"server-info">>],
   Result = els_code_lens:enabled_lenses(),
   ?assertEqual(Expected, Result),
   ok.
@@ -175,8 +175,6 @@ initialize_lenses_invalid(Config) ->
   InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
   els_client:initialize(RootUri, InitOpts),
   Result = els_code_lens:enabled_lenses(),
-  Expected = [ <<"ct-run-test">>
-             , <<"server-info">>
-             , <<"show-behaviour-usages">>],
+  Expected = [<<"ct-run-test">>, <<"show-behaviour-usages">>],
   ?assertEqual(Expected, Result),
   ok.

--- a/test/els_initialization_SUITE_data/lenses_invalid.config
+++ b/test/els_initialization_SUITE_data/lenses_invalid.config
@@ -1,5 +1,5 @@
 lenses:
   enabled:
-    - server-info
+    - ct-run-test
   disabled:
-    - ct-run-tests # Typo intentional
+    - show-behaviour-usagess # Typo intentional


### PR DESCRIPTION
### Description

The lens is not quite stable yet, so let's not set false expectations.

Fixes #666 .
