### PR TITLE
Detect parse transforms properly.

### DIFF
--- a/priv/code_navigation/src/diagnostics_parse_transform_usage_list.erl
+++ b/priv/code_navigation/src/diagnostics_parse_transform_usage_list.erl
@@ -1,0 +1,8 @@
+-module(diagnostics_parse_transform_usage_list).
+
+-export([ main/1 ]).
+
+-compile([{parse_transform, diagnostics_parse_transform}, debug_info]).
+
+main(Args) ->
+  ok.

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -245,7 +245,9 @@ attribute(Tree) ->
       [poi(Pos, behaviour, Behaviour)];
     {callback, {callback, {{F, A}, _}}} ->
       [poi(Pos, callback, {F, A})];
-    {compile, {compile, CompileOpts}} ->
+    {compile, {compile, {parse_transform, ParseTransform}}} ->
+      [poi(Pos, parse_transform, ParseTransform)];
+    {compile, {compile, CompileOpts}} when is_list(CompileOpts) ->
       [poi(Pos, parse_transform, PT) || {parse_transform, PT} <- CompileOpts];
     {module, {Module, _Args}} ->
       [poi(Pos, module, Module)];

--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -245,8 +245,8 @@ attribute(Tree) ->
       [poi(Pos, behaviour, Behaviour)];
     {callback, {callback, {{F, A}, _}}} ->
       [poi(Pos, callback, {F, A})];
-    {compile, {compile, {parse_transform, ParseTransform}}} ->
-      [poi(Pos, parse_transform, ParseTransform)];
+    {compile, {compile, CompileOpts}} ->
+      [poi(Pos, parse_transform, PT) || {parse_transform, PT} <- CompileOpts];
     {module, {Module, _Args}} ->
       [poi(Pos, module, Module)];
     {module, Module} ->

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -15,6 +15,7 @@
         , compiler_with_behaviour/1
         , compiler_with_custom_macros/1
         , compiler_with_parse_transform/1
+        , compiler_with_parse_transform_list/1
         , compiler_with_parse_transform_included/1
         , code_reload/1
         , code_reload_sticky_mod/1
@@ -148,6 +149,22 @@ compiler_with_custom_macros(Config) ->
 -spec compiler_with_parse_transform(config()) -> ok.
 compiler_with_parse_transform(Config) ->
   Uri = ?config(diagnostics_parse_transform_usage_uri, Config),
+  els_mock_diagnostics:subscribe(),
+  ok = els_client:did_save(Uri),
+  Diagnostics = els_mock_diagnostics:wait_until_complete(),
+  ?assertEqual(1, length(Diagnostics)),
+  Warnings = [D || #{severity := ?DIAGNOSTIC_WARNING} = D <- Diagnostics],
+  ?assertEqual(1, length(Warnings)),
+  WarningRanges = [ Range || #{range := Range} <- Warnings],
+  ExpectedWarningsRanges = [ #{ 'end' => #{character => 0, line => 7}
+                              , start => #{character => 0, line => 6}}
+                           ],
+  ?assertEqual(ExpectedWarningsRanges, WarningRanges),
+  ok.
+
+-spec compiler_with_parse_transform_list(config()) -> ok.
+compiler_with_parse_transform_list(Config) ->
+  Uri = ?config(diagnostics_parse_transform_usage_list_uri, Config),
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
   Diagnostics = els_mock_diagnostics:wait_until_complete(),

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -148,6 +148,8 @@ compiler_with_custom_macros(Config) ->
 
 -spec compiler_with_parse_transform(config()) -> ok.
 compiler_with_parse_transform(Config) ->
+  _ = code:delete(diagnostics_parse_transform),
+  _ = code:purge(diagnostics_parse_transform),
   Uri = ?config(diagnostics_parse_transform_usage_uri, Config),
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
@@ -164,6 +166,8 @@ compiler_with_parse_transform(Config) ->
 
 -spec compiler_with_parse_transform_list(config()) -> ok.
 compiler_with_parse_transform_list(Config) ->
+  _ = code:delete(diagnostics_parse_transform),
+  _ = code:purge(diagnostics_parse_transform),
   Uri = ?config(diagnostics_parse_transform_usage_list_uri, Config),
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
@@ -180,6 +184,8 @@ compiler_with_parse_transform_list(Config) ->
 
 -spec compiler_with_parse_transform_included(config()) -> ok.
 compiler_with_parse_transform_included(Config) ->
+  _ = code:delete(diagnostics_parse_transform),
+  _ = code:purge(diagnostics_parse_transform),
   Uri = ?config(diagnostics_parse_transform_usage_included_uri, Config),
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -148,6 +148,7 @@ sources() ->
   , diagnostics_macros
   , diagnostics_parse_transform
   , diagnostics_parse_transform_usage
+  , diagnostics_parse_transform_usage_list
   , diagnostics_parse_transform_usage_included
   , diagnostics_xref
   , elvis_diagnostics


### PR DESCRIPTION
Compile options in the module is a list, and several parse transforms can be specified there.
