### PR TITLE
[#319] Wait for tables after initialize

### DIFF
--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -73,6 +73,10 @@ handle_request({initialize, Params}, State) ->
                   _ -> #{}
                 end,
   ok = els_config:initialize(RootUri, Capabilities, InitOptions),
+  NewState = State#{ root_uri => RootUri, init_options => InitOptions},
+  {server_capabilities(), NewState};
+handle_request({initialized, _Params}, State) ->
+  #{root_uri := RootUri, init_options := InitOptions} = State,
   DbDir = application:get_env(erlang_ls, db_dir, default_db_dir()),
   OtpPath = els_config:get(otp_path),
   NodeName = node_name(RootUri, els_utils:to_binary(OtpPath)),
@@ -83,8 +87,6 @@ handle_request({initialize, Params}, State) ->
     true  -> els_indexing:start();
     false -> lager:info("Skipping Indexing (disabled via InitOptions)")
   end,
-  {server_capabilities(), State};
-handle_request({initialized, _Params}, State) ->
   {null, State};
 handle_request({shutdown, _Params}, State) ->
   {null, State};

--- a/test/els_execute_command_SUITE.erl
+++ b/test/els_execute_command_SUITE.erl
@@ -77,16 +77,13 @@ erlang_ls_info(Config) ->
     = els_client:workspace_executecommand(PrefixedCommand, [#{uri => Uri}]),
   Expected = [],
   ?assertEqual(Expected, Result),
-  CheckFun = fun() -> case els_client:get_notifications() of
-                        [] -> false;
-                        Notifications -> {true, Notifications}
-                      end
-             end,
-  {ok, [Notification]} = els_test_utils:wait_for_fun(CheckFun, 10, 3),
-  ?assertEqual(maps:get(method, Notification), <<"window/showMessage">>),
-  Params = maps:get(params, Notification),
-  ?assertEqual(<<"Erlang LS (in code_navigation), ">>
-              , binary:part(maps:get(message, Params), 0, 32)),
+  Notifications = wait_for_notifications(2),
+  [ begin
+      ?assertEqual(maps:get(method, Notification), <<"window/showMessage">>),
+      Params = maps:get(params, Notification),
+      ?assertEqual(<<"Erlang LS (in code_navigation), ">>
+                  , binary:part(maps:get(message, Params), 0, 32))
+    end || Notification <- Notifications ],
   ok.
 
 -spec ct_run_test(config()) -> ok.
@@ -166,3 +163,19 @@ wait_until_mock_called(M, F) ->
     _ ->
       ok
   end.
+
+-spec wait_for_notifications(pos_integer()) -> [map()].
+wait_for_notifications(Num) ->
+  wait_for_notifications(Num, []).
+
+-spec wait_for_notifications(integer(), [map()]) -> [map()].
+wait_for_notifications(Num, Acc) when Num =< 0 ->
+  Acc;
+wait_for_notifications(Num, Acc) ->
+  CheckFun = fun() -> case els_client:get_notifications() of
+                        [] -> false;
+                        Notifications -> {true, Notifications}
+                      end
+             end,
+  {ok, Notifications} = els_test_utils:wait_for_fun(CheckFun, 10, 3),
+  wait_for_notifications(Num - length(Notifications), Acc).

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -71,6 +71,7 @@ init_per_testcase(_TestCase, Config) ->
   RootPath  = ?config(root_path, Config),
   RootUri   = ?config(root_uri, Config),
   els_client:initialize(RootUri, #{indexingEnabled => false}),
+  els_client:initialized(),
   SrcConfig = lists:flatten(
                 [index_file(RootPath, src, S) || S <- sources()]),
   TestConfig = lists:flatten(


### PR DESCRIPTION
### Description

Now that all calls go through a provider, this should enable us to move the `wait-for-tables` from the `initialize` to the `initialized`. This should mean a much faster prompt for the user in big code bases and a happy @alanz .

Requests performed by the client before the DB is ready should simply queue / time out.

The fact that we now show progress reports with percentages should also help users in understanding when the server is fully ready.

Please try this on big code bases and try to break it.

Fixes #319 .
