### PR TITLE
Fix indexing on Windows

### DIFF
--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -130,15 +130,15 @@ start(Group, Entries) ->
 %% @doc Try indexing a file.
 -spec try_index_file(binary(), mode()) -> ok | {error, any()}.
 try_index_file(FullName, Mode) ->
+  Uri = els_uri:uri(FullName),
   try
-    Uri = els_uri:uri(FullName),
-    lager:debug("Indexing file. [filename=~s]", [FullName]),
+    lager:debug("Indexing file. [filename=~s, uri=~s]", [FullName, Uri]),
     {ok, Text} = file:read_file(FullName),
     ok         = index(Uri, Text, Mode)
   catch Type:Reason:St ->
       lager:error("Error indexing file "
-                  "[filename=~s] "
-                  "~p:~p:~p", [FullName, Type, Reason, St]),
+                  "[filename=~s, uri=~s] "
+                  "~p:~p:~p", [FullName, Uri, Type, Reason, St]),
       {error, {Type, Reason}}
   end.
 


### PR DESCRIPTION
### Description

The indexed data was wrong on Windows (crashes also the tests) due to a mismatch between `file:///c:/some/path` and `file:///c%3a/some/path` URIs. With this, the common test suite finally runs through.