### PR TITLE
Use https transport for rebar3_erlang_ls plugin config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,7 @@
 {plugins, [ rebar3_proper
           , coveralls
           , {rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "0.1.11"}}}
-          , {rebar3_erlang_ls, {git, "git@github.com:erlang-ls/rebar3_erlang_ls.git", {branch, "master"}}}
+          , {rebar3_erlang_ls, {git, "https://github.com/erlang-ls/rebar3_erlang_ls.git", {branch, "master"}}}
           ]
 }.
 


### PR DESCRIPTION
Otherwise it does not download for unauthenticated users.

