### PR TITLE
[#718] Customize prefix for key-bindings, add which-key integration

### DIFF
--- a/misc/dotemacs
+++ b/misc/dotemacs
@@ -26,6 +26,9 @@
 ;; Include the Language Server Protocol Clients
 (package-require 'lsp-mode)
 
+;; Customize prefix for key-bindings
+(setq lsp-keymap-prefix "C-l")
+
 ;; Enable LSP for Erlang files
 (add-hook 'erlang-mode-hook #'lsp)
 
@@ -63,3 +66,9 @@
 ;; - helm-lsp-workspace-symbol
 ;; - helm-lsp-global-workspace-symbol
 (package-install 'helm-lsp)
+
+;; Which-key integration
+(package-require 'which-key)
+(add-hook 'erlang-mode-hook 'which-key-mode)
+(with-eval-after-load 'lsp-mode
+  (add-hook 'lsp-mode-hook #'lsp-enable-which-key-integration))


### PR DESCRIPTION
### Description

The `which-key` package is supported by Emacs' `lsp-mode` and it offers a nice interface towards LSP shortcuts. The prefix has been changed to be a bit friendlier to Mac users.

Here is what it looks like:

![Screenshot 2020-04-30 at 13 43 19](https://user-images.githubusercontent.com/91769/80706495-b3b12c00-8ae8-11ea-9f11-fc021cae381f.png)

Fixes #718
