### PR TITLE
[#720] Always show diagnostics at the bottom, using 1/3 of the available space

### DIFF
--- a/misc/dotemacs
+++ b/misc/dotemacs
@@ -72,3 +72,12 @@
 (add-hook 'erlang-mode-hook 'which-key-mode)
 (with-eval-after-load 'lsp-mode
   (add-hook 'lsp-mode-hook #'lsp-enable-which-key-integration))
+
+;; Always show diagnostics at the bottom, using 1/3 of the available space
+(add-to-list 'display-buffer-alist
+             `(,(rx bos "*Flycheck errors*" eos)
+              (display-buffer-reuse-window
+               display-buffer-in-side-window)
+              (side            . bottom)
+              (reusable-frames . visible)
+              (window-height   . 0.33)))


### PR DESCRIPTION
Fixes #720 
