### PR TITLE
[#609] Store CT Logs as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,11 @@ jobs:
       run: rebar3 compile
     - name: Run CT Tests
       run: rebar3 ct
+    - name: Store CT Logs
+      uses: actions/upload-artifact@v1
+      with:
+        name: ct-logs
+        path: _build/test/logs
     - name: Run PropEr Tests
       run: rebar3 proper --cover --constraint_tries 100
     - name: Run Checks


### PR DESCRIPTION
### Description

There's currently not an easy way to blacklist a specific dir or file via wildcards (e.g. the `log_private` dir which contained the DB), so the artifacts are huge. Once the feature is available in the `upload-artifact` GitHub action we can add that filtering. See:

https://github.com/actions/upload-artifact/issues/44

Fixes #609 .
