### PR TITLE
Handle message as string, not as pattern.

### DIFF
--- a/src/els_stdio.erl
+++ b/src/els_stdio.erl
@@ -26,7 +26,7 @@ init({Cb, IoDevice}) ->
 
 -spec send(any(), binary()) -> ok.
 send(Connection, Payload) ->
-  io:format(Connection, Payload, []).
+  io:format(Connection, "~s", [Payload]).
 
 %%==============================================================================
 %% Listener loop function


### PR DESCRIPTION
The notification sending was failing with badarg
if the notification text had ~p or similar.