### PR TITLE
[#713] Bump Erlang LS VSCode extension to 0.0.11 in .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,4 +2,4 @@ image: erlang:22.2.7
 
 vscode:
   extensions:
-    - erlang-ls.erlang-ls@0.0.10:oBQX+Zo6jp9FsnCThGqAJw==
+    - erlang-ls.erlang-ls@0.0.11:LP8pbQuwxtiTrGIO84ngGw==


### PR DESCRIPTION
### Description

Fixes #713 .
