### PR TITLE
Fix crash from asking erl_lint format our own error messages

### DIFF
--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -153,9 +153,8 @@ diagnostic(_Path, MessagePath, Range, Document, Module, Desc0, Severity) ->
   %% The compiler message is related to an included file. Replace the
   %% original location with the location of the file inclusion.
   %% And re-route the format_error call to this module as a no-op
-  Desc1 = lists:flatten(Module:format_error(Desc0)),
-  Desc = lists:flatten(io_lib:format("Issue in included file (~p): ~s",
-                                     [Line, Desc1])),
+  Desc1 = Module:format_error(Desc0),
+  Desc = io_lib:format("Issue in included file (~p): ~s", [Line, Desc1]),
   diagnostic(InclusionRange, ?MODULE, Desc, Severity).
 
 -spec diagnostic(poi_range(), module(), string(), integer()) ->

--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -363,7 +363,7 @@ handle_rpc_result(Err, Module) ->
 compile_options(Module) ->
   case code:which(Module) of
     non_existing ->
-      lager:info("Could not find compile options. [module=~p]", Module),
+      lager:info("Could not find compile options. [module=~p]", [Module]),
       [];
     Beam ->
       case beam_lib:chunks(Beam, [compile_info]) of

--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -186,12 +186,15 @@ range(none) ->
 %%      a given document.
 -spec inclusion_range(string(), els_dt_document:item()) -> poi_range().
 inclusion_range(IncludePath, Document) ->
-  [Range|_] =
+  case
     inclusion_range(IncludePath, Document, include) ++
     inclusion_range(IncludePath, Document, include_lib) ++
     inclusion_range(IncludePath, Document, behaviour) ++
-    inclusion_range(IncludePath, Document, parse_transform),
-  Range.
+    inclusion_range(IncludePath, Document, parse_transform)
+  of
+    [Range|_] -> Range;
+    _ -> range(1)
+  end.
 
 -spec inclusion_range( string()
                      , els_dt_document:item()

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -157,7 +157,7 @@ compiler_with_broken_behaviour(Config) ->
   [BehaviourError | _ ] = Errors,
   ExpectedError =
     #{message =>
-        <<"Issue in included file (5): [\"syntax error before: \",[]]">>,
+        <<"Issue in included file (5): syntax error before: ">>,
       range =>
         #{'end' => #{character => 21, line => 2},
           start => #{character => 0, line => 2}},


### PR DESCRIPTION
The diagnostic processing calles 'Module:format_error/1' to render diagnostics.
For included files we render these ourselves, and wrap them in a context
message. Do not pass the wrapped messages on to the original fomatter again.


