### PR TITLE
Add COMPLETION_TRIGGER_KIND_FOR_INCOMPLETE_COMPLETIONS branch

### DIFF
--- a/src/els_completion_provider.erl
+++ b/src/els_completion_provider.erl
@@ -47,6 +47,8 @@ handle_request({completion, Params}, State) ->
                  ?COMPLETION_TRIGGER_KIND_CHARACTER ->
                    els_text:line(Text, Line, Character - Length);
                  ?COMPLETION_TRIGGER_KIND_INVOKED ->
+                   els_text:line(Text, Line, Character);
+                 ?COMPLETION_TRIGGER_KIND_FOR_INCOMPLETE_COMPLETIONS ->
                    els_text:line(Text, Line, Character)
                end,
       Opts   = #{ trigger  => TriggerCharacter


### PR DESCRIPTION
### Description

Current code of `els_completion_provider` has branches for
- `COMPLETION_TRIGGER_KIND_CHARACTER`
- `COMPLETION_TRIGGER_KIND_INVOKED`
but the `COMPLETION_TRIGGER_KIND_FOR_INCOMPLETE_COMPLETIONS` branch is missing.

In my environment, the following crash occured:
```
2020-05-30 13:11:32.825 [error] <0.201.0>@els_methods:dispatch:69 Unexpected error [type=exit] [error={{{case_clause,3},[{els_completion_provider,handle_request,2,[{file,"/home/shino/g/erlang_ls/src/els_completion_provider.erl"},{line,46}]},{els_provider,handle_call,3,[{file,"/home/shino/g/erlang_ls/src/els_provider.erl"},{line,80}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,706}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,735}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]},{gen_server,call,[els_completion_provider,{handle_request,els_completion_provider,{completion,#{<<"context">> => #{<<"triggerKind">> => 3},<<"position">> => #{<<"character">> => 4,<<"line">> => 28},<<"textDocument">> => #{<<"uri">> => <<"file:///home/shino/g/erlang_ls/src/els_completion_provider.erl">>}}}},infinity]}}] [stack=[{gen_server,call,3,[{file,"gen_server.erl"},{line,246}]},{els_methods,textdocument_completion,2,[{file,"/home/shino/g/erlang_ls/src/els_methods.erl"},{line,242}]},{els_methods,dispatch,4,[{file,"/home/shino/g/erlang_ls/src/els_methods.erl"},{line,64}]},{els_server,handle_request,2,[{file,"/home/shino/g/erlang_ls/src/els_server.erl"},{line,137}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{els_server,handle_cast,2,[{file,"/home/shino/g/erlang_ls/src/els_server.erl"},{line,114}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,680}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,756}]}]]
```

Fixes #632 .

Additional note:
The steps to reproduce the crash above :
1. Open els_completion_provider.erl in Emacs 
2. Go to is_enabled function
3. Set cursor position to the line head of `true`
4. Press `a` key about once per seconds
5. When fourth or fifth `a` is pressed, crash happened.