### PR TITLE
[#615] report a warning for a missing or malformed config file

### DIFF
--- a/test/els_execute_command_SUITE.erl
+++ b/test/els_execute_command_SUITE.erl
@@ -77,7 +77,8 @@ erlang_ls_info(Config) ->
     = els_client:workspace_executecommand(PrefixedCommand, [#{uri => Uri}]),
   Expected = [],
   ?assertEqual(Expected, Result),
-  Notifications = wait_for_notifications(2),
+  Notifications = els_test_utils:wait_for_notifications(2),
+  ?assertEqual(2, length(Notifications)),
   [ begin
       ?assertEqual(maps:get(method, Notification), <<"window/showMessage">>),
       Params = maps:get(params, Notification),
@@ -163,19 +164,3 @@ wait_until_mock_called(M, F) ->
     _ ->
       ok
   end.
-
--spec wait_for_notifications(pos_integer()) -> [map()].
-wait_for_notifications(Num) ->
-  wait_for_notifications(Num, []).
-
--spec wait_for_notifications(integer(), [map()]) -> [map()].
-wait_for_notifications(Num, Acc) when Num =< 0 ->
-  Acc;
-wait_for_notifications(Num, Acc) ->
-  CheckFun = fun() -> case els_client:get_notifications() of
-                        [] -> false;
-                        Notifications -> {true, Notifications}
-                      end
-             end,
-  {ok, Notifications} = els_test_utils:wait_for_fun(CheckFun, 10, 3),
-  wait_for_notifications(Num - length(Notifications), Acc).

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -11,6 +11,7 @@
         , start/1
         , wait_for/2
         , wait_for_fun/3
+        , wait_for_notifications/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -133,6 +134,26 @@ wait_for_fun(CheckFun, WaitTime, Retries) ->
       timer:sleep(WaitTime),
       wait_for_fun(CheckFun, WaitTime, Retries - 1)
   end.
+
+
+-spec wait_for_notifications(pos_integer()) -> [map()].
+wait_for_notifications(Num) ->
+  wait_for_notifications(Num, []).
+
+-spec wait_for_notifications(integer(), [map()]) -> [map()].
+wait_for_notifications(Num, Acc) when Num =< 0 ->
+  Acc;
+wait_for_notifications(Num, Acc) ->
+  CheckFun = fun() -> case els_client:get_notifications() of
+                        [] -> false;
+                        Notifications -> {true, Notifications}
+                      end
+             end,
+  {ok, Notifications} = wait_for_fun(CheckFun, 10, 3),
+  wait_for_notifications(Num - length(Notifications),
+                         lists:append(Notifications, Acc)).
+
+
 
 -spec get_group(config()) -> atom().
 get_group(Config) ->


### PR DESCRIPTION
1. If a config file is specified via the config_path setting, send a warning
message if the file is not found.

2. Once a config file is found, if it does not parse as a yaml file, send a
warning.

Fixes #615 .
