### PR TITLE
[#762] add include dir option of deps for compiler diagnostics

### DIFF
--- a/priv/code_navigation/deps/some_dep/include/some_dep.hrl
+++ b/priv/code_navigation/deps/some_dep/include/some_dep.hrl
@@ -1,0 +1,2 @@
+-record(some_dep_record, {field1, field2}).
+

--- a/priv/code_navigation/src/diagnostics_compiler_with_include_of_third_party_dep_header.erl
+++ b/priv/code_navigation/src/diagnostics_compiler_with_include_of_third_party_dep_header.erl
@@ -1,0 +1,11 @@
+-module(diagnostics_compiler_with_include_of_third_party_dep_header).
+
+-include_lib("some_dep/include/some_dep.hrl").
+
+-export([ main/1 ]).
+
+main(_Args) ->
+  #some_dep_record{
+    field1 = 1,
+    field2 = 2
+  }.

--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -288,7 +288,8 @@ compile_file(Path, Dependencies) ->
   Olds = [load_dependency(Dependency, Path)
           || Dependency <- Dependencies
                , not code:is_sticky(Dependency) ],
-  Res = compile:file(Path, diagnostics_options()),
+  IncludeDirs = [{i, D} || D <- els_config:get(deps_dirs)],
+  Res = compile:file(Path, diagnostics_options() ++ IncludeDirs),
   %% Restore things after compilation
   [code:load_binary(Dependency, Filename, Binary)
    || {{Dependency, Binary, Filename}, _} <- Olds],

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -156,6 +156,7 @@ sources() ->
   , diagnostics_parse_transform_usage_list
   , diagnostics_parse_transform_usage_broken
   , diagnostics_parse_transform_usage_included
+  , diagnostics_compiler_with_include_of_third_party_dep_header
   , diagnostics_xref
   , elvis_diagnostics
   , format_input


### PR DESCRIPTION
If an erlang file has a hrl included the compiler diagnostics raises an
error because it is not included in the arguments for the compile call.

Fix needs that the dependency directory is configured correctly in the `erlang_ls.config` file. 

Related #762
