### PR TITLE
[#767] Update "server-info" lens to give OTP Path too.

### DIFF
--- a/src/els_execute_command_provider.erl
+++ b/src/els_execute_command_provider.erl
@@ -58,10 +58,23 @@ execute_command(<<"server-info">>, _Arguments) ->
                  undefined -> <<"undefined">>;
                  Path -> list_to_binary(Path)
                end,
+
+  OtpPathConfig = list_to_binary(els_config:get(otp_path)),
+  OtpRootDir = list_to_binary(code:root_dir()),
+  OtpMessage = case OtpRootDir == OtpPathConfig of
+                 true ->
+                   <<", OTP root ", OtpRootDir/binary>>;
+                 false ->
+                   <<", OTP root(code):"
+                    , OtpRootDir/binary
+                   , ", OTP root(config):"
+                    , OtpPathConfig/binary>>
+               end,
   Message = <<"Erlang LS (in ", Root/binary, "), version: "
              , BinVersion/binary
              , ", config from "
              , ConfigPath/binary
+             , OtpMessage/binary
             >>,
   els_server:send_notification(<<"window/showMessage">>,
                                #{ type => ?MESSAGE_TYPE_INFO,


### PR DESCRIPTION
This lists the value of the 'otp_path' configuration variable, and also the
'code:root_dir()' value if it differs.

This can be accessed by enabling the "server-info" code lens in erlang_ls.config

    lenses:
      enabled:
        - server-info

and invoking it.

May help in debugging #767 .
