### PR TITLE
[#637] Provide serverInfo in initialize response message

### DIFF
--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -103,6 +103,7 @@ handle_request({exit, #{status := Status}}, State) ->
 
 -spec server_capabilities() -> server_capabilities().
 server_capabilities() ->
+  {ok, Version} = application:get_key(?APP, vsn),
   #{ capabilities =>
        #{ textDocumentSync =>
             #{ openClose => true
@@ -139,6 +140,10 @@ server_capabilities() ->
             els_execute_command_provider:options()
         , codeLensProvider =>
             els_code_lens_provider:options()
+        },
+     serverInfo =>
+       #{ name    => <<"Erlang LS">>
+        , version => els_utils:to_binary(Version)
         }
    }.
 


### PR DESCRIPTION
As suggested in #637

Note: it does not show up in the UI in vscode 1.46.1, in any obvious way.


