### PR TITLE
[#771] Do not ask for text on file save

### DIFF
--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -108,7 +108,7 @@ server_capabilities() ->
        #{ textDocumentSync =>
             #{ openClose => true
              , change    => ?TEXT_DOCUMENT_SYNC_KIND_FULL
-             , save      => #{includeText => true}
+             , save      => #{includeText => false}
              }
         , hoverProvider =>
             els_hover_provider:is_enabled()


### PR DESCRIPTION
Signed-off-by: Saurav Tiwary <srv.twry@gmail.com>

### Description

This PR disable the `includeText` flag while saving a text document since the files are processed from the disk hence the text isn't required.

Fixes #771 
