### PR TITLE
Added loop detection into dependency discovery

### DIFF
--- a/src/els_diagnostics_utils.erl
+++ b/src/els_diagnostics_utils.erl
@@ -15,20 +15,23 @@
 
 -spec dependencies(uri()) -> [atom()].
 dependencies(Uri) ->
-  dependencies([Uri], []).
+  dependencies([Uri], [], sets:new()).
 
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec dependencies([uri()], [atom()]) -> [atom()].
-dependencies([], Acc) ->
+-spec dependencies([uri()], [atom()], sets:set(binary())) -> [atom()].
+dependencies([], Acc, _AlreadyProcessed) ->
   Acc;
-dependencies([Uri|Uris], Acc) ->
+dependencies([Uri|Uris], Acc, AlreadyProcessed) ->
   case els_dt_document:lookup(Uri) of
     {ok, [Document]} ->
       Deps = els_dt_document:pois(Document, [behaviour, parse_transform]),
       IncludedUris = included_uris(Document),
-      dependencies(Uris ++ IncludedUris, Acc ++ [Id || #{id := Id} <- Deps]);
+      FilteredUris = [IncludedUri || IncludedUri <- IncludedUris,
+                      not set:is_element(IncludedUri, AlreadyProcessed)],
+      dependencies(Uris ++ FilteredUris, Acc ++ [Id || #{id := Id} <- Deps],
+                   set:add_element(Uri, AlreadyProcessed));
     Error ->
       lager:info("Lookup failed [Error=~p]", [Error]),
       []

--- a/src/els_diagnostics_utils.erl
+++ b/src/els_diagnostics_utils.erl
@@ -29,9 +29,9 @@ dependencies([Uri|Uris], Acc, AlreadyProcessed) ->
       Deps = els_dt_document:pois(Document, [behaviour, parse_transform]),
       IncludedUris = included_uris(Document),
       FilteredUris = [IncludedUri || IncludedUri <- IncludedUris,
-                      not set:is_element(IncludedUri, AlreadyProcessed)],
+                      not sets:is_element(IncludedUri, AlreadyProcessed)],
       dependencies(Uris ++ FilteredUris, Acc ++ [Id || #{id := Id} <- Deps],
-                   set:add_element(Uri, AlreadyProcessed));
+                   sets:add_element(Uri, AlreadyProcessed));
     Error ->
       lager:info("Lookup failed [Error=~p]", [Error]),
       []


### PR DESCRIPTION
### Description
If there is a dependency loop in include files, then els_diagnostics_utils:dependencies/1 would infinitely recurse.  

I've added a simple set of previously-visited uris to prevent such loops from occuring