### PR TITLE
[#796] Fix CI pipeline for OTP 23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [21.3, 22.2, 23.0]
+        otp-version: [21.3, 22.2, 23.1]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/test/els_execute_command_SUITE.erl
+++ b/test/els_execute_command_SUITE.erl
@@ -100,7 +100,7 @@ ct_run_test(Config) ->
                                              }]),
   Expected = [],
   ?assertEqual(Expected, Result),
-  wait_until_mock_called(els_protocol, notification),
+  els_test_utils:wait_until_mock_called(els_protocol, notification),
   ?assertEqual(1, meck:num_calls(els_distribution_server, rpc_call, '_')),
   Notifications = [{Method, Args} ||
                     { _Pid
@@ -153,16 +153,6 @@ setup_mocks() ->
 teardown_mocks() ->
   meck:unload(els_protocol),
   ok.
-
--spec wait_until_mock_called(atom(), atom()) -> ok.
-wait_until_mock_called(M, F) ->
-  case meck:num_calls(M, F, '_') of
-    0 ->
-      timer:sleep(100),
-      wait_until_mock_called(M, F);
-    _ ->
-      ok
-  end.
 
 -spec wait_for_notifications(pos_integer()) -> [map()].
 wait_for_notifications(Num) ->

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -11,6 +11,7 @@
         , start/1
         , wait_for/2
         , wait_for_fun/3
+        , wait_until_mock_called/2
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -234,6 +235,16 @@ atoms_append(Atom1, Atom2) ->
   Bin1 = atom_to_binary(Atom1, utf8),
   Bin2 = atom_to_binary(Atom2, utf8),
   binary_to_atom(<<Bin1/binary, Bin2/binary>>, utf8).
+
+-spec wait_until_mock_called(atom(), atom()) -> ok.
+wait_until_mock_called(M, F) ->
+  case meck:num_calls(M, F, '_') of
+    0 ->
+      timer:sleep(100),
+      wait_until_mock_called(M, F);
+    _ ->
+      ok
+  end.
 
 -spec wait_for_db() -> ok.
 wait_for_db() ->


### PR DESCRIPTION
### Description

* Bump OTP image to 23.1
* Ensure DB is up and running when performing manual indexing
* Refactor helper function

Fixes #796 .
