### PR TITLE
[#800] Ensure the path is recognized by OTP 23.1 as an absolute one

### DIFF
--- a/src/els_uri.erl
+++ b/src/els_uri.erl
@@ -69,7 +69,7 @@ uri(Path) ->
     uri_string:recompose(#{
       scheme => <<"file">>,
       host => Host,
-      path => [<<"/">>, Path1]
+      path => [$/, Path1]
     })
   ).
 


### PR DESCRIPTION
Reference: erlang/otp@40efd73

Fixes #800 .
