### PR TITLE
[#754] Return the original io:getopts/0 values in noop_group_leader.

### DIFF
--- a/src/els_sup.erl
+++ b/src/els_sup.erl
@@ -102,7 +102,9 @@ noop_group_leader() ->
       lager:info("noop_group_leader got [message=~p]", [Message]),
       case Message of
         {io_request, From, ReplyAs, getopts} ->
-          From ! {io_reply, ReplyAs, []};
+          %% We need to pass the underlying io opts, otherwise shell_docs does
+          %% not know which encoding to use. See #754
+          From ! {io_reply, ReplyAs, io:getopts()};
         {io_request, From, ReplyAs, _} ->
           From ! {io_reply, ReplyAs, ok};
         _ ->


### PR DESCRIPTION
Otherwise the shell_docs:render does not receive an encoding, and causes a crash
when requesting information for hover requests.

Fixes #754

