### PR TITLE
Bump DB Schema version for force DB rebuild

### DIFF
--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 -define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"8">>).
+-define(DB_SCHEMA_VSN, <<"9">>).
 -define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================


### PR DESCRIPTION
Prior to release 0.5.1, the database could end up with faulty URI entries in it
if run using OTP 23.

The solution is to delete the database so that it is rebuilt.

This commit bumps the database version number, so this happens automatically.
