### PR TITLE
[#770] Run mnesia in RAM-only mode

### DIFF
--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -5,8 +5,7 @@
         , clear_tables/0
         , delete/2
         , delete_object/1
-        , dump_tables/0
-        , install/2
+        , install/0
         , lookup/2
         , match/1
         , stop/0
@@ -16,47 +15,30 @@
         ]).
 
 -define(SERVER, ?MODULE).
--define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"9">>).
--define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================
 %% Exported functions
 %%==============================================================================
 
--spec install(atom(), string()) -> ok.
-install(NodeName, BaseDir) ->
-  els_distribution_server:start_distribution(NodeName),
-  DbDir = filename:join([BaseDir, atom_to_list(NodeName)]),
-  lager:info("Configuring DB [dir=~s]", [DbDir]),
-  ok = filelib:ensure_dir(filename:join([DbDir, "dummy"])),
-  ok = application:set_env(mnesia, dir, DbDir),
+-spec install() -> ok.
+install() ->
+  lager:info("Configuring DB", []),
+  ok = application:set_env(mnesia, schema_location, ram),
   %% Avoid mnesia overload while indexing
   ok = application:set_env(mnesia, dump_log_write_threshold, 50000),
   %% We have 4 tables. Let's load them in parallel
   ok = application:set_env(mnesia, no_table_loaders, 4),
-  ensure_db(DbDir).
+  ensure_db().
 
 -spec stop() -> ok | {error, any()}.
 stop() ->
   application:stop(mnesia).
 
--spec ensure_db(string()) -> ok.
-ensure_db(DbDir) ->
-  maybe_delete_db_schema(DbDir),
-  ok = write_db_schema_vsn_file(filename:dirname(DbDir)),
-  case mnesia:create_schema([node()]) of
-    {error, {_, {already_exists, _}}} ->
-      lager:info("DB Schema already exists, skipping"),
-      ok;
-    ok ->
-      lager:info("DB Schema created"),
-      ok
-  end,
+-spec ensure_db() -> ok.
+ensure_db() ->
   lager:info("Preparing tables"),
   application:start(mnesia),
   ensure_tables(),
-  wait_for_tables(),
   lager:info("DB Initialized"),
   ok.
 
@@ -72,14 +54,6 @@ delete(Table, Key) ->
 -spec delete_object(any()) -> ok.
 delete_object(Item) ->
   mnesia:dirty_delete_object(Item).
-
--spec dump_tables() -> ok.
-dump_tables() ->
-  %% First dump the content of the .LOG file to the respective .DCL
-  %% files, then merge the .DCL files into the .DCD files.
-  mnesia:dump_log(),
-  mnesia_controller:snapshot_dcd(tables()),
-  ok.
 
 -spec lookup(atom(), any()) -> {ok, [tuple()]}.
 lookup(Table, Key) ->
@@ -97,16 +71,6 @@ write(Record) when is_tuple(Record) ->
 clear_tables() ->
   [ok = clear_table(T) || T <- tables()],
   ok.
-
--spec wait_for_tables() -> ok.
-wait_for_tables() ->
-  wait_for_tables(?TIMEOUT).
-
--spec wait_for_tables(timeout()) -> ok.
-wait_for_tables(Timeout) ->
-  Token = maybe_report_progress_begin(),
-  ok = mnesia:wait_for_tables(tables(), Timeout),
-  maybe_report_progress_end(Token).
 
 -spec clear_table(atom()) -> ok.
 clear_table(Table) ->
@@ -127,93 +91,4 @@ transaction(F) ->
     {aborted, Reason} -> {error, {aborted, Reason}};
     {atomic, ok}      -> ok;
     {atomic, Result}  -> {ok, Result}
-  end.
-
--spec maybe_delete_db_schema(string()) -> ok.
-maybe_delete_db_schema(DbDir) ->
-  case read_db_schema_vsn_file(filename:dirname(DbDir)) of
-    ?DB_SCHEMA_VSN ->
-      Fmt = "DB Schema up to date [dir=~s] [vsn=~s]",
-      Args = [DbDir, ?DB_SCHEMA_VSN],
-      lager:info(Fmt, Args);
-    Vsn ->
-      Fmt = "Deleting DB Schema [dir=~s] [current_vsn=~s] [required_vsn=~s]",
-      Args = [DbDir, Vsn, ?DB_SCHEMA_VSN],
-      lager:info(Fmt, Args),
-      ok = del_dir(DbDir)
-  end.
-
--spec write_db_schema_vsn_file(string()) -> ok.
-write_db_schema_vsn_file(BaseDir) ->
-  ok = file:write_file(db_schema_vsn_file(BaseDir), ?DB_SCHEMA_VSN).
-
--spec read_db_schema_vsn_file(string()) -> binary().
-read_db_schema_vsn_file(BaseDir) ->
-  case file:read_file(db_schema_vsn_file(BaseDir)) of
-    {ok, Vsn} ->
-      Vsn;
-    {error, Error} ->
-      Fmt = "Error while accessing DB Schema Vsn file [error=~p]",
-      Args = [Error],
-      lager:warning(Fmt, Args),
-      <<>>
-  end.
-
--spec db_schema_vsn_file(string()) -> string().
-db_schema_vsn_file(BaseDir) ->
-  filename:join([BaseDir, ?DB_SCHEMA_VSN_FILE]).
-
-%% OTP does not include a library function to delete a non-empty dir.
-%% This code is adapted from:
-%% https://stackoverflow.com/questions/30606773
--spec del_dir(string()) -> ok.
-del_dir(Dir) ->
-  lists:foreach(fun(D) ->
-                    ok = file:del_dir(D)
-                end, del_all_files([Dir], [])).
-
--spec del_all_files([string()], [string()]) -> [string()].
-del_all_files([], EmptyDirs) ->
-  EmptyDirs;
-del_all_files([Dir | T], EmptyDirs) ->
-  {ok, FilesInDir} = file:list_dir(Dir),
-  {Files, Dirs} = lists:foldl(fun(F, {Fs, Ds}) ->
-                                  Path = filename:join([Dir, F]),
-                                  case filelib:is_dir(Path) of
-                                    true ->
-                                      {Fs, [Path | Ds]};
-                                    false ->
-                                      {[Path | Fs], Ds}
-                                  end
-                              end, {[], []}, FilesInDir),
-  lists:foreach(fun(F) ->
-                    ok = file:delete(F)
-                end, Files),
-  del_all_files(T ++ Dirs, [Dir | EmptyDirs]).
-
--spec maybe_report_progress_begin() ->
-        els_progress:token() | undefined.
-maybe_report_progress_begin() ->
-  case els_work_done_progress:is_supported() of
-    true ->
-      Title = <<"Initializing DB...">>,
-      Msg = <<"Loading tables...">>,
-      Token = els_work_done_progress:send_create_request(),
-      Begin = els_work_done_progress:value_begin(Title, Msg),
-      els_progress:send_notification(Token, Begin),
-      Token;
-    false ->
-      undefined
-  end.
-
--spec maybe_report_progress_end(els_progress:token()) -> ok.
-maybe_report_progress_end(Token) ->
-  case els_work_done_progress:is_supported() of
-    true ->
-      Msg = <<"Tables loaded.">>,
-      End = els_work_done_progress:value_end(Msg),
-      els_progress:send_notification(Token, End),
-      ok;
-    false ->
-      ok
   end.

--- a/src/els_dt_document.erl
+++ b/src/els_dt_document.erl
@@ -73,7 +73,7 @@ name() -> ?MODULE.
 -spec opts() -> proplists:proplist().
 opts() ->
   [ {attributes        , record_info(fields, els_dt_document)}
-  , {disc_copies       , [node()]}
+  , {ram_copies        , [node()]}
   , {index             , []}
   , {type              , set}
   , {storage_properties, [{ets, []}]}

--- a/src/els_dt_document_index.erl
+++ b/src/els_dt_document_index.erl
@@ -55,7 +55,7 @@ name() -> ?MODULE.
 -spec opts() -> proplists:proplist().
 opts() ->
   [ {attributes        , record_info(fields, els_dt_document_index)}
-  , {disc_copies       , [node()]}
+  , {ram_copies        , [node()]}
   , {index             , [#els_dt_document_index.kind]}
   , {type              , bag}
   , {storage_properties, [{ets, []}]}

--- a/src/els_dt_references.erl
+++ b/src/els_dt_references.erl
@@ -55,7 +55,7 @@ name() -> ?MODULE.
 -spec opts() -> proplists:proplist().
 opts() ->
   [ {attributes        , record_info(fields, els_dt_references)}
-  , {disc_copies       , [node()]}
+  , {ram_copies        , [node()]}
   , {index             , [#els_dt_references.uri]}
   , {type              , bag}
   , {storage_properties, [{ets, [ {read_concurrency, true}

--- a/src/els_dt_signatures.erl
+++ b/src/els_dt_signatures.erl
@@ -50,7 +50,7 @@ name() -> ?MODULE.
 -spec opts() -> proplists:proplist().
 opts() ->
   [ {attributes        , record_info(fields, els_dt_signatures)}
-  , {disc_copies       , [node()]}
+  , {ram_copies        , [node()]}
   , {index             , []}
   , {type              , set}
   , {storage_properties, [{ets, []}]}

--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -76,11 +76,8 @@ handle_request({initialize, Params}, State) ->
   NewState = State#{ root_uri => RootUri, init_options => InitOptions},
   {server_capabilities(), NewState};
 handle_request({initialized, _Params}, State) ->
-  #{root_uri := RootUri, init_options := InitOptions} = State,
-  DbDir = application:get_env(erlang_ls, db_dir, default_db_dir()),
-  OtpPath = els_config:get(otp_path),
-  NodeName = node_name(RootUri, els_utils:to_binary(OtpPath)),
-  els_db:install(NodeName, DbDir),
+  #{init_options := InitOptions} = State,
+  els_db:install(),
   case maps:get(<<"indexingEnabled">>, InitOptions, true) of
     true  -> els_indexing:start();
     false -> lager:info("Skipping Indexing (disabled via InitOptions)")
@@ -150,11 +147,3 @@ server_capabilities() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec node_name(uri(), binary()) -> atom().
-node_name(RootUri, OtpPath) ->
-  <<SHA:160/integer>> = crypto:hash(sha, <<RootUri/binary, OtpPath/binary>>),
-  list_to_atom(lists:flatten(io_lib:format("erlang_ls_~40.16.0b", [SHA]))).
-
--spec default_db_dir() -> string().
-default_db_dir() ->
-  filename:basedir(user_cache, "erlang_ls").

--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -111,13 +111,6 @@ start(Group, Entries) ->
   Task = fun({Dir, Mode}, _) -> index_dir(Dir, Mode) end,
   Config = #{ task => Task
             , entries => Entries
-              %% Indexing a directory can lead to a huge number
-              %% of DB transactions happening in a very short
-              %% time window. After indexing, let's manually
-              %% trigger a DB dump. This ensures that the DB can
-              %% be loaded much faster on a restart.
-            , on_complete => fun(_) -> els_db:dump_tables() end
-            , on_error => fun(_) -> els_db:dump_tables() end
             , title => <<"Indexing ", Group/binary>>
             },
   {ok, _Pid} = els_background_job:new(Config),

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -58,19 +58,18 @@ end_per_testcase(_TestCase, Config) ->
 %% Testcases
 %%==============================================================================
 -spec index_otp(config()) -> ok.
-index_otp(Config) ->
-  index_otp(db, ?config(priv_dir, Config)).
+index_otp(_Config) ->
+  index_otp().
 
 -spec reindex_otp(config()) -> ok.
-reindex_otp(Config) ->
-  index_otp(db, ?config(priv_dir, Config)),
+reindex_otp(_Config) ->
+  index_otp(),
   ok.
 
--spec index_otp(atom(), string()) -> ok.
-index_otp(DBName, DBDir) ->
-  ok = els_db:install(DBName, DBDir),
+-spec index_otp() -> ok.
+index_otp() ->
+  ok = els_db:install(),
   [els_indexing:index_dir(Dir, 'shallow') || Dir <- els_config:get(otp_paths)],
-  els_db:dump_tables(),
   ok = els_db:stop().
 
 -spec otp_apps_exclude() -> [string()].


### PR DESCRIPTION
1. We already store everything in RAM, with disc copies only.

2. The time to load tables on startup is comparable to the initial indexing time.

3. During indexing erlang_ls is still useful, while waiting for tables it does
not process any messages.

4. If we end up with multiple instances of erlang_ls running against the same
code base, we will not get contention for the mnesia database directory. (Note:
this can happen when running under vscode in remote mode).

Fixes #770


