### PR TITLE
[#770] Switch back from Mnesia to simple ETS

### DIFF
--- a/src/els_dap_general_provider.erl
+++ b/src/els_dap_general_provider.erl
@@ -66,7 +66,7 @@ handle_request({<<"launch">>, Params}, State) ->
 
   ProjectNode = case Params of
                   #{ <<"projectnode">> := Node } -> binary_to_atom(Node, utf8);
-                  _ -> node_name("dap_project_", Cwd)
+                  _ -> els_distribution_server:node_name("dap_project_", Cwd)
                 end,
   case Params of
     #{ <<"runinterminal">> := Cmd
@@ -86,7 +86,7 @@ handle_request({<<"launch">>, Params}, State) ->
                 els_utils:cmd("rebar3", ["shell", "--name", ProjectNode]) end)
   end,
 
-  LocalNode = node_name("dap_", Cwd),
+  LocalNode = els_distribution_server:node_name("dap_", Cwd),
   els_distribution_server:start_distribution(LocalNode),
   lager:info("Distribution up on: [~p]", [LocalNode]),
 
@@ -262,13 +262,6 @@ inject_dap_agent(Node) ->
   {Module, Bin, File} = code:get_object_code(Module),
   {_Replies, _} = els_dap_rpc:load_binary(Node, Module, File, Bin),
   ok.
-
--spec node_name(string(), binary()) -> atom().
-node_name(Prefix, Binary) ->
-  <<SHA:160/integer>> = crypto:hash(sha, Binary),
-  Id = lists:flatten(io_lib:format("~40.16.0b", [SHA])),
-  {ok, Hostname} = inet:gethostname(),
-  list_to_atom(Prefix ++ Id ++ "@" ++ Hostname).
 
 -spec id(pid()) -> integer().
 id(Pid) ->

--- a/src/els_db.erl
+++ b/src/els_db.erl
@@ -4,114 +4,17 @@
 -export([ clear_table/1
         , clear_tables/0
         , delete/2
-        , delete_object/1
-        , dump_tables/0
-        , install/2
+        , delete_object/2
         , lookup/2
-        , match/1
-        , stop/0
+        , match/2
+        , match_delete/2
         , tables/0
-        , transaction/1
-        , write/1
+        , write/2
         ]).
-
--define(SERVER, ?MODULE).
--define(TIMEOUT, infinity).
--define(DB_SCHEMA_VSN, <<"9">>).
--define(DB_SCHEMA_VSN_FILE, "DB_SCHEMA_VSN").
 
 %%==============================================================================
 %% Exported functions
 %%==============================================================================
-
--spec install(atom(), string()) -> ok.
-install(NodeName, BaseDir) ->
-  els_distribution_server:start_distribution(NodeName),
-  DbDir = filename:join([BaseDir, atom_to_list(NodeName)]),
-  lager:info("Configuring DB [dir=~s]", [DbDir]),
-  ok = filelib:ensure_dir(filename:join([DbDir, "dummy"])),
-  ok = application:set_env(mnesia, dir, DbDir),
-  %% Avoid mnesia overload while indexing
-  ok = application:set_env(mnesia, dump_log_write_threshold, 50000),
-  %% We have 4 tables. Let's load them in parallel
-  ok = application:set_env(mnesia, no_table_loaders, 4),
-  ensure_db(DbDir).
-
--spec stop() -> ok | {error, any()}.
-stop() ->
-  application:stop(mnesia).
-
--spec ensure_db(string()) -> ok.
-ensure_db(DbDir) ->
-  maybe_delete_db_schema(DbDir),
-  ok = write_db_schema_vsn_file(filename:dirname(DbDir)),
-  case mnesia:create_schema([node()]) of
-    {error, {_, {already_exists, _}}} ->
-      lager:info("DB Schema already exists, skipping"),
-      ok;
-    ok ->
-      lager:info("DB Schema created"),
-      ok
-  end,
-  lager:info("Preparing tables"),
-  application:start(mnesia),
-  ensure_tables(),
-  wait_for_tables(),
-  lager:info("DB Initialized"),
-  ok.
-
--spec ensure_tables() -> ok.
-ensure_tables() ->
-  [els_db_table:ensure(T) || T <- tables()],
-  ok.
-
--spec delete(atom(), any()) -> ok.
-delete(Table, Key) ->
-  mnesia:dirty_delete({Table, Key}).
-
--spec delete_object(any()) -> ok.
-delete_object(Item) ->
-  mnesia:dirty_delete_object(Item).
-
--spec dump_tables() -> ok.
-dump_tables() ->
-  %% First dump the content of the .LOG file to the respective .DCL
-  %% files, then merge the .DCL files into the .DCD files.
-  mnesia:dump_log(),
-  mnesia_controller:snapshot_dcd(tables()),
-  ok.
-
--spec lookup(atom(), any()) -> {ok, [tuple()]}.
-lookup(Table, Key) ->
-  {ok, mnesia:dirty_read(Table, Key)}.
-
--spec match(tuple()) -> {ok, [tuple()]}.
-match(Pattern) when is_tuple(Pattern) ->
-  {ok, mnesia:dirty_match_object(Pattern)}.
-
--spec write(tuple()) -> ok.
-write(Record) when is_tuple(Record) ->
-  mnesia:dirty_write(Record).
-
--spec clear_tables() -> ok.
-clear_tables() ->
-  [ok = clear_table(T) || T <- tables()],
-  ok.
-
--spec wait_for_tables() -> ok.
-wait_for_tables() ->
-  wait_for_tables(?TIMEOUT).
-
--spec wait_for_tables(timeout()) -> ok.
-wait_for_tables(Timeout) ->
-  Token = maybe_report_progress_begin(),
-  ok = mnesia:wait_for_tables(tables(), Timeout),
-  maybe_report_progress_end(Token).
-
--spec clear_table(atom()) -> ok.
-clear_table(Table) ->
-  mnesia:clear_table(Table),
-  ok.
 
 -spec tables() -> [atom()].
 tables() ->
@@ -121,99 +24,35 @@ tables() ->
   , els_dt_signatures
   ].
 
--spec transaction(function()) -> ok | {ok, any()} | {error, any()}.
-transaction(F) ->
-  case mnesia:transaction(F) of
-    {aborted, Reason} -> {error, {aborted, Reason}};
-    {atomic, ok}      -> ok;
-    {atomic, Result}  -> {ok, Result}
-  end.
+-spec delete(atom(), any()) -> ok.
+delete(Table, Key) ->
+  els_db_server:delete(Table, Key).
 
--spec maybe_delete_db_schema(string()) -> ok.
-maybe_delete_db_schema(DbDir) ->
-  case read_db_schema_vsn_file(filename:dirname(DbDir)) of
-    ?DB_SCHEMA_VSN ->
-      Fmt = "DB Schema up to date [dir=~s] [vsn=~s]",
-      Args = [DbDir, ?DB_SCHEMA_VSN],
-      lager:info(Fmt, Args);
-    Vsn ->
-      Fmt = "Deleting DB Schema [dir=~s] [current_vsn=~s] [required_vsn=~s]",
-      Args = [DbDir, Vsn, ?DB_SCHEMA_VSN],
-      lager:info(Fmt, Args),
-      ok = del_dir(DbDir)
-  end.
+-spec delete_object(atom(), any()) -> ok.
+delete_object(Table, Object) ->
+  els_db_server:delete_object(Table, Object).
 
--spec write_db_schema_vsn_file(string()) -> ok.
-write_db_schema_vsn_file(BaseDir) ->
-  ok = file:write_file(db_schema_vsn_file(BaseDir), ?DB_SCHEMA_VSN).
+-spec lookup(atom(), any()) -> {ok, [tuple()]}.
+lookup(Table, Key) ->
+  {ok, ets:lookup(Table, Key)}.
 
--spec read_db_schema_vsn_file(string()) -> binary().
-read_db_schema_vsn_file(BaseDir) ->
-  case file:read_file(db_schema_vsn_file(BaseDir)) of
-    {ok, Vsn} ->
-      Vsn;
-    {error, Error} ->
-      Fmt = "Error while accessing DB Schema Vsn file [error=~p]",
-      Args = [Error],
-      lager:warning(Fmt, Args),
-      <<>>
-  end.
+-spec match(atom(), tuple()) -> {ok, [tuple()]}.
+match(Table, Pattern) when is_tuple(Pattern) ->
+  {ok, ets:match_object(Table, Pattern)}.
 
--spec db_schema_vsn_file(string()) -> string().
-db_schema_vsn_file(BaseDir) ->
-  filename:join([BaseDir, ?DB_SCHEMA_VSN_FILE]).
+-spec match_delete(atom(), tuple()) -> ok.
+match_delete(Table, Pattern) when is_tuple(Pattern) ->
+  els_db_server:match_delete(Table, Pattern).
 
-%% OTP does not include a library function to delete a non-empty dir.
-%% This code is adapted from:
-%% https://stackoverflow.com/questions/30606773
--spec del_dir(string()) -> ok.
-del_dir(Dir) ->
-  lists:foreach(fun(D) ->
-                    ok = file:del_dir(D)
-                end, del_all_files([Dir], [])).
+-spec write(atom(), tuple()) -> ok.
+write(Table, Object) when is_tuple(Object) ->
+  els_db_server:write(Table, Object).
 
--spec del_all_files([string()], [string()]) -> [string()].
-del_all_files([], EmptyDirs) ->
-  EmptyDirs;
-del_all_files([Dir | T], EmptyDirs) ->
-  {ok, FilesInDir} = file:list_dir(Dir),
-  {Files, Dirs} = lists:foldl(fun(F, {Fs, Ds}) ->
-                                  Path = filename:join([Dir, F]),
-                                  case filelib:is_dir(Path) of
-                                    true ->
-                                      {Fs, [Path | Ds]};
-                                    false ->
-                                      {[Path | Fs], Ds}
-                                  end
-                              end, {[], []}, FilesInDir),
-  lists:foreach(fun(F) ->
-                    ok = file:delete(F)
-                end, Files),
-  del_all_files(T ++ Dirs, [Dir | EmptyDirs]).
+-spec clear_table(atom()) -> ok.
+clear_table(Table) ->
+  els_db_server:clear_table(Table).
 
--spec maybe_report_progress_begin() ->
-        els_progress:token() | undefined.
-maybe_report_progress_begin() ->
-  case els_work_done_progress:is_supported() of
-    true ->
-      Title = <<"Initializing DB...">>,
-      Msg = <<"Loading tables...">>,
-      Token = els_work_done_progress:send_create_request(),
-      Begin = els_work_done_progress:value_begin(Title, Msg),
-      els_progress:send_notification(Token, Begin),
-      Token;
-    false ->
-      undefined
-  end.
-
--spec maybe_report_progress_end(els_progress:token()) -> ok.
-maybe_report_progress_end(Token) ->
-  case els_work_done_progress:is_supported() of
-    true ->
-      Msg = <<"Tables loaded.">>,
-      End = els_work_done_progress:value_end(Msg),
-      els_progress:send_notification(Token, End),
-      ok;
-    false ->
-      ok
-  end.
+-spec clear_tables() -> ok.
+clear_tables() ->
+  [ok = clear_table(T) || T <- tables()],
+  ok.

--- a/src/els_db_server.erl
+++ b/src/els_db_server.erl
@@ -1,0 +1,94 @@
+%%%=============================================================================
+%%% @doc The db gen_server.
+%%% @end
+%%%=============================================================================
+
+-module(els_db_server).
+
+%%==============================================================================
+%% API
+%%==============================================================================
+-export([ start_link/0
+        , clear_table/1
+        , delete/2
+        , delete_object/2
+        , match_delete/2
+        , write/2
+        ]).
+
+%%==============================================================================
+%% Callbacks for the gen_server behaviour
+%%==============================================================================
+-behaviour(gen_server).
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        ]).
+-type state() :: #{}.
+
+%%==============================================================================
+%% Macro Definitions
+%%==============================================================================
+-define(SERVER, ?MODULE).
+
+%%==============================================================================
+%% API
+%%==============================================================================
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+  gen_server:start_link({local, ?SERVER}, ?MODULE, unused, []).
+
+-spec clear_table(atom()) -> ok.
+clear_table(Table) ->
+  gen_server:call(?SERVER, {clear_table, Table}).
+
+-spec delete(atom(), any()) -> ok.
+delete(Table, Key) ->
+  gen_server:call(?SERVER, {delete, Table, Key}).
+
+-spec delete_object(atom(), any()) -> ok.
+delete_object(Table, Key) ->
+  gen_server:call(?SERVER, {delete_object, Table, Key}).
+
+-spec match_delete(atom(), tuple()) -> ok.
+match_delete(Table, Pattern) ->
+  gen_server:call(?SERVER, {match_delete, Table, Pattern}).
+
+-spec write(atom(), tuple()) -> ok.
+write(Table, Object) ->
+  gen_server:call(?SERVER, {write, Table, Object}).
+
+%%==============================================================================
+%% Callbacks for the gen_server behaviour
+%%==============================================================================
+-spec init(unused) -> {ok, state()}.
+init(unused) ->
+  [ok = els_db_table:init(Table) || Table <- els_db:tables()],
+  {ok, #{}}.
+
+-spec handle_call(any(), {pid(), any()}, state()) ->
+        {reply, any(), state()} | {noreply, state()}.
+handle_call({clear_table, Table}, _From, State) ->
+  true = ets:delete_all_objects(Table),
+  {reply, ok, State};
+handle_call({delete, Table, Key}, _From, State) ->
+  true = ets:delete(Table, Key),
+  {reply, ok, State};
+handle_call({delete_object, Table, Key}, _From, State) ->
+  true = ets:delete_object(Table, Key),
+  {reply, ok, State};
+handle_call({match_delete, Table, Pattern}, _From, State) ->
+  true = ets:match_delete(Table, Pattern),
+  {reply, ok, State};
+handle_call({write, Table, Object}, _From, State) ->
+  true = ets:insert(Table, Object),
+  {reply, ok, State}.
+
+-spec handle_cast(any(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) ->
+  {noreply, State}.
+
+-spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info(_Request, State) ->
+  {noreply, State}.

--- a/src/els_db_table.erl
+++ b/src/els_db_table.erl
@@ -15,17 +15,37 @@
 %% Exports
 %%==============================================================================
 
--export([ ensure/1 ]).
+-export([ default_opts/0
+        , init/1
+        , name/1
+        , opts/1
+        ]).
+
+%%==============================================================================
+%% Type Definitions
+%%==============================================================================
+-type table() :: atom().
+-export_type([ table/0 ]).
 
 %%==============================================================================
 %% API
 %%==============================================================================
 
--spec ensure(module()) -> ok.
-ensure(Table) ->
-  case mnesia:create_table(Table:name(), Table:opts()) of
-    {atomic, ok} ->
-      ok;
-    {aborted, {already_exists, _}} ->
-      ok
-  end.
+-spec default_opts() -> [any()].
+default_opts() ->
+  [public, named_table, {keypos, 2}, {read_concurrency, true}].
+
+-spec init(table()) -> ok.
+init(Table) ->
+  TableName = name(Table),
+  lager:info("Creating table [name=~p]", [TableName]),
+  ets:new(TableName, opts(Table)),
+  ok.
+
+-spec name(table()) -> atom().
+name(Table) ->
+  Table:name().
+
+-spec opts(table()) -> proplists:proplist().
+opts(Table) ->
+  default_opts() ++ Table:opts().

--- a/src/els_distribution_server.erl
+++ b/src/els_distribution_server.erl
@@ -15,6 +15,7 @@
         , wait_connect_and_monitor/2
         , rpc_call/3
         , rpc_call/4
+        , node_name/2
         ]).
 
 %%==============================================================================
@@ -166,3 +167,11 @@ wait_connect_and_monitor(Node, Attempts) ->
 ensure_epmd() ->
   0 = els_utils:cmd("epmd", ["-daemon"]),
   ok.
+
+-spec node_name(string(), binary()) -> atom().
+node_name(Prefix, Binary) ->
+  <<SHA:160/integer>> = crypto:hash(sha, Binary),
+  Int = erlang:unique_integer([positive]),
+  Id = lists:flatten(io_lib:format("~40.16.0b_~p", [SHA, Int])),
+  {ok, Hostname} = inet:gethostname(),
+  list_to_atom(Prefix ++ Id ++ "@" ++ Hostname).

--- a/src/els_dt_document.erl
+++ b/src/els_dt_document.erl
@@ -72,12 +72,7 @@ name() -> ?MODULE.
 
 -spec opts() -> proplists:proplist().
 opts() ->
-  [ {attributes        , record_info(fields, els_dt_document)}
-  , {disc_copies       , [node()]}
-  , {index             , []}
-  , {type              , set}
-  , {storage_properties, [{ets, []}]}
-  ].
+  [].
 
 %%==============================================================================
 %% API
@@ -118,7 +113,7 @@ to_item(#els_dt_document{ uri  = Uri
 -spec insert(item()) -> ok | {error, any()}.
 insert(Map) when is_map(Map) ->
   Record = from_item(Map),
-  els_db:write(Record).
+  els_db:write(name(), Record).
 
 -spec lookup(uri()) -> {ok, [item()]}.
 lookup(Uri) ->

--- a/src/els_dt_document_index.erl
+++ b/src/els_dt_document_index.erl
@@ -54,12 +54,7 @@ name() -> ?MODULE.
 
 -spec opts() -> proplists:proplist().
 opts() ->
-  [ {attributes        , record_info(fields, els_dt_document_index)}
-  , {disc_copies       , [node()]}
-  , {index             , [#els_dt_document_index.kind]}
-  , {type              , bag}
-  , {storage_properties, [{ets, []}]}
-  ].
+  [bag].
 
 %%==============================================================================
 %% API
@@ -76,7 +71,7 @@ to_item(#els_dt_document_index{id = Id, uri = Uri, kind = Kind}) ->
 -spec insert(item()) -> ok | {error, any()}.
 insert(Map) when is_map(Map) ->
   Record = from_item(Map),
-  els_db:write(Record).
+  els_db:write(name(), Record).
 
 -spec lookup(atom()) -> {ok, [item()]}.
 lookup(Id) ->
@@ -86,7 +81,7 @@ lookup(Id) ->
 -spec find_by_kind(els_dt_document:kind()) -> {ok, [item()]}.
 find_by_kind(Kind) ->
   Pattern = #els_dt_document_index{kind = Kind, _ = '_'},
-  {ok, Items} = els_db:match(Pattern),
+  {ok, Items} = els_db:match(name(), Pattern),
   {ok, [to_item(Item) || Item <- Items]}.
 
 -spec new(atom(), uri(), els_dt_document:kind()) -> item().

--- a/src/els_dt_references.erl
+++ b/src/els_dt_references.erl
@@ -54,13 +54,7 @@ name() -> ?MODULE.
 
 -spec opts() -> proplists:proplist().
 opts() ->
-  [ {attributes        , record_info(fields, els_dt_references)}
-  , {disc_copies       , [node()]}
-  , {index             , [#els_dt_references.uri]}
-  , {type              , bag}
-  , {storage_properties, [{ets, [ {read_concurrency, true}
-                                , {write_concurrency, true} ]}]}
-  ].
+  [bag].
 
 %%==============================================================================
 %% API
@@ -81,14 +75,12 @@ to_item(#els_dt_references{ id = {_Category, Id}, uri = Uri, range = Range }) ->
 -spec delete_by_uri(uri()) -> ok | {error, any()}.
 delete_by_uri(Uri) ->
   Pattern = #els_dt_references{uri = Uri, _ = '_'},
-  {ok, Items} = els_db:match(Pattern),
-  [ok = els_db:delete_object(Item) ||  Item <- Items],
-  ok.
+  ok = els_db:match_delete(name(), Pattern).
 
 -spec insert(poi_kind(), item()) -> ok | {error, any()}.
 insert(Kind, Map) when is_map(Map) ->
   Record = from_item(Kind, Map),
-  els_db:write(Record).
+  els_db:write(name(), Record).
 
 %% @doc Find all
 -spec find_all() -> {ok, [item()]} | {error, any()}.
@@ -105,7 +97,7 @@ find_by_id(Kind, Id) ->
 
 -spec find_by(tuple()) -> {ok, [item()]}.
 find_by(Pattern) ->
-  {ok, Items} = els_db:match(Pattern),
+  {ok, Items} = els_db:match(name(), Pattern),
   {ok, [to_item(Item) || Item <- Items]}.
 
 -spec kind_to_category(poi_kind()) -> function | type | macro | record.

--- a/src/els_dt_signatures.erl
+++ b/src/els_dt_signatures.erl
@@ -49,12 +49,7 @@ name() -> ?MODULE.
 
 -spec opts() -> proplists:proplist().
 opts() ->
-  [ {attributes        , record_info(fields, els_dt_signatures)}
-  , {disc_copies       , [node()]}
-  , {index             , []}
-  , {type              , set}
-  , {storage_properties, [{ets, []}]}
-  ].
+  [].
 
 %%==============================================================================
 %% API
@@ -73,7 +68,7 @@ to_item(#els_dt_signatures{ mfa = MFA, spec = Spec }) ->
 -spec insert(item()) -> ok | {error, any()}.
 insert(Map) when is_map(Map) ->
   Record = from_item(Map),
-  els_db:write(Record).
+  els_db:write(name(), Record).
 
 -spec lookup(mfa()) -> {ok, [item()]}.
 lookup(MFA) ->

--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -76,11 +76,7 @@ handle_request({initialize, Params}, State) ->
   NewState = State#{ root_uri => RootUri, init_options => InitOptions},
   {server_capabilities(), NewState};
 handle_request({initialized, _Params}, State) ->
-  #{root_uri := RootUri, init_options := InitOptions} = State,
-  DbDir = application:get_env(erlang_ls, db_dir, default_db_dir()),
-  OtpPath = els_config:get(otp_path),
-  NodeName = node_name(RootUri, els_utils:to_binary(OtpPath)),
-  els_db:install(NodeName, DbDir),
+  #{init_options := InitOptions} = State,
   case maps:get(<<"indexingEnabled">>, InitOptions, true) of
     true  -> els_indexing:start();
     false -> lager:info("Skipping Indexing (disabled via InitOptions)")
@@ -146,15 +142,3 @@ server_capabilities() ->
         , version => els_utils:to_binary(Version)
         }
    }.
-
-%%==============================================================================
-%% Internal Functions
-%%==============================================================================
--spec node_name(uri(), binary()) -> atom().
-node_name(RootUri, OtpPath) ->
-  <<SHA:160/integer>> = crypto:hash(sha, <<RootUri/binary, OtpPath/binary>>),
-  list_to_atom(lists:flatten(io_lib:format("erlang_ls_~40.16.0b", [SHA]))).
-
--spec default_db_dir() -> string().
-default_db_dir() ->
-  filename:basedir(user_cache, "erlang_ls").

--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -60,10 +60,7 @@ index(Uri, Text, Mode) ->
       ok;
     _ ->
       Document = els_dt_document:new(Uri, Text),
-      F = fun() ->
-              do_index(Document, Mode)
-          end,
-      els_db:transaction(F)
+      do_index(Document, Mode)
   end.
 
 -spec do_index(els_dt_document:item(), mode()) -> ok.
@@ -111,13 +108,6 @@ start(Group, Entries) ->
   Task = fun({Dir, Mode}, _) -> index_dir(Dir, Mode) end,
   Config = #{ task => Task
             , entries => Entries
-              %% Indexing a directory can lead to a huge number
-              %% of DB transactions happening in a very short
-              %% time window. After indexing, let's manually
-              %% trigger a DB dump. This ensures that the DB can
-              %% be loaded much faster on a restart.
-            , on_complete => fun(_) -> els_db:dump_tables() end
-            , on_error => fun(_) -> els_db:dump_tables() end
             , title => <<"Indexing ", Group/binary>>
             },
   {ok, _Pid} = els_background_job:new(Config),

--- a/src/els_sup.erl
+++ b/src/els_sup.erl
@@ -48,6 +48,10 @@ init([]) ->
                   , start    => {els_config, start_link, []}
                   , shutdown => brutal_kill
                   }
+               , #{ id       => els_db_server
+                  , start    => {els_db_server, start_link, []}
+                  , shutdown => brutal_kill
+                  }
                , #{ id    => els_providers_sup
                   , start => {els_providers_sup, start_link, []}
                   , type  => supervisor

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -168,7 +168,6 @@ resolve_paths(PathSpecs, RootPath, Recursive) ->
 
 -spec halt(non_neg_integer()) -> ok.
 halt(ExitCode) ->
-  els_db:stop(),
   ok = init:stop(ExitCode).
 
 %% @doc Returns a project-relative file path for a given URI

--- a/test/els_indexing_SUITE.erl
+++ b/test/els_indexing_SUITE.erl
@@ -58,20 +58,18 @@ end_per_testcase(_TestCase, Config) ->
 %% Testcases
 %%==============================================================================
 -spec index_otp(config()) -> ok.
-index_otp(Config) ->
-  index_otp(db, ?config(priv_dir, Config)).
+index_otp(_Config) ->
+  do_index_otp().
 
 -spec reindex_otp(config()) -> ok.
-reindex_otp(Config) ->
-  index_otp(db, ?config(priv_dir, Config)),
+reindex_otp(_Config) ->
+  do_index_otp(),
   ok.
 
--spec index_otp(atom(), string()) -> ok.
-index_otp(DBName, DBDir) ->
-  ok = els_db:install(DBName, DBDir),
+-spec do_index_otp() -> ok.
+do_index_otp() ->
   [els_indexing:index_dir(Dir, 'shallow') || Dir <- els_config:get(otp_paths)],
-  els_db:dump_tables(),
-  ok = els_db:stop().
+  ok.
 
 -spec otp_apps_exclude() -> [string()].
 otp_apps_exclude() ->

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -75,8 +75,6 @@ init_per_testcase(_TestCase, Config) ->
   RootUri   = ?config(root_uri, Config),
   els_client:initialize(RootUri, #{indexingEnabled => false}),
   els_client:initialized(),
-  %% Ensure the DB is up and running before attempting manual indexing
-  wait_for_db(),
   SrcConfig = lists:flatten(
                 [index_file(RootPath, src, S) || S <- sources()]),
   TestConfig = lists:flatten(
@@ -245,15 +243,3 @@ wait_until_mock_called(M, F) ->
     _ ->
       ok
   end.
-
--spec wait_for_db() -> ok.
-wait_for_db() ->
-  CheckFun = fun() ->
-                 try mnesia:wait_for_tables(els_db:tables(), 5000) of
-                   ok -> true;
-                   _Error -> false
-                 catch _C:_E:_S ->
-                     false
-                 end
-             end,
-  wait_for_fun(CheckFun, 200, 10).


### PR DESCRIPTION
### Description

For now, let's switch back to plain ETS. We can then follow up by adding persistence (via DETS) if necessary. In that case, we could have a dedicated option in the `erlang_ls.config` file to enable it. Before adding persistency, we should really check if it's worth, performance-wise.

All write operations to the ETS tables are serialized via a `gen_server`. Reads happen straight from the ETS table, which has `read_concurrency` enabled, even if it shouldn't matter much in Erlang LS.

Fixes #770 .
