### PR TITLE
[#812] Use project basename for ELS and DAP node names

### DIFF
--- a/src/els_dap_general_provider.erl
+++ b/src/els_dap_general_provider.erl
@@ -63,11 +63,12 @@ handle_request({<<"initialize">>, _Params}, State) ->
 handle_request({<<"launch">>, Params}, State) ->
   #{<<"cwd">> := Cwd} = Params,
   ok = file:set_cwd(Cwd),
-
-  ProjectNode = case Params of
-                  #{ <<"projectnode">> := Node } -> binary_to_atom(Node, utf8);
-                  _ -> els_distribution_server:node_name("dap_project_", Cwd)
-                end,
+  Name = filename:basename(Cwd),
+  ProjectNode =
+    case Params of
+      #{ <<"projectnode">> := Node } -> binary_to_atom(Node, utf8);
+      _ -> els_distribution_server:node_name(<<"erlang_ls_dap_project">>, Name)
+    end,
   case Params of
     #{ <<"runinterminal">> := Cmd
      } ->
@@ -85,8 +86,7 @@ handle_request({<<"launch">>, Params}, State) ->
       spawn(fun() ->
                 els_utils:cmd("rebar3", ["shell", "--name", ProjectNode]) end)
   end,
-
-  LocalNode = els_distribution_server:node_name("dap_", Cwd),
+  LocalNode = els_distribution_server:node_name(<<"erlang_ls_dap">>, Name),
   els_distribution_server:start_distribution(LocalNode),
   lager:info("Distribution up on: [~p]", [LocalNode]),
 

--- a/src/els_distribution_server.erl
+++ b/src/els_distribution_server.erl
@@ -168,10 +168,9 @@ ensure_epmd() ->
   0 = els_utils:cmd("epmd", ["-daemon"]),
   ok.
 
--spec node_name(string(), binary()) -> atom().
-node_name(Prefix, Binary) ->
-  <<SHA:160/integer>> = crypto:hash(sha, Binary),
-  Int = erlang:unique_integer([positive]),
-  Id = lists:flatten(io_lib:format("~40.16.0b_~p", [SHA, Int])),
+-spec node_name(binary(), binary()) -> atom().
+node_name(Prefix, Name) ->
+  Int = erlang:phash2(erlang:timestamp()),
+  Id = lists:flatten(io_lib:format("~s_~s_~p", [Prefix, Name, Int])),
   {ok, Hostname} = inet:gethostname(),
-  list_to_atom(Prefix ++ Id ++ "@" ++ Hostname).
+  list_to_atom(Id ++ "@" ++ Hostname).

--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -77,9 +77,8 @@ handle_request({initialize, Params}, State) ->
   {server_capabilities(), NewState};
 handle_request({initialized, _Params}, State) ->
   #{root_uri := RootUri, init_options := InitOptions} = State,
-  OtpPath = els_utils:to_binary(els_config:get(otp_path)),
-  Binary = <<RootUri/binary, OtpPath/binary>>,
-  NodeName = els_distribution_server:node_name("els_", Binary),
+  NodeName = els_distribution_server:node_name( <<"erlang_ls">>
+                                              , filename:basename(RootUri)),
   els_distribution_server:start_distribution(NodeName),
   lager:info("Started distribution for: [~p]", [NodeName]),
   case maps:get(<<"indexingEnabled">>, InitOptions, true) of


### PR DESCRIPTION
### Description

Fixes #812 
