### PR TITLE
Rename xref diagnostics to crossref

### DIFF
--- a/src/els_crossref_diagnostics.erl
+++ b/src/els_crossref_diagnostics.erl
@@ -1,7 +1,8 @@
 %%==============================================================================
-%% Xref diagnostics
+%% Crossref diagnostics
+%% Like xref, but using the internal indexing results
 %%==============================================================================
--module(els_xref_diagnostics).
+-module(els_crossref_diagnostics).
 
 %%==============================================================================
 %% Behaviours
@@ -45,7 +46,7 @@ run(Uri) ->
 
 -spec source() -> binary().
 source() ->
-  <<"XRef">>.
+  <<"CrossRef">>.
 
 %%==============================================================================
 %% Internal Functions

--- a/src/els_diagnostics.erl
+++ b/src/els_diagnostics.erl
@@ -57,9 +57,9 @@
 -spec available_diagnostics() -> [diagnostic_id()].
 available_diagnostics() ->
   [ <<"compiler">>
+  , <<"crossref">>
   , <<"dialyzer">>
   , <<"elvis">>
-  , <<"xref">>
   , <<"unused_includes">>
   ].
 

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -26,8 +26,8 @@
         , escript/1
         , escript_warnings/1
         , escript_errors/1
-        , xref/1
-        , xref_pseudo_functions/1
+        , crossref/1
+        , crossref_pseudo_functions/1
         , unused_includes/1
         ]).
 
@@ -72,16 +72,16 @@ init_per_testcase(TestCase, Config) when TestCase =:= code_reload orelse
   mock_rpc(),
   mock_code_reload_enabled(),
   els_test_utils:init_per_testcase(TestCase, Config);
-init_per_testcase(xref, Config) ->
-  meck:new(els_xref_diagnostics, [passthrough, no_link]),
-  meck:expect(els_xref_diagnostics, is_default, 0, true),
+init_per_testcase(crossref, Config) ->
+  meck:new(els_crossref_diagnostics, [passthrough, no_link]),
+  meck:expect(els_crossref_diagnostics, is_default, 0, true),
   els_mock_diagnostics:setup(),
-  els_test_utils:init_per_testcase(xref, Config);
-init_per_testcase(xref_pseudo_functions, Config) ->
-  meck:new(els_xref_diagnostics, [passthrough, no_link]),
-  meck:expect(els_xref_diagnostics, is_default, 0, true),
+  els_test_utils:init_per_testcase(crossref, Config);
+init_per_testcase(crossref_pseudo_functions, Config) ->
+  meck:new(els_crossref_diagnostics, [passthrough, no_link]),
+  meck:expect(els_crossref_diagnostics, is_default, 0, true),
   els_mock_diagnostics:setup(),
-  els_test_utils:init_per_testcase(xref_pseudo_functions, Config);
+  els_test_utils:init_per_testcase(crossref_pseudo_functions, Config);
 init_per_testcase(unused_includes, Config) ->
   meck:new(els_unused_includes_diagnostics, [passthrough, no_link]),
   meck:expect(els_unused_includes_diagnostics, is_default, 0, true),
@@ -97,14 +97,14 @@ end_per_testcase(TestCase, Config) when TestCase =:= code_reload orelse
   unmock_rpc(),
   unmock_code_reload_enabled(),
   els_test_utils:end_per_testcase(TestCase, Config);
-end_per_testcase(xref, Config) ->
-  meck:unload(els_xref_diagnostics),
-  els_test_utils:end_per_testcase(xref, Config),
+end_per_testcase(crossref, Config) ->
+  meck:unload(els_crossref_diagnostics),
+  els_test_utils:end_per_testcase(crossref, Config),
   els_mock_diagnostics:teardown(),
   ok;
-end_per_testcase(xref_pseudo_functions, Config) ->
-  meck:unload(els_xref_diagnostics),
-  els_test_utils:end_per_testcase(xref_pseudo_functions, Config),
+end_per_testcase(crossref_pseudo_functions, Config) ->
+  meck:unload(els_crossref_diagnostics),
+  els_test_utils:end_per_testcase(crossref_pseudo_functions, Config),
   els_mock_diagnostics:teardown(),
   ok;
 end_per_testcase(unused_includes, Config) ->
@@ -405,8 +405,8 @@ code_reload_sticky_mod(Config) ->
   ?assertNot(meck:called(rpc, call, ['fakenode', c, c, [Module]])),
   ok.
 
--spec xref(config()) -> ok.
-xref(Config) ->
+-spec crossref(config()) -> ok.
+crossref(Config) ->
   Uri = ?config(diagnostics_xref_uri, Config),
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
@@ -416,14 +416,14 @@ xref(Config) ->
                 , range =>
                     #{ 'end' => #{character => 11, line => 5}
                      , start => #{character => 2, line => 5}}
-                , severity => 1, source => <<"XRef">>}
+                , severity => 1, source => <<"CrossRef">>}
              , #{ message =>
                     <<"Cannot find definition for function non_existing/0">>
                 , range =>
                     #{ 'end' => #{character => 14, line => 6}
                      , start => #{character => 2, line => 6}}
                 , severity => 1
-                , source => <<"XRef">>
+                , source => <<"CrossRef">>
                 }
              , #{ message =>
                     <<"function non_existing/0 undefined">>
@@ -439,8 +439,8 @@ xref(Config) ->
   ok.
 
 %% #641
--spec xref_pseudo_functions(config()) -> ok.
-xref_pseudo_functions(Config) ->
+-spec crossref_pseudo_functions(config()) -> ok.
+crossref_pseudo_functions(Config) ->
   Uri = ?config(diagnostics_xref_pseudo_uri, Config),
   els_mock_diagnostics:subscribe(),
   ok = els_client:did_save(Uri),
@@ -451,7 +451,7 @@ xref_pseudo_functions(Config) ->
        range =>
          #{'end' => #{character => 28, line => 30},
            start => #{character => 2, line => 30}},
-       severity => 1, source => <<"XRef">>}],
+       severity => 1, source => <<"CrossRef">>}],
   F = fun(#{message := M1}, #{message := M2}) -> M1 =< M2 end,
   ?assertEqual(Expected, lists:sort(F, Diagnostics)),
   ok.

--- a/test/els_initialization_SUITE.erl
+++ b/test/els_initialization_SUITE.erl
@@ -128,7 +128,7 @@ initialize_diagnostics_custom(Config) ->
   ConfigPath = filename:join(DataDir, "diagnostics_custom.config"),
   InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
   els_client:initialize(RootUri, InitOpts),
-  Expected = [<<"compiler">>, <<"dialyzer">>, <<"xref">>],
+  Expected = [<<"compiler">>, <<"crossref">>, <<"dialyzer">>],
   Result = els_diagnostics:enabled_diagnostics(),
   ?assertEqual(Expected, Result),
   ok.
@@ -141,7 +141,7 @@ initialize_diagnostics_invalid(Config) ->
   InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
   els_client:initialize(RootUri, InitOpts),
   Result = els_diagnostics:enabled_diagnostics(),
-  Expected = [<<"compiler">>, <<"dialyzer">>, <<"elvis">>, <<"xref">>],
+  Expected = [<<"compiler">>, <<"crossref">>, <<"dialyzer">>, <<"elvis">>],
   ?assertEqual(Expected, Result),
   ok.
 

--- a/test/els_initialization_SUITE_data/diagnostics_custom.config
+++ b/test/els_initialization_SUITE_data/diagnostics_custom.config
@@ -1,5 +1,5 @@
 diagnostics:
   enabled:
-    - xref
+    - crossref
   disabled:
     - elvis

--- a/test/els_initialization_SUITE_data/diagnostics_invalid.config
+++ b/test/els_initialization_SUITE_data/diagnostics_invalid.config
@@ -1,5 +1,5 @@
 diagnostics:
   enabled:
-    - xref
+    - crossref
   disabled:
     - elviss # Typo intentional


### PR DESCRIPTION
This is an internal erlang_ls diagnostic, based on the results of indexing.

The name 'xref' causes people to think it is a version of the 'xref' tool.

This also opens the way to provide an integration of the actual 'xref' tool at a
fututure date.

