### PR TITLE
[#404] Add experimental diagnostics to detect unused included files

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -579,6 +579,7 @@
                    | include_lib
                    | macro
                    | module
+                   | parse_transform
                    | record
                    | record_access
                    | record_expr

--- a/priv/code_navigation/include/definition.hrl
+++ b/priv/code_navigation/include/definition.hrl
@@ -1,0 +1,1 @@
+-define(MACRO_FOR_TRANSITIVE_INCLUSION, true).

--- a/priv/code_navigation/include/transitive.hrl
+++ b/priv/code_navigation/include/transitive.hrl
@@ -1,0 +1,1 @@
+-include("definition.hrl").

--- a/priv/code_navigation/src/diagnostics_unused_includes.erl
+++ b/priv/code_navigation/src/diagnostics_unused_includes.erl
@@ -1,0 +1,14 @@
+-module(diagnostics_unused_includes).
+
+-include_lib("kernel/include/file.hrl").
+-include_lib("et/include/et.hrl").
+-include("code_navigation.hrl").
+-include("diagnostics.hrl").
+-include("transitive.hrl").
+
+-export([main/0]).
+
+-spec main() -> {defined_type(), any()}.
+main() ->
+  _ = #file_info{},
+  {?INCLUDED_MACRO_A, ?MACRO_FOR_TRANSITIVE_INCLUSION}.

--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -16,6 +16,10 @@
 %% identity function for our own diagnostics
 -export([ format_error/1 ]).
 
+-export([ inclusion_range/2
+        , inclusion_range/3
+        ]).
+
 %%==============================================================================
 %% Includes
 %%==============================================================================
@@ -241,7 +245,9 @@ include_lib_id(Path) ->
   Length     = length(Components),
   End        = Length - 1,
   Beginning  = max(1, Length - 2),
-  filename:join(lists:sublist(Components, Beginning, End)).
+  [H|T]      = lists:sublist(Components, Beginning, End),
+  %% Strip the app version number from the path
+  filename:join([re:replace(H, "-.*", "", [{return, list}])], filename:join(T)).
 
 -spec macro_options() -> [macro_option()].
 macro_options() ->

--- a/src/els_diagnostics.erl
+++ b/src/els_diagnostics.erl
@@ -60,6 +60,7 @@ available_diagnostics() ->
   , <<"dialyzer">>
   , <<"elvis">>
   , <<"xref">>
+  , <<"unused_includes">>
   ].
 
 -spec default_diagnostics() -> [diagnostic_id()].

--- a/src/els_diagnostics_utils.erl
+++ b/src/els_diagnostics_utils.erl
@@ -7,6 +7,7 @@
 %% Exports
 %%==============================================================================
 -export([ dependencies/1
+        , included_uris/1
         ]).
 %%==============================================================================
 %% Includes
@@ -16,6 +17,11 @@
 -spec dependencies(uri()) -> [atom()].
 dependencies(Uri) ->
   dependencies([Uri], [], sets:new()).
+
+-spec included_uris(els_dt_document:item()) -> [uri()].
+included_uris(Document) ->
+  POIs = els_dt_document:pois(Document, [include, include_lib]),
+  included_uris([Id || #{id := Id} <- POIs], []).
 
 %%==============================================================================
 %% Internal Functions
@@ -36,11 +42,6 @@ dependencies([Uri|Uris], Acc, AlreadyProcessed) ->
       lager:info("Lookup failed [Error=~p]", [Error]),
       []
   end.
-
--spec included_uris(els_dt_document:item()) -> [uri()].
-included_uris(Document) ->
-  POIs = els_dt_document:pois(Document, [include, include_lib]),
-  included_uris([Id || #{id := Id} <- POIs], []).
 
 -spec included_uris([atom()], [uri()]) -> [uri()].
 included_uris([], Acc) ->

--- a/src/els_unused_includes_diagnostics.erl
+++ b/src/els_unused_includes_diagnostics.erl
@@ -1,0 +1,120 @@
+%%==============================================================================
+%% Unused Includes diagnostics
+%%==============================================================================
+-module(els_unused_includes_diagnostics).
+
+%%==============================================================================
+%% Behaviours
+%%==============================================================================
+-behaviour(els_diagnostics).
+
+%%==============================================================================
+%% Exports
+%%==============================================================================
+-export([ is_default/0
+        , run/1
+        , source/0
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("erlang_ls.hrl").
+
+%%==============================================================================
+%% Callback Functions
+%%==============================================================================
+
+-spec is_default() -> boolean().
+is_default() ->
+  false.
+
+-spec run(uri()) -> [els_diagnostics:diagnostic()].
+run(Uri) ->
+  case els_dt_document:lookup(Uri) of
+    {ok, []} ->
+      [];
+    {ok, [Document|_]} ->
+      Includes = els_dt_document:pois(Document, [include, include_lib]),
+      UnusedIncludes = find_unused_includes(Document, Includes),
+      [ els_diagnostics:make_diagnostic(
+          els_protocol:range(inclusion_range(UI, Document))
+         , <<"Unused file: ", (filename:basename(UI))/binary>>
+            , ?DIAGNOSTIC_WARNING
+         , source()
+         ) || UI <- UnusedIncludes ]
+  end.
+
+-spec source() -> binary().
+source() ->
+  <<"UnusedIncludes">>.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+-spec find_unused_includes(els_dt_document:item(), [poi()]) -> [uri()].
+find_unused_includes(#{uri := Uri} = Document, Includes) ->
+  Graph = expand_includes(Uri),
+  POIs = els_dt_document:pois(Document),
+  IncludedUris = els_diagnostics_utils:included_uris(Document),
+  Fun = fun(POI, Acc) ->
+            update_unused(Graph, Uri, POI, Acc)
+        end,
+  UnusedIncludes = lists:foldl(Fun, IncludedUris, POIs -- Includes),
+  digraph:delete(Graph),
+  UnusedIncludes.
+
+-spec update_unused(digraph:graph(), uri(), poi(), [uri()]) -> [uri()].
+update_unused(Graph, Uri, POI, Acc) ->
+  case els_code_navigation:goto_definition(Uri, POI) of
+    {ok, DefinitionUri, _DefinitionPOI} ->
+      case digraph:get_path(Graph, DefinitionUri, Uri) of
+        false ->
+          Acc;
+        Path ->
+          Acc -- Path
+      end;
+    {error, _Reason} ->
+      Acc
+  end.
+
+-spec expand_includes(uri()) -> digraph:graph().
+expand_includes(Uri) ->
+  expand_includes([Uri], digraph:new(), sets:new()).
+
+-spec expand_includes([uri()], digraph:graph(), sets:set()) -> digraph:graph().
+expand_includes([], Graph, _Visited) ->
+  Graph;
+expand_includes([Uri|Uris], Graph, Visited) ->
+  case els_dt_document:lookup(Uri) of
+    {ok, [Document]} ->
+      IncludedUris = els_diagnostics_utils:included_uris(Document),
+      NonVisitedIncludedUris = [U || U <- IncludedUris
+                                       , not sets:is_element(U, Visited)],
+      Dest = digraph:add_vertex(Graph, Uri),
+      NewGraph = lists:foldl(fun(U, G) ->
+                                 Src = digraph:add_vertex(G, U),
+                                 digraph:add_edge(G, Src, Dest),
+                                 G
+                             end
+                            , Graph
+                            , IncludedUris),
+      expand_includes( Uris ++ NonVisitedIncludedUris
+                     , NewGraph
+                     , sets:add_element(Uri, Visited));
+    {ok, []} ->
+      lager:warning("Failed lookup while expanding includes [uri=~p]", [Uri]),
+      []
+  end.
+
+-spec inclusion_range(uri(), els_dt_document:item()) -> poi_range().
+inclusion_range(Uri, Document) ->
+  Path = binary_to_list(els_uri:path(Uri)),
+  case
+    els_compiler_diagnostics:inclusion_range(Path, Document, include) ++
+    els_compiler_diagnostics:inclusion_range(Path, Document, include_lib) of
+    [Range|_] ->
+      Range;
+    _ ->
+      #{from => {1, 1}, to => {2, 1}}
+  end.

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -161,6 +161,7 @@ sources() ->
   , diagnostics_parse_transform_usage_included
   , diagnostics_xref
   , diagnostics_xref_pseudo
+  , diagnostics_unused_includes
   , elvis_diagnostics
   , format_input
   , my_gen_server


### PR DESCRIPTION
### Description

This approach is not particularly performant and it detects a few false positives, but - considering this is disabled by default and currently undocumented -, I believe it's a step in the right direction. We can refine the algorithm incrementally.

Fixes #404 .
