### PR TITLE
[#820] Add support for renaming callback functions

### DIFF
--- a/include/erlang_ls.hrl
+++ b/include/erlang_ls.hrl
@@ -573,6 +573,7 @@
                    | export_type_entry
                    | folding_range
                    | function
+                   | function_clause
                    | implicit_fun
                    | import_entry
                    | include

--- a/priv/code_navigation/src/rename.erl
+++ b/priv/code_navigation/src/rename.erl
@@ -1,0 +1,3 @@
+-module(rename).
+
+-callback rename_me(any()) -> ok.

--- a/priv/code_navigation/src/rename_usage1.erl
+++ b/priv/code_navigation/src/rename_usage1.erl
@@ -1,0 +1,11 @@
+-module(rename_usage1).
+
+-behaviour(rename).
+
+-export([rename_me/1]).
+
+-spec rename_me(any()) -> any().
+rename_me(x) ->
+  ok;
+rename_me(_) ->
+  any.

--- a/priv/code_navigation/src/rename_usage2.erl
+++ b/priv/code_navigation/src/rename_usage2.erl
@@ -1,0 +1,8 @@
+-module(rename_usage2).
+
+-behaviour(rename).
+
+-export([rename_me/1]).
+
+rename_me(_) ->
+  ok.

--- a/src/els_client.erl
+++ b/src/els_client.erl
@@ -43,6 +43,7 @@
         , document_formatting/3
         , document_rangeformatting/3
         , document_ontypeformatting/4
+        , document_rename/4
         , folding_range/1
         , shutdown/0
         , start_link/2
@@ -158,6 +159,11 @@ document_rangeformatting(Uri, Range, FormattingOptions) ->
 document_ontypeformatting(Uri, Position, Char, FormattingOptions) ->
   gen_server:call(?SERVER, {document_ontypeformatting,
                             {Uri, Position, Char, FormattingOptions}}).
+
+-spec document_rename(uri(), non_neg_integer(), non_neg_integer(), binary()) ->
+        ok.
+document_rename(Uri, Line, Character, NewName) ->
+  gen_server:call(?SERVER, {rename, {Uri, Line, Character, NewName}}).
 
 -spec did_open(uri(), binary(), number(), binary()) -> ok.
 did_open(Uri, LanguageId, Version, Text) ->
@@ -379,6 +385,7 @@ method_lookup(document_codelens)        -> <<"textDocument/codeLens">>;
 method_lookup(document_formatting)      -> <<"textDocument/formatting">>;
 method_lookup(document_rangeformatting) -> <<"textDocument/rangeFormatting">>;
 method_lookup(document_ontypeormatting) -> <<"textDocument/onTypeFormatting">>;
+method_lookup(rename)                   -> <<"textDocument/rename">>;
 method_lookup(did_open)                 -> <<"textDocument/didOpen">>;
 method_lookup(did_save)                 -> <<"textDocument/didSave">>;
 method_lookup(did_close)                -> <<"textDocument/didClose">>;
@@ -433,6 +440,13 @@ request_params({ document_formatting
    , options      => #{ tabSize      => TabSize
                       , insertSpaces => InsertSpaces
                       }
+   };
+request_params({rename, {Uri, Line, Character, NewName}}) ->
+  #{ textDocument => #{ uri => Uri }
+   , position     => #{ line      => Line
+                      , character => Character
+                      }
+   , newName      => NewName
    };
 request_params({folding_range, {Uri}}) ->
   TextDocument = #{ uri => Uri },

--- a/src/els_general_provider.erl
+++ b/src/els_general_provider.erl
@@ -140,6 +140,8 @@ server_capabilities() ->
             els_execute_command_provider:options()
         , codeLensProvider =>
             els_code_lens_provider:options()
+        , renameProvider =>
+            els_rename_provider:is_enabled()
         },
      serverInfo =>
        #{ name    => <<"Erlang LS">>

--- a/src/els_methods.erl
+++ b/src/els_methods.erl
@@ -27,6 +27,7 @@
         , workspace_didchangeconfiguration/2
         , textdocument_codeaction/2
         , textdocument_codelens/2
+        , textdocument_rename/2
         , workspace_executecommand/2
         , workspace_didchangewatchedfiles/2
         , workspace_symbol/2
@@ -356,6 +357,16 @@ textdocument_codeaction(Params, State) ->
 textdocument_codelens(Params, State) ->
   Provider = els_code_lens_provider,
   Response = els_provider:handle_request(Provider, {document_codelens, Params}),
+  {response, Response, State}.
+
+%%==============================================================================
+%% textDocument/rename
+%%==============================================================================
+
+-spec textdocument_rename(params(), state()) -> result().
+textdocument_rename(Params, State) ->
+  Provider = els_rename_provider,
+  Response = els_provider:handle_request(Provider, {rename, Params}),
   {response, Response, State}.
 
 %%==============================================================================

--- a/src/els_provider.erl
+++ b/src/els_provider.erl
@@ -34,7 +34,8 @@
                   | els_code_action_provider
                   | els_general_provider
                   | els_code_lens_provider
-                  | els_execute_command_provider.
+                  | els_execute_command_provider
+                  | els_rename_provider.
 -type request()  :: {atom() | binary(), map()}.
 -type state()    :: #{ provider := provider()
                      , internal_state := any()
@@ -114,6 +115,7 @@ available_providers() ->
   , els_code_lens_provider
   , els_execute_command_provider
   , els_diagnostics_provider
+  , els_rename_provider
   ].
 
 -spec enabled_providers() -> [provider()].

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -67,9 +67,13 @@ range({Line, Column}, behaviour, Behaviour, _Data) ->
   #{ from => From, to => To };
 range({Line, Column}, callback, {F, _A}, _Data) ->
   From = {Line, Column},
-  To = plus(From, atom_to_list(F)),
+  To = {Line, Column + length("callback") + length(atom_to_list(F))},
   #{ from => From, to => To };
 range({Line, Column}, function, {F, _A}, _Data) ->
+  From = {Line, Column},
+  To = plus(From, atom_to_list(F)),
+  #{ from => From, to => To };
+range({Line, Column}, function_clause, {F, _A, _Index}, _Data) ->
   From = {Line, Column},
   To = plus(From, atom_to_list(F)),
   #{ from => From, to => To };

--- a/src/els_rename_provider.erl
+++ b/src/els_rename_provider.erl
@@ -1,0 +1,105 @@
+-module(els_rename_provider).
+
+-behaviour(els_provider).
+
+-export([ handle_request/2
+        , is_enabled/0
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("erlang_ls.hrl").
+
+%%==============================================================================
+%% Defines
+%%==============================================================================
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type state() :: any().
+
+%%==============================================================================
+%% els_provider functions
+%%==============================================================================
+-spec is_enabled() -> boolean().
+is_enabled() -> true.
+
+-spec handle_request(any(), state()) -> {any(), state()}.
+handle_request({rename, Params}, State) ->
+  #{ <<"textDocument">> := #{<<"uri">> := Uri}
+   , <<"position">> := #{ <<"line">>      := Line
+                        , <<"character">> := Character
+                        }
+   , <<"newName">> := NewName
+   } = Params,
+  {ok, Document} = els_utils:lookup_document(Uri),
+  Elem = els_dt_document:get_element_at_pos(Document, Line + 1, Character + 1),
+  WorkspaceEdits = workspace_edits(Uri, Elem, NewName),
+  {WorkspaceEdits, State}.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+-spec workspace_edits(uri(), [poi()], binary()) -> null | [any()].
+workspace_edits(_Uri, [], _NewName) ->
+  null;
+workspace_edits(Uri, [#{kind := callback} = POI | _], NewName) ->
+  #{id := {Name, Arity} = Id} = POI,
+  Module = els_uri:module(Uri),
+  {ok, Refs} = els_dt_references:find_by_id(behaviour, Module),
+  Changes =
+    lists:foldl(
+      fun(#{uri := U}, Acc) ->
+          {ok, Doc} = els_utils:lookup_document(U),
+          ExportEntries = els_dt_document:pois(Doc, [export_entry]),
+          FunctionClauses = els_dt_document:pois(Doc, [function_clause]),
+          Specs = els_dt_document:pois(Doc, [spec]),
+          Acc#{ U =>
+                  [ #{ range => editable_range(P)
+                     , newText => NewName
+                     } || #{id := I} = P <- ExportEntries, I =:= Id
+                  ] ++
+                  [ #{ range => editable_range(P)
+                     , newText => NewName
+                     } || #{id := {N, A, _I}} = P <- FunctionClauses
+                            , N =:= Name
+                            , A =:= Arity
+                  ] ++
+                  [ #{ range => editable_range(P)
+                     , newText => NewName
+                     } || #{id := I} = P <- Specs, I =:= Id
+                  ]
+              }
+      end, #{ Uri =>
+                [#{ range => editable_range(POI)
+                  , newText => NewName
+                  }]
+            }, Refs),
+  #{changes => Changes};
+workspace_edits(_Uri, _POIs, _NewName) ->
+  null.
+
+-spec editable_range(poi()) -> range().
+editable_range(#{kind := callback, range := Range}) ->
+  #{ from := {FromL, FromC}, to := {ToL, ToC} } = Range,
+  #{ start => #{line => FromL - 1, character => FromC + length("callback")}
+   , 'end' => #{line => ToL - 1,   character => ToC}
+   };
+editable_range(#{kind := export_entry, id := {F, _A}, range := Range}) ->
+  #{ from := {FromL, FromC}, to := {ToL, _ToC} } = Range,
+  #{ start => #{line => FromL - 1, character => FromC}
+   , 'end' => #{line => ToL - 1,   character => FromC + length(atom_to_list(F))}
+   };
+editable_range(#{kind := spec, id := {F, _A}, range := Range}) ->
+  #{ from := {FromL, FromC}, to := {ToL, _ToC} } = Range,
+  #{ start => #{ line => FromL - 1
+               , character => FromC + length("spec") + 1}
+   , 'end' => #{line => ToL - 1
+               , character =>
+                  FromC + length("spec") + length(atom_to_list(F)) + 1
+               }
+   };
+editable_range(#{kind := _Kind, range := Range}) ->
+  els_protocol:range(Range).

--- a/test/els_rename_SUITE.erl
+++ b/test/els_rename_SUITE.erl
@@ -1,0 +1,107 @@
+-module(els_rename_SUITE).
+
+-include("erlang_ls.hrl").
+
+%% CT Callbacks
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , groups/0
+        , all/0
+        ]).
+
+%% Test cases
+-export([ rename_behaviour_callback/1 ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+  [{timetrap, {seconds, 30}}].
+
+-spec all() -> [{group, atom()}].
+all() ->
+  [{group, tcp}, {group, stdio}].
+
+-spec groups() -> [atom()].
+groups() ->
+  els_test_utils:groups(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(TestCase, Config) ->
+  els_test_utils:init_per_testcase(TestCase, Config).
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) ->
+  els_test_utils:end_per_testcase(TestCase, Config).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec rename_behaviour_callback(config()) -> ok.
+rename_behaviour_callback(Config) ->
+  Uri = ?config(rename_uri, Config),
+  Line = 2,
+  Char = 9,
+  NewName = <<"new_awesome_name">>,
+  #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
+  Expected =  #{changes =>
+                  #{ binary_to_atom(Uri, utf8) =>
+                       [ #{ newText => NewName
+                          , range =>
+                              #{ 'end' => #{character => 19, line => 2}
+                               , start => #{character => 10, line => 2}}}
+                       ]
+                   , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
+                       [ #{ newText => NewName
+                          , range =>
+                              #{ 'end' => #{character => 18, line => 4}
+                               , start => #{character => 9, line => 4}}}
+                       , #{ newText => NewName
+                          , range =>
+                              #{ 'end' => #{character => 9, line => 7}
+                               , start => #{character => 0, line => 7}}}
+                       , #{ newText => NewName
+                          , range =>
+                              #{ 'end' => #{character => 9, line => 9}
+                               , start => #{character => 0, line => 9}}}
+                       , #{ newText => NewName
+                          , range =>
+                              #{ 'end' => #{character => 15, line => 6}
+                               , start => #{character => 6, line => 6}}}
+                       ]
+                   , binary_to_atom(?config(rename_usage2_uri, Config), utf8) =>
+                       [ #{ newText => NewName
+                          , range =>
+                              #{ 'end' => #{character => 18, line => 4}
+                               , start => #{character => 9, line => 4}}}
+                       , #{ newText => NewName
+                          , range =>
+                             #{ 'end' => #{character => 9, line => 6}
+                              , start => #{character => 0, line => 6}}}
+                       ]
+                   }
+               },
+  ?assertEqual(Expected, Result).

--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -165,6 +165,9 @@ sources() ->
   , elvis_diagnostics
   , format_input
   , my_gen_server
+  , rename
+  , rename_usage1
+  , rename_usage2
   ].
 
 tests() ->


### PR DESCRIPTION
* Introduce plumbing for textDocument/rename
* Implement renaming for callback functions
* Index function_clauses
* Fix range for callbacks

Still not included:

* Renaming of function callers

From Emacs:
```
lsp-rename
```

![diff](https://user-images.githubusercontent.com/91769/101261482-d5862780-3737-11eb-92ec-89e0e9625193.png)

Fixes #820 .
