### PR TITLE
Add column numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [21.3, 22.2, 23.1]
+        otp-version: [21, 22, 23, 24]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/apps/els_core/src/els_escript.erl
+++ b/apps/els_core/src/els_escript.erl
@@ -149,17 +149,7 @@ parse_source(S, File, Fd, StartLine, HeaderSz) ->
   _ = io:get_line(Fd, ''),
   Encoding = epp:set_encoding(Fd),
   {ok, _} = file:position(Fd, HeaderSz),
-  {ok, Epp} =
-        case erlang:function_exported(epp, open, 5) of
-            true ->
-                %% Pre OTP-24 function to call for escripts
-                %% Done via apply in order to silence dialyzer
-                apply(epp, open, [File, Fd, StartLine,
-                                  IncludePath, PreDefMacros]);
-            false ->
-                epp:open([{fd, Fd}, {name, File}, {location, StartLine},
-                          {includes, IncludePath}, {macros, PreDefMacros}])
-        end,
+  {ok, Epp} = epp_open(File, Fd, StartLine, IncludePath, PreDefMacros),
   _ = [io:setopts(Fd, [{encoding, Encoding}]) || Encoding =/= none],
   {ok, FileForm} = epp:parse_erl_form(Epp),
   OptModRes = epp:parse_erl_form(Epp),
@@ -180,6 +170,31 @@ parse_source(S, File, Fd, StartLine, HeaderSz) ->
   ok = epp:close(Epp),
   ok = file:close(Fd),
   check_source(S2).
+
+-spec epp_open(_, _, pos_integer(), _, _) -> {ok, term()}.
+-if(?OTP_RELEASE < 24).
+%% If the environment used to compile is < 24 we should test
+%% if the eep:open/5 function is available, and if it is we use that.
+%% We to the check as we want the a version compiled with 23 to
+%% work with 24.
+epp_open(File, Fd, StartLine, IncludePath, PreDefMacros) ->
+    case erlang:function_exported(epp, open, 5) of
+        true ->
+            epp:open(File, Fd, StartLine, IncludePath, PreDefMacros);
+        false ->
+            epp:open([{fd, Fd}, {name, File}, {location, StartLine},
+                      {includes, IncludePath}, {macros, PreDefMacros}])
+    end.
+-else.
+%% This is compiled with 24 or later, so has no chance of working
+%% with earlier releases that 24 so we can just use the new way of
+%% opening an escript.
+epp_open(File, Fd, StartLine, IncludePath, PreDefMacros) ->
+    epp:open([{fd, Fd}, {name, File}, {location, StartLine},
+              {includes, IncludePath}, {macros, PreDefMacros}]).
+-endif.
+
+
 
 -spec check_source(state()) -> state().
 check_source(S) ->

--- a/apps/els_core/src/els_escript.erl
+++ b/apps/els_core/src/els_escript.erl
@@ -182,17 +182,21 @@ epp_open(File, Fd, StartLine, IncludePath, PreDefMacros) ->
         true ->
             epp:open(File, Fd, StartLine, IncludePath, PreDefMacros);
         false ->
-            epp:open([{fd, Fd}, {name, File}, {location, StartLine},
-                      {includes, IncludePath}, {macros, PreDefMacros}])
+            epp_open24(File, Fd, StartLine, IncludePath, PreDefMacros)
     end.
 -else.
 %% This is compiled with 24 or later, so has no chance of working
 %% with earlier releases that 24 so we can just use the new way of
 %% opening an escript.
 epp_open(File, Fd, StartLine, IncludePath, PreDefMacros) ->
+    epp_open24(File, Fd, StartLine, IncludePath, PreDefMacros).
+-endif.
+
+%% Extracted out in order to not break dont_repeat_yourself rule
+-spec epp_open24(_, _, pos_integer(), _, _) -> {ok, term()}.
+epp_open24(File, Fd, StartLine, IncludePath, PreDefMacros) ->
     epp:open([{fd, Fd}, {name, File}, {location, StartLine},
               {includes, IncludePath}, {macros, PreDefMacros}]).
--endif.
 
 
 

--- a/apps/els_core/src/els_escript.erl
+++ b/apps/els_core/src/els_escript.erl
@@ -195,8 +195,10 @@ epp_open(File, Fd, StartLine, IncludePath, PreDefMacros) ->
 %% Extracted out in order to not break dont_repeat_yourself rule
 -spec epp_open24(_, _, pos_integer(), _, _) -> {ok, term()}.
 epp_open24(File, Fd, StartLine, IncludePath, PreDefMacros) ->
-    epp:open([{fd, Fd}, {name, File}, {location, StartLine},
-              {includes, IncludePath}, {macros, PreDefMacros}]).
+    %% We use apply in order to fool dialyzer not not analyze this path
+    apply(epp, open,
+          [[{fd, Fd}, {name, File}, {location, StartLine},
+            {includes, IncludePath}, {macros, PreDefMacros}]]).
 
 
 

--- a/apps/els_core/src/els_text.erl
+++ b/apps/els_core/src/els_text.erl
@@ -12,7 +12,7 @@
 
 -type text()       :: binary().
 -type line_num()   :: non_neg_integer().
--type column_num() :: non_neg_integer().
+-type column_num() :: pos_integer().
 -type token()      :: erl_scan:token().
 
 %% @doc Extract the N-th line from a text.
@@ -27,14 +27,14 @@ line(Text, LineNum, ColumnNum) ->
   Line = line(Text, LineNum),
   binary:part(Line, {0, ColumnNum}).
 
-%% @doc Extract a snippet from a text, from start location to end location.
+%% @doc Extract a snippet from a text, from [StartLoc..EndLoc).
 -spec range(text(), {line_num(), column_num()}, {line_num(), column_num()}) ->
         text().
 range(Text, StartLoc, EndLoc) ->
   LineStarts = line_starts(Text),
   StartPos = pos(LineStarts, StartLoc),
   EndPos = pos(LineStarts, EndLoc),
-  binary:part(Text, StartPos, EndPos - StartPos + 1).
+  binary:part(Text, StartPos, EndPos - StartPos).
 
 %% @doc Return tokens from text.
 -spec tokens(text()) -> [any()].
@@ -61,7 +61,7 @@ line_starts(Text) ->
   [{-1, 1} | binary:matches(Text, <<"\n">>)].
 
 -spec pos([{integer(), any()}], {line_num(), column_num()}) ->
-        non_neg_integer().
+        pos_integer().
 pos(LineStarts, {LineNum, ColumnNum}) ->
   {LinePos, _} = lists:nth(LineNum, LineStarts),
   LinePos + ColumnNum.

--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -159,6 +159,6 @@ pois(Item, Kinds) ->
 -spec get_element_at_pos(item(), non_neg_integer(), non_neg_integer()) ->
   [poi()].
 get_element_at_pos(Item, Line, Column) ->
-  POIs = maps:get(pois, Item),
+  POIs = pois(Item),
   MatchedPOIs = els_poi:match_pos(POIs, {Line, Column}),
   els_poi:sort(MatchedPOIs).

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -89,7 +89,9 @@ find_attribute_pois(Tree, Tokens) ->
           [ poi(Pos, import_entry, {M, F, A})
             || {{F, A}, {atom, Pos, _}} <- lists:zip(Imports, Atoms)];
         {spec, {spec, {{F, A}, _FTs}}} ->
-          From = erl_syntax:get_pos(Tree),
+          %% This location has to match that of spec in
+          %% find_attribute_tokens/1
+          From = erl_scan:location(hd(Tokens)),
           To   = erl_scan:location(lists:last(Tokens)),
           [poi({From, To}, spec, {F, A})];
         {export_type, {export_type, Exports}} ->
@@ -138,7 +140,7 @@ analyze_attribute(Tree) ->
       [ArgTuple] = erl_syntax:attribute_arguments(Tree),
       [TypeTree, _, ArgsListTree] = erl_syntax:tuple_elements(ArgTuple),
       Definition = [], %% ignore definition
-      %% concrete will throw an error if `TyperTree' is a macro
+      %% concrete will throw an error if `TypeTree' is a macro
       try erl_syntax:concrete(TypeTree) of
         TypeName ->
           {AttrName, {AttrName, {TypeName,

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -220,25 +220,37 @@ do_points_of_interest(Tree, EndLocation) ->
 application(Tree) ->
   case application_mfa(Tree) of
     undefined -> [];
-    {F, A} ->
-      Pos = erl_syntax:get_pos(Tree),
+    {{F, A}, Pos} ->
       case erl_internal:bif(F, A) of
         %% Call to a function from the `erlang` module
         true -> [poi(Pos, application, {erlang, F, A}, #{imported => true})];
         %% Local call
         false -> [poi(Pos, application, {F, A})]
       end;
-    MFA ->
-      [poi(erl_syntax:get_pos(Tree), application, MFA)]
+    {MFA, Pos} ->
+      [poi(Pos, application, MFA)]
   end.
 
 -spec application_mfa(tree()) ->
-  {module(), atom(), arity()} | {atom(), arity()} | undefined.
+  {{module(), atom(), arity()}, pos()} | {{atom(), arity()}, pos()} | undefined.
 application_mfa(Tree) ->
   case erl_syntax_lib:analyze_application(Tree) of
     %% Remote call
-    {M, {F, A}} -> {M, F, A};
-    {F, A} -> {F, A};
+    {M, {F, A}} ->
+          %% For remote calls we use the column position of the
+          %% module part. In OTP-24+ this is the same as doing
+          %% erl_syntax:get_pos(Tree), but in OTP-23 and earlier
+          %% the position of the tree is the ':' of the application.
+          Operator = erl_syntax:application_operator(Tree),
+          Pos = case erl_syntax:type(Operator) of
+                    module_qualifier ->
+                        erl_syntax:get_pos(
+                          erl_syntax:module_qualifier_argument(Operator));
+                    _ ->
+                        erl_syntax:get_pos(Tree)
+                end,
+          {{M, F, A}, Pos};
+    {F, A} -> {{F, A}, erl_syntax:get_pos(Tree)};
     A when is_integer(A) ->
       %% If the function is not explicitly named (e.g. a variable is
       %% used as the module qualifier or the function name), only the
@@ -265,7 +277,7 @@ application_with_variable(Operator, A) ->
       ModuleName   = node_name(Module),
       FunctionName = node_name(Function),
       case {ModuleName, FunctionName} of
-        {'MODULE', F} -> {F, A};
+        {'MODULE', F} -> {{F, A}, erl_syntax:get_pos(Module)};
         _ -> undefined
       end;
     _ -> undefined

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -46,12 +46,10 @@ range({_Line, _Column} = From, atom, Name, _Data) ->
   #{ from => From, to => To };
 range({Line, Column}, application, {_, F, A}, #{imported := true} = Data) ->
   range({Line, Column}, application, {F, A}, Data);
-range({Line, Column}, application, {M, F, _A}, _Data) ->
-  %% Column indicates the position of the :
-  CFrom = Column - string:length(atom_to_string(M)),
-  From = {Line, CFrom},
+range({Line, Column} = From, application, {M, F, _A}, _Data) ->
   %% module:function
-  CTo = Column + string:length(atom_to_string(F)) + 1,
+  CTo = Column + string:length(atom_to_string(M)) +
+        string:length(atom_to_string(F)) + 1,
   To = {Line, CTo},
   #{ from => From, to => To };
 range({Line, Column}, application, {F, _A}, _Data) ->

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -27,9 +27,9 @@ range({{Line, Column}, {ToLine, ToColumn}}, Name, _, _Data)
   when Name =:= folding_range;
        Name =:= spec ->
   %% -1 as we include the "-" before spec.
-  From = {Line, Column - 1},
+  From = {Line, Column},
   %% +1 as we include the . after the spec
-  To = {ToLine, ToColumn - 1 + 1},
+  To = {ToLine, ToColumn + 1},
   #{ from => From, to => To };
 range({{_Line, _Column} = From, {_ToLine, _ToColumn} = To}, Name, _, _Data)
   when Name =:= export;

--- a/apps/els_lsp/src/els_rename_provider.erl
+++ b/apps/els_lsp/src/els_rename_provider.erl
@@ -98,16 +98,16 @@ workspace_edits(_Uri, _POIs, _NewName) ->
 -spec editable_range(poi()) -> range().
 editable_range(#{kind := callback, range := Range}) ->
   #{ from := {FromL, FromC} } = Range,
-  EditFromC = FromC + length("-callback "),
+  EditFromC = FromC + string:length("-callback "),
   els_protocol:range(Range#{ from := {FromL, EditFromC } });
 editable_range(#{kind := export_entry, id := {F, _A}, range := Range}) ->
   #{ from := {FromL, FromC} } = Range,
-  EditToC = FromC + length(atom_to_string(F)),
+  EditToC = FromC + string:length(atom_to_string(F)),
   els_protocol:range(Range#{ to := {FromL, EditToC} });
 editable_range(#{kind := spec, id := {F, _A}, range := Range}) ->
   #{ from := {FromL, FromC}, to := {_ToL, _ToC} } = Range,
-  EditFromC = FromC + length("-spec "),
-  EditToC = EditFromC + length(atom_to_string(F)),
+  EditFromC = FromC + string:length("-spec "),
+  EditToC = EditFromC + string:length(atom_to_string(F)),
   els_protocol:range(Range#{ from := {FromL, EditFromC}
                            , to := {FromL, EditToC} });
 editable_range(#{kind := implicit_fun, id := {M, F, _A}, range := Range}) ->
@@ -138,7 +138,7 @@ editable_range(#{kind := _Kind, range := Range}) ->
 -spec editable_range(poi_kind(), els_dt_references:item()) -> range().
 editable_range(macro, #{range := Range}) ->
   #{ from := {FromL, FromC} } = Range,
-  EditFromC = FromC + length("?"),
+  EditFromC = FromC + string:length("?"),
   els_protocol:range(Range#{ from := {FromL, EditFromC} }).
 
 -spec changes(uri(), poi(), binary()) -> #{uri() => [text_edit()]} | null.

--- a/rebar.config
+++ b/rebar.config
@@ -71,6 +71,8 @@
            , {plt_extra_apps, [dialyzer, hipe, mnesia, common_test, debugger]}
            ]}.
 
+{edoc_opts, [{preprocess, true}]}.
+
 {xref_checks, [ undefined_function_calls
               , undefined_functions
               , locals_not_used

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,16 +1,30 @@
-case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
-  {"true", Token} when is_list(Token) ->
-    CONFIG1 = [{coveralls_repo_token, Token},
-               {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
-               {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
-               {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")} | CONFIG],
-    case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
-        andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
-        [_, "pull", PRNO, _] ->
-            [{coveralls_service_pull_request, PRNO} | CONFIG1];
+CoverallsConfig =
+    case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
+        {"true", Token} when is_list(Token) ->
+            CONFIG1 = [{coveralls_repo_token, Token},
+                       {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
+                       {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
+                       {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")}],
+            case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
+                andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
+                [_, "pull", PRNO, _] ->
+                    [{coveralls_service_pull_request, PRNO} | CONFIG1];
+                _ ->
+                    CONFIG1
+            end;
         _ ->
-            CONFIG1
-    end;
-  _ ->
-    CONFIG
-end.
+            []
+    end,
+%% Remove HiPE from dialyzer on versions of Erlang that does not support it
+DiaConfig =
+  case application:load(hipe) of
+      {error,_} ->
+          {dialyzer,DiaOpts} = lists:keyfind(dialyzer, 1, CONFIG),
+          {plt_extra_apps,Extra} = lists:keyfind(plt_extra_apps, 1, DiaOpts),
+          NewDiaOpts = lists:keyreplace(plt_extra_apps, 1, DiaOpts,
+                           {plt_extra_apps, lists:delete(hipe, Extra)}),
+          lists:keyreplace(dialyzer, 1, CONFIG, {dialyzer, NewDiaOpts});
+      _ ->
+          CONFIG
+  end,
+DiaConfig ++ CoverallsConfig.


### PR DESCRIPTION
This PR adds rudimentary support for giving error location information based on the column number returned by the erlang compiler.

This PR depends on https://github.com/erlang/otp/pull/2664 and https://github.com/erlang-ls/erlang_ls/pull/832.

I decided to use the poi that the column is pointing to as the object to mark as the compiler only emits the starting column and not the end column.

Using the poi is not ideal as sometimes it can select a much larger section than it should, the most obvious example is when an attribute is broken somehow. It is however better than trying to come up with some other heuristic about which range it is that is responsible for the warning.

I've put this PR as a draft as I'm not happy about the usage of `poi`s. So I'm looking to see if anyone has any better suggestions? :)