### PR TITLE
[#835] Move CI badge from Travis CI to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![erlang_ls](images/erlang-ls-logo-small.png?raw=true "Erlang LS")
 
-[![Build Status](https://travis-ci.org/erlang-ls/erlang_ls.svg?branch=master)](https://travis-ci.org/erlang-ls/erlang_ls)
+![Build](https://github.com/erlang-ls/erlang_ls/workflows/Build/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/erlang-ls/erlang_ls/badge.svg?branch=master)](https://coveralls.io/github/erlang-ls/erlang_ls?branch=master)
 
 An Erlang server implementing Microsoft's Language Server Protocol 3.15.


### PR DESCRIPTION
### Description

Fixes #835
