### PR TITLE
Add tests for highlight of records, spec, behaviour and more

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -6,6 +6,7 @@
          , ruleset => erl_files
          , rules   => [ {elvis_style, god_modules, #{ignore => [ els_client
                                                                , els_definition_SUITE
+                                                               , els_document_highlight_SUITE
                                                                , els_methods
                                                                ]}}
                       , {elvis_style, dont_repeat_yourself, #{ ignore => [ els_diagnostics_SUITE

--- a/priv/code_navigation/src/code_navigation.erl
+++ b/priv/code_navigation/src/code_navigation.erl
@@ -1,7 +1,7 @@
 -module(code_navigation).
 
 -behaviour(behaviour_a).
-
+-wildattribute(a).
 -export([ function_a/0, function_b/0, function_g/1, function_j/0 ]).
 
 %% behaviour_a callbacks
@@ -30,8 +30,8 @@ callback_a() ->
 
 function_c() ->
   code_navigation_extra:do(test),
-  A = #record_a{},
-  _X = A#record_a.field_a,
+  A = #record_a{ field_a = a },
+  _X = A#record_a.field_a, _Y = A#record_a.field_a,
   length([1, 2, 3]).
 
 -type type_a() :: any().

--- a/src/els_range.erl
+++ b/src/els_range.erl
@@ -19,12 +19,16 @@ compare(_, _) ->
 
 -spec range(pos() | {pos(), pos()}, poi_kind(), any(), any()) -> poi_range().
 range({{Line, Column}, {ToLine, ToColumn}}, Name, _, _Data)
-  when Name =:= export;
-       Name =:= export_type;
-       Name =:= folding_range;
+  when Name =:= folding_range;
        Name =:= spec ->
+  %% -1 as we include the "-" before spec.
   From = {Line, Column - 1},
-  To = {ToLine, ToColumn - 1},
+  %% +1 as we include the . after the spec
+  To = {ToLine, ToColumn - 1 + 1},
+  #{ from => From, to => To };
+range({{_Line, _Column} = From, {_ToLine, _ToColumn} = To}, Name, _, _Data)
+  when Name =:= export;
+       Name =:= export_type ->
   #{ from => From, to => To };
 range(Pos, export_entry, {F, A}, _Data) ->
   get_entry_range(Pos, F, A);
@@ -52,22 +56,21 @@ range({Line, Column}, application, {F, _A}, _Data) ->
 range({Line, Column}, implicit_fun, {M, F, A}, _Data) ->
   From = {Line, Column},
   %% Assumes "fun M:F/A"
-  Length = 6 + length(atom_to_list(M) ++ atom_to_list(F) ++ integer_to_list(A)),
-  To = {Line, Column + Length},
+  To = plus(From, "fun " ++ atom_to_list(M) ++ ":" ++
+                atom_to_list(F) ++ "/" ++ integer_to_list(A)),
   #{ from => From, to => To };
 range({Line, Column}, implicit_fun, {F, A}, _Data) ->
   From = {Line, Column},
   %% Assumes "fun F/A"
-  Length = 5 + length(atom_to_list(F) ++ integer_to_list(A)),
-  To = {Line, Column + Length},
+  To = plus(From, "fun " ++ atom_to_list(F) ++ "/" ++ integer_to_list(A)),
   #{ from => From, to => To };
 range({Line, Column}, behaviour, Behaviour, _Data) ->
   From = {Line, Column - 1},
-  To = {Line, Column + length("behaviour") + length(atom_to_list(Behaviour))},
+  To = plus(From, "-behaviour(" ++ atom_to_list(Behaviour) ++ ")."),
   #{ from => From, to => To };
 range({Line, Column}, callback, {F, _A}, _Data) ->
-  From = {Line, Column},
-  To = {Line, Column + length("callback") + length(atom_to_list(F))},
+  From = {Line, Column - 1},
+  To = plus(From, "-callback " ++ atom_to_list(F)),
   #{ from => From, to => To };
 range({Line, Column}, function, {F, _A}, _Data) ->
   From = {Line, Column},
@@ -83,11 +86,11 @@ range({Line, Column}, define, Define, _Data) ->
   #{ from => From, to => To };
 range({Line, Column}, include, Include, _Data) ->
   From = {Line, Column - 1},
-  To = {Line, Column + length("include") + length(Include) + 5},
+  To = plus(From, "-include(\"" ++ Include ++ "\")."),
   #{ from => From, to => To };
 range({Line, Column}, include_lib, Include, _Data) ->
   From = {Line, Column - 1},
-  To = {Line, Column + length("include_lib") + length(Include) + 5},
+  To = plus(From, "-include_lib(\"" ++ Include ++ "\")."),
   #{ from => From, to => To };
 range({Line, Column}, macro, Macro, _Data) when is_atom(Macro) ->
   From = {Line, Column},
@@ -103,12 +106,12 @@ range({Line, _Column}, parse_transform, _Define, _Data) ->
   To = From,
   #{ from => From, to => To };
 range(Pos, record_access, Record, Field) ->
-  #{ from => minus(Pos, "#")
-   , to => plus(Pos, atom_to_list(Record) ++ "." ++ atom_to_list(Field)) };
-range({Line, Column}, record_expr, Record, _Data) ->
-  From = {Line, Column - 1},
-  To = plus({Line, Column}, atom_to_list(Record)),
-  #{ from => From, to => To };
+  From = plus(Pos, "#"),
+  #{ from => From
+   , to => plus(From, atom_to_list(Record) ++ "." ++ atom_to_list(Field)) };
+range(Pos, record_expr, Record, _Data) ->
+  From = plus(Pos, "#"),
+  #{ from => From, to => plus(From, atom_to_list(Record)) };
 range({Line, Column}, record, Record, _Data) ->
   From = plus({Line, Column}, "record("),
   To = plus(From, atom_to_list(Record)),
@@ -119,7 +122,7 @@ range({Line, Column}, type_application, {F, _A}, _Data) ->
   #{ from => From, to => To };
 range({Line, Column}, type_application, {M, F, _A}, _Data) ->
   From = {Line, Column},
-  To = {Line, Column + length(atom_to_list(M)) + length(atom_to_list(F))},
+  To = plus(From, atom_to_list(M) ++ ":" ++ atom_to_list(F)),
   #{ from => From, to => To };
 range({Line, Column}, type_definition, {Name, _}, _Data) ->
   From = {Line, Column},
@@ -138,10 +141,10 @@ get_entry_range({Line, Column}, F, A) ->
   To = {Line, Column + Length},
   #{ from => From, to => To }.
 
--spec minus(pos(), string()) -> pos().
-minus({Line, Column}, String) ->
-  {Line, Column - length(String) - 1}.
+%% -spec minus(pos(), string()) -> pos().
+%% minus({Line, Column}, String) ->
+%%   {Line, Column - string:length(String)}.
 
 -spec plus(pos(), string()) -> pos().
 plus({Line, Column}, String) ->
-  {Line, Column + length(String)}.
+  {Line, Column + string:length(String)}.

--- a/src/els_rename_provider.erl
+++ b/src/els_rename_provider.erl
@@ -92,24 +92,19 @@ workspace_edits(_Uri, _POIs, _NewName) ->
 
 -spec editable_range(poi()) -> range().
 editable_range(#{kind := callback, range := Range}) ->
-  #{ from := {FromL, FromC}, to := {ToL, ToC} } = Range,
-  #{ start => #{line => FromL - 1, character => FromC + length("callback")}
-   , 'end' => #{line => ToL - 1,   character => ToC}
-   };
+  #{ from := {FromL, FromC} } = Range,
+  EditFromC = FromC + length("-callback "),
+  els_protocol:range(Range#{ from := {FromL, EditFromC } });
 editable_range(#{kind := export_entry, id := {F, _A}, range := Range}) ->
-  #{ from := {FromL, FromC}, to := {ToL, _ToC} } = Range,
-  #{ start => #{line => FromL - 1, character => FromC}
-   , 'end' => #{line => ToL - 1,   character => FromC + length(atom_to_list(F))}
-   };
+  #{ from := {FromL, FromC} } = Range,
+  EditToC = FromC + length(atom_to_list(F)),
+  els_protocol:range(Range#{ to := {FromL, EditToC} });
 editable_range(#{kind := spec, id := {F, _A}, range := Range}) ->
-  #{ from := {FromL, FromC}, to := {ToL, _ToC} } = Range,
-  #{ start => #{ line => FromL - 1
-               , character => FromC + length("spec") + 1}
-   , 'end' => #{line => ToL - 1
-               , character =>
-                  FromC + length("spec") + length(atom_to_list(F)) + 1
-               }
-   };
+  #{ from := {FromL, FromC}, to := {_ToL, _ToC} } = Range,
+  EditFromC = FromC + length("-spec "),
+  EditToC = EditFromC + length(atom_to_list(F)),
+  els_protocol:range(Range#{ from := {FromL, EditFromC}
+                           , to := {FromL, EditToC} });
 editable_range(#{kind := _Kind, range := Range}) ->
   els_protocol:range(Range).
 

--- a/test/els_diagnostics_SUITE.erl
+++ b/test/els_diagnostics_SUITE.erl
@@ -182,7 +182,7 @@ compiler_with_broken_behaviour(Config) ->
     #{message =>
         <<"Issue in included file (5): syntax error before: ">>,
       range =>
-        #{'end' => #{character => 21, line => 2},
+        #{'end' => #{character => 24, line => 2},
           start => #{character => 0, line => 2}},
       severity => 1,
       source => <<"Compiler">>},

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -195,13 +195,16 @@ module(Config) ->
 record(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   ExpectedLocations = [ #{ uri => Uri
-                         , range => #{from => {23, 2}, to => {23, 11}}
+                         , range => #{from => {23, 4}, to => {23, 12}}
                          }
                       , #{ uri => Uri
-                         , range => #{from => {33, 6}, to => {33, 15}}
+                         , range => #{from => {33, 8}, to => {33, 16}}
                          }
                       , #{ uri => Uri
-                         , range => #{from => {34, 7}, to => {34, 25}}
+                         , range => #{from => {34, 10}, to => {34, 26}}
+                         }
+                      , #{ uri => Uri
+                         , range => #{from => {34, 35}, to => {34, 51}}
                          }
                       ],
 
@@ -277,7 +280,7 @@ type_remote(Config) ->
   UriTypes = ?config(code_navigation_types_uri, Config),
   Uri = ?config(code_navigation_extra_uri, Config),
   ExpectedLocations = [ #{ uri   => Uri
-                         , range => #{from => {11, 38}, to => {11, 65}}
+                         , range => #{from => {11, 38}, to => {11, 66}}
                          }
                       ],
 

--- a/test/els_rename_SUITE.erl
+++ b/test/els_rename_SUITE.erl
@@ -81,8 +81,8 @@ rename_behaviour_callback(Config) ->
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 19, line => 6}
-                               , start => #{character => 10, line => 6}}}
+                              #{ 'end' => #{character => 18, line => 6}
+                               , start => #{character => 9, line => 6}}}
                        , #{ newText => NewName
                           , range =>
                               #{ 'end' => #{character => 9, line => 9}
@@ -99,8 +99,8 @@ rename_behaviour_callback(Config) ->
                    , binary_to_atom(?config(rename_usage2_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 19, line => 6}
-                               , start => #{character => 10, line => 6}}}
+                              #{ 'end' => #{character => 18, line => 6}
+                               , start => #{character => 9, line => 6}}}
                        , #{ newText => NewName
                           , range =>
                              #{ 'end' => #{character => 9, line => 8}


### PR DESCRIPTION
Add test for various highlight ranges. Also fixed various bugs found when implementing the tests.

As you said in the other PR, we really need a better way to test this. Also, the way that the ranges is done is very fragile as you can just insert a space somewhere and it will break. i.e.

```erlang
fun 
                
lists

:

foldl

/

3.
```

The poi range for this incorrect, but the above is correct (though unusual) code. Not to mention if we start putting strange unicode characters in the code... Maybe I'll see what I can do about that after the holidays.

This PR at least is an improvement :)