### PR TITLE
[#844] Do not crash if atoms are used as a compiler directive

### DIFF
--- a/src/els_parser.erl
+++ b/src/els_parser.erl
@@ -124,7 +124,9 @@ find_compile_options_pois(CompileOpts, Tokens) when is_list(CompileOpts) ->
            (_, Acc) ->
             Acc
         end,
-  lists:foldl(Fun, [], CompileOpts).
+  lists:foldl(Fun, [], CompileOpts);
+find_compile_options_pois(_CompileOpts, _Tokens) ->
+  [].
 
 -spec type_to_poi(tree()) -> [poi()].
 type_to_poi({type, {_, {type, Pos, record, [{atom, _, RecordName}]}, _}}) ->


### PR DESCRIPTION
### Description

Fixes #844 .
