### PR TITLE
Handle macros in patterns

### DIFF
--- a/src/els_dodger.erl
+++ b/src/els_dodger.erl
@@ -791,16 +791,27 @@ macro(L, {Type, _, A}, Rest, As, Opt) ->
 macro_call([{'(', _}, {')', _}], L, {_, Ln, _} = N, Rest, As, Opt) ->
   {Open, Close} = parentheses(As),
   scan_macros_1([], Rest,
-                lists:reverse(Open ++ [{atom, L, ?macro_call},
-                                       {'(', L}, N, {')', Ln}] ++ Close,
+                %% {'?macro_call', N }
+                lists:reverse(Open ++ [{'{', L},
+                                       {atom, L, ?macro_call},
+                                       {',', L},
+                                       N,
+                                       {'}', Ln}] ++ Close,
                               As), Opt);
 macro_call([{'(', _} | Args], L, {_, Ln, _}=N, Rest, As, Opt) ->
   {Open, Close} = parentheses(As),
+  %% drop closing parenthesis
+  {')', _} = lists:last(Args), %% assert
+  Args1 = lists:droplast(Args),
   %% note that we must scan the argument list; it may not be skipped
-  scan_macros_1(Args ++ Close,
+  scan_macros_1(Args1 ++ [{'}', Ln} | Close],
                 Rest,
-                lists:reverse(Open ++ [{atom, L, ?macro_call},
-                                       {'(', L}, N, {',', Ln}],
+                %% {'?macro_call', N, Arg1, ... }
+                lists:reverse(Open ++ [{'{', L},
+                                       {atom, L, ?macro_call},
+                                       {',', L},
+                                       N,
+                                       {',', Ln}],
                               As), Opt).
 
 -spec macro_atom(atom | var, atom()) -> atom().
@@ -866,15 +877,18 @@ rewrite(Node) ->
         _ ->
           Node
       end;
-    application ->
-      F = erl_syntax:application_operator(Node),
-      case erl_syntax:type(F) of
-        atom ->
-          case erl_syntax:atom_value(F) of
-            ?macro_call ->
-              [A | As] = erl_syntax:application_arguments(Node),
-              M = erl_syntax:macro(A, rewrite_list(As)),
-              erl_syntax:copy_pos(Node, M);
+    tuple ->
+      case erl_syntax:tuple_elements(Node) of
+        [MagicWord, A | As] ->
+          case erl_syntax:type(MagicWord) of
+            atom ->
+              case erl_syntax:atom_value(MagicWord) of
+                ?macro_call ->
+                  M = erl_syntax:macro(A, rewrite_list(As)),
+                  erl_syntax:copy_pos(Node, M);
+                _ ->
+                  rewrite_1(Node)
+              end;
             _ ->
               rewrite_1(Node)
           end;

--- a/test/els_rename_SUITE.erl
+++ b/test/els_rename_SUITE.erl
@@ -168,14 +168,13 @@ rename_parametrized_macro(Config) ->
                               #{ 'end' => #{character => 55, line => 18}
                                , start => #{character => 32, line => 18}}}
                        ]
-                   %%   This is currently not possible due to #805
-                   %% , binary_to_atom(
-                   %%     ?config(rename_usage2_uri, Config), utf8) =>
-                   %%     [ #{ newText => NewName
-                   %%        , range =>
-                   %%            #{ 'end' => #{character => 52, line => 14}
-                   %%             , start => #{character => 29, line => 14}}}
-                   %%     ]
+                    , binary_to_atom(
+                        ?config(rename_usage2_uri, Config), utf8) =>
+                        [ #{ newText => NewName
+                           , range =>
+                               #{ 'end' => #{character => 53, line => 14}
+                                , start => #{character => 30, line => 14}}}
+                        ]
                    }
                },
   assert_changes(Expected, Result).


### PR DESCRIPTION
The dodger used to replace a macro with a local function call. That works in
expressions but not in patterns like function heads or catch patterns. Instead
of a function call a tuple syntax is used which works in more places.
(`?MACRO(Arg1, Arg2)` is temporarily replaced by `{'a-magic-atom', MACRO, Arg1, Arg2}`
 instead of old `'a-magic-atom'(MACRO, Arg1, Arg2)`)

This change is motivated by the commonly used `?EXCEPTION` macro

```
try
  ...
catch
  ?EXCEPTION(Class, Reason, StackToken) ->
    ...
end.
```

Open source examples:
https://github.com/devinus/poolboy/commit/5d40cc517edc9bb8ee70756544167b63f66662f0
https://github.com/eproxus/meck/commit/558e925b48ce257b12e381080c851dc49c87d7bb

I only noticed when looking at the tests that there is already a ticket which is addressed by this change:
Fixes #805 . 

I ran this modified `els_dodger` and `epp_dodger` on most of the OTP modules, and they either return the same result or `epp_dodger` returns some errors while `els_dodger` doesn't.

I'm willing to submit this change upstream to OTP, but erlang_ls has a better turnaround time and more added value to start here first :)