### PR TITLE
Dont crash in case compiler option is not found in a beam

### DIFF
--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -378,7 +378,7 @@ compile_options(Module) ->
       case beam_lib:chunks(Beam, [compile_info]) of
         {ok, {_, Chunks}} ->
           Info = proplists:get_value(compile_info, Chunks),
-          proplists:get_value(options, Info);
+          proplists:get_value(options, Info, []);
         Error ->
           lager:info( "Error extracting compile_info. [module=~p] [error=~p]"
                     , [Module, Error]),


### PR DESCRIPTION
### Description
In case module was compiled with the 'deterministic' flag, the compile_info key does not have the 'option'  part so it is 'undefined'
Fixes # 
'undefined' is treated as a list and used with ++ that crashes els_compiler_diagnostics:load_dependencies(317).
