### PR TITLE
db_dir env var is not used any more

### DIFF
--- a/test/els_test_utils.erl
+++ b/test/els_test_utils.erl
@@ -55,8 +55,6 @@ init_per_suite(Config) ->
                            , ?TEST_APP]),
   RootUri = els_uri:uri(RootPath),
   application:load(erlang_ls),
-  Priv = ?config(priv_dir, Config),
-  application:set_env(erlang_ls, db_dir, Priv),
   [ {root_uri, RootUri}
   , {root_path, RootPath}
   | Config ].


### PR DESCRIPTION
### Description

Just a minor cleanup in test. Additionally the [Internals](https://erlang-ls.github.io/internals/) page also talks about Mnesia. Maybe that page could be deleted or just mention the database is only stored in memory?
