### PR TITLE
Implement using long names for distribution

### DIFF
--- a/src/els_compiler_diagnostics.erl
+++ b/src/els_compiler_diagnostics.erl
@@ -338,7 +338,8 @@ load_dependency(Module, IncludingPath) ->
 maybe_compile_and_load(Uri, [] = _CDiagnostics) ->
   case els_config:get(code_reload) of
     #{"node" := NodeStr} ->
-      Node = list_to_atom(NodeStr),
+      Node = els_utils:compose_node_name(NodeStr,
+                                         els_config_runtime:get_name_type()),
       Module = els_uri:module(Uri),
       case rpc:call(Node, code, is_sticky, [Module]) of
         true -> ok;

--- a/src/els_config.erl
+++ b/src/els_config.erl
@@ -83,6 +83,7 @@ initialize(RootUri, Capabilities, InitOptions) ->
 do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   RootPath        = els_utils:to_list(els_uri:path(RootUri)),
   OtpPath         = maps:get("otp_path", Config, code:root_dir()),
+  lager:info("OTP Path: ~p", [OtpPath]),
   DepsDirs        = maps:get("deps_dirs", Config, []),
   AppsDirs        = maps:get("apps_dirs", Config, ["."]),
   IncludeDirs     = maps:get("include_dirs", Config, ["include"]),
@@ -115,6 +116,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = set(macros         , Macros),
   ok = set(plt_path       , DialyzerPltPath),
   ok = set(code_reload    , CodeReload),
+  lager:info("Config=~p", [Config]),
   ok = set(runtime, maps:merge( els_config_runtime:default_config()
                               , Runtime)),
   ok = set('ct-run-test', maps:merge( els_config_ct_run_test:default_config()

--- a/src/els_config_runtime.erl
+++ b/src/els_config_runtime.erl
@@ -27,20 +27,7 @@ default_config() ->
 -spec get_node_name() -> atom().
 get_node_name() ->
   Value = maps:get("node_name", els_config:get(runtime), default_node_name()),
-  NodeName = case lists:member($@, Value) of
-               true ->
-                 Value;
-               _ ->
-                 {ok, HostName} = inet:gethostname(),
-                 Value ++ [$@ | HostName]
-             end,
-  case get_name_type() of
-    shortnames ->
-      list_to_atom(NodeName);
-    longnames ->
-      Domain = proplists:get_value(domain, inet:get_rc(), ""),
-      list_to_atom(NodeName ++ "." ++ Domain)
-  end.
+  els_utils:compose_node_name(Value, get_name_type()).
 
 -spec get_otp_path() -> string().
 get_otp_path() ->

--- a/src/els_utils.erl
+++ b/src/els_utils.erl
@@ -13,6 +13,7 @@
         , resolve_paths/3
         , to_binary/1
         , to_list/1
+        , compose_node_name/2
         ]).
 
 -include("erlang_ls.hrl").
@@ -368,3 +369,21 @@ make_normalized_path([".." | T], [Head | Tail]) when Head =/= ".." ->
   make_normalized_path(T, Tail);
 make_normalized_path([H | T], NormalizedPath) ->
   make_normalized_path(T, [H | NormalizedPath]).
+
+-spec compose_node_name(Name :: string(), Type :: shortnames | longnames) ->
+  NodeName :: atom().
+compose_node_name(Name, Type) ->
+  NodeName = case lists:member($@, Name) of
+               true ->
+                 Name;
+               _ ->
+                 {ok, HostName} = inet:gethostname(),
+                 Name ++ [$@ | HostName]
+             end,
+  case Type of
+    shortnames ->
+      list_to_atom(NodeName);
+    longnames ->
+      Domain = proplists:get_value(domain, inet:get_rc(), ""),
+      list_to_atom(NodeName ++ "." ++ Domain)
+  end.


### PR DESCRIPTION
### Description

Add use_long_names boolean variable to erlang_ls.config
Add cookie string variable to erlang_ls.config

This change will allow using long node names for the runtime node