### PR TITLE
Fix macro rename deleting the next character

### DIFF
--- a/src/els_rename_provider.erl
+++ b/src/els_rename_provider.erl
@@ -110,10 +110,9 @@ editable_range(#{kind := _Kind, range := Range}) ->
 
 -spec editable_range(poi_kind(), els_dt_references:item()) -> range().
 editable_range(macro, #{range := Range}) ->
-  #{ from := {FromL, FromC}, to := {ToL, ToC} } = Range,
-  #{ start => #{line => FromL - 1, character => FromC}
-   , 'end' => #{line => ToL - 1,   character => ToC}
-   }.
+  #{ from := {FromL, FromC} } = Range,
+  EditFromC = FromC + length("?"),
+  els_protocol:range(Range#{ from := {FromL, EditFromC} }).
 
 -spec changes(uri(), poi(), binary()) -> #{uri() => [text_edit()]} | null.
 changes(Uri, #{kind := 'define', id := Id} = POI, NewName) ->

--- a/test/els_rename_SUITE.erl
+++ b/test/els_rename_SUITE.erl
@@ -127,17 +127,17 @@ rename_macro(Config) ->
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 14, line => 15}
+                              #{ 'end' => #{character => 13, line => 15}
                                , start => #{character => 4, line => 15}}}
                        , #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 26, line => 15}
+                              #{ 'end' => #{character => 25, line => 15}
                                , start => #{character => 16, line => 15}}}
                        ]
                    , binary_to_atom(?config(rename_usage2_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 27, line => 11}
+                              #{ 'end' => #{character => 26, line => 11}
                                , start => #{character => 17, line => 11}}}
                        ]
                    }
@@ -161,18 +161,18 @@ rename_parametrized_macro(Config) ->
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 27, line => 18}
+                              #{ 'end' => #{character => 26, line => 18}
                                , start => #{character => 4, line => 18}}}
                        , #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 55, line => 18}
+                              #{ 'end' => #{character => 54, line => 18}
                                , start => #{character => 32, line => 18}}}
                        ]
                     , binary_to_atom(
                         ?config(rename_usage2_uri, Config), utf8) =>
                         [ #{ newText => NewName
                            , range =>
-                               #{ 'end' => #{character => 53, line => 14}
+                               #{ 'end' => #{character => 52, line => 14}
                                 , start => #{character => 30, line => 14}}}
                         ]
                    }
@@ -196,17 +196,17 @@ rename_macro_from_usage(Config) ->
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 14, line => 15}
+                              #{ 'end' => #{character => 13, line => 15}
                                , start => #{character => 4, line => 15}}}
                        , #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 26, line => 15}
+                              #{ 'end' => #{character => 25, line => 15}
                                , start => #{character => 16, line => 15}}}
                        ]
                    , binary_to_atom(?config(rename_usage2_uri, Config), utf8) =>
                        [ #{ newText => NewName
                           , range =>
-                              #{ 'end' => #{character => 27, line => 11}
+                              #{ 'end' => #{character => 26, line => 11}
                                , start => #{character => 17, line => 11}}}
                        ]
                    }


### PR DESCRIPTION
The range of a macro poi includes the leading '?'. However the columns were not
converted to protocol-range, so the values were shifted one char to the right
resulting in the '?' being preserved but the char after the macro being deleted.