### PR TITLE
Update Makefile to build needed .plt for typer tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ install: all
 	@ cp _build/default/bin/erlang_ls /usr/local/bin
 
 ci:
+	dialyzer --build_plt --apps erts kernel stdlib
 	rebar3 do compile, ct, proper --cover --constraint_tries 100, dialyzer, xref, cover, edoc
 
 coveralls:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ install: all
 	@ echo "Installing escript..."
 	@ cp _build/default/bin/erlang_ls /usr/local/bin
 
-ci:
+$HOME/.dialyzer_plt:
 	dialyzer --build_plt --apps erts kernel stdlib
+
+ci: $HOME/.dialyzer_plt
 	rebar3 do compile, ct, proper --cover --constraint_tries 100, dialyzer, xref, cover, edoc
 
 coveralls:


### PR DESCRIPTION
The `suggest_spec` test fails if the appropriate PLT does not exist.

Update the makefile so that `make ci` builds the PLT, so the tests can be run
locally and pass.
