### PR TITLE
[#869] Avoid un-necessary CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,9 @@ on:
     branches:
       - '*'
   pull_request:
-    branches:
-      - master
+    types:
+      - opened
+      - synchronize
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Leaving '*' instead of 'main' only to be able to run CI *before*
opening a PR.

Fixes #869 .
