### PR TITLE
Make els_code_navigation find non-fully qualified BIFs

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_autoimport.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_autoimport.erl
@@ -1,0 +1,6 @@
+-module(diagnostics_autoimport).
+
+-export([main/1]).
+
+main(_Args) ->
+    fun atom_to_list/1.

--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_autoimport_disabled.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_autoimport_disabled.erl
@@ -1,0 +1,7 @@
+-module(diagnostics_autoimport_disabled).
+-compile(no_auto_import).
+
+-export([main/1]).
+
+main(_Args) ->
+    fun atom_to_list/1.

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -153,6 +153,8 @@ sources() ->
   , completion_snippets
   , diagnostics
   , diagnostics_bound_var_in_pattern
+  , diagnostics_autoimport
+  , diagnostics_autoimport_disabled
   , diagnostics_behaviour
   , diagnostics_behaviour_impl
   , diagnostics_macros


### PR DESCRIPTION
### Make els_code_navigation find non-fully qualified BIFs

Add indexing of no_auto_import compile options. Use this information when deciding whether a fun reference is to a BIF.

Fixes #860.
