### PR TITLE
Don't store the pois of OTP modules in ets at startup

### DIFF
--- a/src/els_indexing.erl
+++ b/src/els_indexing.erl
@@ -65,7 +65,15 @@ index(Uri, Text, Mode) ->
 
 -spec do_index(els_dt_document:item(), mode()) -> ok.
 do_index(#{uri := Uri, id := Id, kind := Kind} = Document, Mode) ->
-  ok = els_dt_document:insert(Document),
+  case Mode of
+    'deep' ->
+      ok = els_dt_document:insert(Document);
+    'shallow' ->
+      %% Don't store detailed POIs when "shallow" indexing.
+      %% They will be reloaded and inserted when needed
+      %% by calling els_utils:lookup_document/1
+      ok
+  end,
   %% Mapping from document id to uri
   ModuleItem = els_dt_document_index:new(Id, Uri, Kind),
   ok = els_dt_document_index:insert(ModuleItem),


### PR DESCRIPTION
They take up a lot of memory, duplicated for each project, and most of them not
used. They will be reloaded and inserted when needed by calling
`els_utils:lookup_document/1` so there is no information loss.

OTP modules are outside of the project root, so for example if one jumps to the definition of an OTP function and opens an OTP module it will start a new ELS node. Hence the POIs of OTP modules in a non-OTP project are mostly unused. (One exception I noticed when showing hover-docs, it fetches the function heads and so it currently loads and stores the module again) 
This is just a quick fix - On the long term there could be a different, limited set of info stored for OTP modules, only those which are for referencing but nothing that is about the implementation.

I observed the below memory reduction with this change when opening a file in erlang_ls (using OTP 21.3.8.2)

- memory on master edef4404

```
1> ets:info(els_dt_document, size).
977
2> ets:info(els_dt_document, memory).
42_895_927 words
3> erlang:memory(ets).
346_978_168 bytes
4> erlang:memory(total).
425_065_032 bytes
```

- memory with no OTP POIs

```
1> ets:info(els_dt_document, size).
128
2> ets:info(els_dt_document, memory).
1_037_279 words
3> erlang:memory(ets).
12_103_352 bytes
4> erlang:memory(total).
53_198_120 bytes
```