### PR TITLE
Support references from function_clause POI

### DIFF
--- a/src/els_dt_references.erl
+++ b/src/els_dt_references.erl
@@ -104,6 +104,7 @@ find_by(Pattern) ->
 kind_to_category(Kind) when Kind =:= application;
                             Kind =:= export_entry;
                             Kind =:= function;
+                            Kind =:= function_clause;
                             Kind =:= implicit_fun ->
   function;
 kind_to_category(Kind) when Kind =:= export_type_entry;

--- a/src/els_references_provider.erl
+++ b/src/els_references_provider.erl
@@ -63,6 +63,12 @@ find_references(Uri, #{ kind := Kind
           {M, F, A} -> {M, F, A}
         end,
   find_references_for_id(Kind, Key);
+find_references(Uri, #{ kind := Kind
+                      , id   := Id
+                      }) when Kind =:= function_clause ->
+  {F, A, _Index} = Id,
+  Key = {els_uri:module(Uri), F, A},
+  find_references_for_id(Kind, Key);
 find_references(_Uri, #{kind := Kind, id := Name})
   when Kind =:= record_expr;
        Kind =:= record ->

--- a/test/els_references_SUITE.erl
+++ b/test/els_references_SUITE.erl
@@ -14,6 +14,7 @@
 -export([ application_local/1
         , application_remote/1
         , function_definition/1
+        , function_multiple_clauses/1
         , fun_local/1
         , fun_remote/1
         , export_entry/1
@@ -107,6 +108,18 @@ function_definition(Config) ->
                          }
                       , #{ uri => Uri
                          , range => #{from => {51, 7}, to => {51, 23}}
+                         }
+                      ],
+  assert_locations(Locations, ExpectedLocations),
+  ok.
+
+-spec function_multiple_clauses(config()) -> ok.
+function_multiple_clauses(Config) ->
+  Uri = ?config(hover_docs_uri, Config),
+  UriCaller = ?config(hover_docs_caller_uri, Config),
+  #{result := Locations} = els_client:references(Uri, 7, 1),
+  ExpectedLocations = [ #{ uri => UriCaller
+                         , range => #{from => {15, 3}, to => {15, 30}}
                          }
                       ],
   assert_locations(Locations, ExpectedLocations),


### PR DESCRIPTION
Finding references when pointer is on the first clause works, because element at
position is a `function` POI. However when the pointer is on another clause of a
multi-clause function, element at position is a `function_clause` POI.
