### PR TITLE
Find POIs recursively in type, spec and record attributes

### DIFF
--- a/apps/els_lsp/test/els_references_SUITE.erl
+++ b/apps/els_lsp/test/els_references_SUITE.erl
@@ -292,7 +292,12 @@ type_local(Config) ->
 type_remote(Config) ->
   UriTypes = ?config(code_navigation_types_uri, Config),
   Uri = ?config(code_navigation_extra_uri, Config),
-  ExpectedLocations = [ #{ uri   => Uri
+  ExpectedLocations = [ %% local reference from another type definition
+                        #{ uri   => UriTypes
+                         , range => #{from => {11, 24}, to => {11, 30}}
+                         }
+                        %% remote reference from a spec
+                      , #{ uri   => Uri
                          , range => #{from => {11, 38}, to => {11, 66}}
                          }
                       ],
@@ -315,9 +320,9 @@ assert_locations(Locations, ExpectedLocations) ->
   ?assertEqual(length(ExpectedLocations), length(Locations)),
   Pairs = lists:zip(lists:sort(Locations), ExpectedLocations),
   [ begin
-      #{uri := Uri, range := Range} = Location,
+      #{range := Range} = Location,
       #{uri := ExpectedUri, range := ExpectedRange} = Expected,
-      ?assertEqual(ExpectedUri, Uri),
+      ?assertMatch(#{uri := ExpectedUri}, Location),
       ?assertEqual( els_protocol:range(ExpectedRange)
                   , Range
                   )


### PR DESCRIPTION
### Description

Use the generic fold and subtree mechanism to descend into nested structures and
find all types and record types.

### Bacground

I started out fixing jumping to type and record definitions from record definitions. Then a bit of scope creep happened, as I realised the body of type and spec attributes used to be parsed on a special shallow way only. Additionally I made preparations to find macros in all kinds of weird places in attributes.

Fixes #815 #818 even more
