### PR TITLE
[dap] limit the watch list to variables in the current frame

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -263,12 +263,12 @@ handle_request( {<<"stepOut">>, Params}
   Pid = to_pid(ThreadId, Threads),
   ok = els_dap_rpc:next(ProjectNode, Pid),
   {#{}, State};
-handle_request({<<"evaluate">>, #{ <<"context">> := <<"hover">>
+handle_request({<<"evaluate">>, #{ <<"context">> := Context
                                  , <<"frameId">> := FrameId
                                  , <<"expression">> := Input
                                  } = _Params}
               , #{ threads := Threads } = State
-              ) ->
+) when Context =:= <<"watch">> orelse Context =:= <<"hover">> ->
   %% hover makes only sense for variables
   %% use the expression as fallback
   case frame_by_id(FrameId, maps:values(Threads)) of
@@ -283,14 +283,14 @@ handle_request({<<"evaluate">>, #{ <<"context">> := <<"hover">>
           {#{<<"result">> => <<"not available">>}, State}
       end
   end;
-handle_request({<<"evaluate">>, #{ <<"context">> := Context
+handle_request({<<"evaluate">>, #{ <<"context">> := <<"repl">>
                                  , <<"frameId">> := FrameId
                                  , <<"expression">> := Input
                                  } = _Params}
               , #{ threads := Threads
                  , project_node := ProjectNode
                  } = State
-) when Context =:= <<"watch">> orelse Context =:= <<"repl">> ->
+) ->
   %% repl and watch can use whole expressions,
   %% but we still want structured variable scopes
   case pid_by_frame_id(FrameId, maps:values(Threads)) of


### PR DESCRIPTION
It's not possible to have fully-fledged expressions through the interpreter in the watch list:
- each evaluate through the meta process triggers an update to the stack frame
- an update to the frame triggers an update to the watch list (which triggers an update to the frame)

This limits this to extracting variables from the current frame, similar to hover. There are some potential things we can do, e.g. erl_eval in the project node, but it's an easy way to break the DAP.

I'll revisit this when working on the REPL.