### PR TITLE
Fix Erlang/OTP 24 compiler warning

### DIFF
--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -147,8 +147,8 @@ find_completion( Prefix
       variables(Document);
     %% Check for "[...] fun atom"
     [{atom, _, _}, {'fun', _} | _] ->
-      bifs(function, _ExportFormat = true)
-        ++ definitions(Document, function, _ExportFormat = true);
+      bifs(function, ExportFormat = true)
+        ++ definitions(Document, function, ExportFormat = true);
     %% Check for "[...] atom"
     [{atom, _, Name} | _] ->
       NameBinary = atom_to_binary(Name, utf8),


### PR DESCRIPTION
Erlang/OTP 24 starts to warn when a \_Variable is used in a match, so we remove the '_'. See https://github.com/erlang/otp/pull/2995 for details about the warning.