### PR TITLE
Handle macros in type attributes

### DIFF
--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -20,6 +20,10 @@
         , types_recursive/1
         , opaque_recursive/1
         , record_def_recursive/1
+        , callback_macro/1
+        , spec_macro/1
+        , type_macro/1
+        , opaque_macro/1
         ]).
 
 %%==============================================================================
@@ -172,6 +176,34 @@ assert_recursive_types(Text) ->
                 #{id := {t2, 1}},
                 #{id := {t3, 0}}],
                parse_find_pois(Text, type_application)),
+  ok.
+
+-spec callback_macro(config()) -> ok.
+callback_macro(_Config) ->
+  Text = "-callback foo() -> ?M().",
+  ?assertMatch([_], parse_find_pois(Text, callback, {foo, 0})),
+  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ok.
+
+-spec spec_macro(config()) -> ok.
+spec_macro(_Config) ->
+  Text = "-spec foo() -> ?M().",
+  ?assertMatch([_], parse_find_pois(Text, spec, {foo, 0})),
+  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ok.
+
+-spec type_macro(config()) -> ok.
+type_macro(_Config) ->
+  Text = "-type t() :: ?M(a, b).",
+  ?assertMatch([_], parse_find_pois(Text, type_definition, {t, 0})),
+  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ok.
+
+-spec opaque_macro(config()) -> ok.
+opaque_macro(_Config) ->
+  Text = "-opaque o() :: ?M(a, b).",
+  ?assertMatch([_], parse_find_pois(Text, type_definition, {o, 0})),
+  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
   ok.
 
 %%==============================================================================


### PR DESCRIPTION
### Description

`erl_syntax:attribute_arguments` returns the AST of AST for type attributes. (See details in code comments) That is problematic in multiple places:
- `els_dodger` can't properly find and rewrite magic-macro-tuples because it will see the AST of the AST of these tuples. It still used to add fallback macros.
- then `erl_syntax:concrete` only handles an AST of a term, it crashes if the input includes AST of macros (or types). [`erl_syntax_lib:analyze_wild_attribute` ](https://github.com/erlang/otp/blob/master/lib/syntax_tools/src/erl_syntax_lib.erl#L1604) uses that and also fails.

Because els forked the dodger we have the freedom to return different representation for type attributes. But that needs to be handled in els_parser as well.
New representation of args are: ([erl_parse abstract format](http://erlang.org/doc/apps/erts/absform.html#module-declarations-and-forms) for reference)
- callback, spec: erl_parse `{{Name,Arity},[AST(fun_type), ...]}` => els_dodger `AST({Name, Arity}, [fun_type, ...]}`
- type, opaque: erl_parse `{Name,AST(type),[AST(var), ..]}` => els_dodger `AST({Name, type, [var, ...]})`

Fixes #908

### TODO

- [ ] more macro tests
