### PR TITLE
fix --version for escripts and have dap version consistent with erlan…

### DIFF
--- a/apps/els_dap/src/els_dap.app.src
+++ b/apps/els_dap/src/els_dap.app.src
@@ -1,6 +1,6 @@
 {application, els_dap, [
     {description, "Erlang LS - Debug Adapter Protocol"},
-    {vsn, "0.1.0"},
+    {vsn, git},
     {registered, []},
     {mod, {els_dap_app, []}},
     {applications, [

--- a/apps/els_dap/src/els_dap.erl
+++ b/apps/els_dap/src/els_dap.erl
@@ -21,6 +21,7 @@
 main(Args) ->
   application:load(getopt),
   application:load(els_core),
+  application:load(els_dap),
   ok = parse_args(Args),
   application:set_env(els_core, server, els_dap_server),
   configure_logging(),

--- a/apps/els_lsp/src/erlang_ls.erl
+++ b/apps/els_lsp/src/erlang_ls.erl
@@ -18,6 +18,7 @@
 main(Args) ->
   application:load(getopt),
   application:load(els_core),
+  application:load(?APP),
   ok = parse_args(Args),
   application:set_env(els_core, server, els_server),
   configure_logging(),


### PR DESCRIPTION
```
erlang_ls --version
```

is currently broken