### PR TITLE
[dap] improve dap startup and shutdown

### DIFF
--- a/apps/els_core/src/els_distribution_server.erl
+++ b/apps/els_core/src/els_distribution_server.erl
@@ -155,11 +155,11 @@ start(Node) ->
   wait_connect_and_monitor(Node),
   ok.
 
--spec wait_connect_and_monitor(atom()) -> ok.
+-spec wait_connect_and_monitor(atom()) ->  ok | error.
 wait_connect_and_monitor(Node) ->
   wait_connect_and_monitor(Node, ?WAIT_ATTEMPTS).
 
--spec wait_connect_and_monitor(Node :: atom(), Attempts :: pos_integer()) -> ok.
+-spec wait_connect_and_monitor(Node :: atom(), Attempts :: pos_integer()) ->  ok | error.
 wait_connect_and_monitor(Node, Attempts) ->
   wait_connect_and_monitor(Node, Attempts, Attempts).
 
@@ -167,7 +167,7 @@ wait_connect_and_monitor(Node, Attempts) ->
   Node :: atom(),
   Attempts :: pos_integer(),
   MaxAttempts :: pos_integer()
-) -> ok.
+) -> ok | error.
 wait_connect_and_monitor(Node, 0, MaxAttempts) ->
   ?LOG_ERROR( "Failed to connect to node ~p after ~p attempts"
             , [Node, MaxAttempts]),

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -97,15 +97,18 @@ handle_request({<<"launch">>, Params}, State) ->
   %% get default and final launch config
   DefaultConfig = #{
     <<"projectnode">> =>
-      atom_to_binary(els_distribution_server:node_name(<<"erlang_ls_dap_project">>, Name)),
-    <<"cookie">> => atom_to_binary(erlang:get_cookie()),
+      atom_to_binary(
+        els_distribution_server:node_name(<<"erlang_ls_dap_project">>, Name),
+        utf8
+      ),
+    <<"cookie">> => atom_to_binary(erlang:get_cookie(), utf8),
     <<"timeout">> => 30
   },
   #{ <<"projectnode">> := ConfProjectNode
    , <<"cookie">>  := ConfCookie
    , <<"timeout">> := TimeOut} = maps:merge(DefaultConfig, Params),
-  ProjectNode = binary_to_atom(ConfProjectNode),
-  Cookie = binary_to_atom(ConfCookie),
+  ProjectNode = binary_to_atom(ConfProjectNode, utf8),
+  Cookie = binary_to_atom(ConfCookie, utf8),
 
   %% set cookie
   true = erlang:set_cookie(LocalNode, Cookie),

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -371,7 +371,8 @@ handle_request({<<"variables">>, #{<<"variablesReference">> := Ref
   {Variables, MoreBindings} = build_variables(Type, Bindings),
   { #{<<"variables">> => Variables}
   , State#{ scope_bindings => maps:merge(RestBindings, MoreBindings)}};
-handle_request({<<"disconnect">>, _Params}, State) ->
+handle_request({<<"disconnect">>, _Params}, State = #{project_node := ProjectNode}) ->
+  els_dap_rpc:halt(ProjectNode),
   els_utils:halt(0),
   {#{}, State}.
 

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -718,14 +718,13 @@ do_function_breaks(Node, Module, FBreaks, Breaks) ->
 
 -spec ensure_connected(node(), timeout()) -> ok.
 ensure_connected(Node, Timeout) ->
-  case is_node_up(Node) of
+  case is_node_connected(Node) of
     true -> ok;
     false ->
       % connect and monitore project node
-      els_distribution_server:wait_connect_and_monitor(Node, Timeout),
-      case is_node_up(Node) of
-        true -> inject_dap_agent(Node);
-        false -> stop_debugger()
+      case els_distribution_server:wait_connect_and_monitor(Node, Timeout) of
+        ok -> inject_dap_agent(Node);
+        _ -> stop_debugger()
       end
   end.
 
@@ -737,6 +736,6 @@ stop_debugger() ->
   ?LOG_NOTICE("terminating debug adapter"),
   els_utils:halt(0).
 
--spec is_node_up(node()) -> boolean().
-is_node_up(Node) ->
+-spec is_node_connected(node()) -> boolean().
+is_node_connected(Node) ->
   lists:member(Node, erlang:nodes(connected)).

--- a/apps/els_dap/src/els_dap_rpc.erl
+++ b/apps/els_dap/src/els_dap_rpc.erl
@@ -9,6 +9,7 @@
         , continue/2
         , eval/3
         , get_meta/2
+        , halt/1
         , i/2
         , load_binary/4
         , meta/4
@@ -63,6 +64,10 @@ eval(Node, Input, Bindings) ->
 -spec get_meta(node(), pid()) -> {ok, pid()}.
 get_meta(Node, Pid) ->
   rpc:call(Node, dbg_iserver, safe_call, [{get_meta, Pid}]).
+
+-spec halt(node()) -> true.
+halt(Node) ->
+  rpc:cast(Node, erlang, halt, []).
 
 -spec i(node(), module()) -> any().
 i(Node, Module) ->

--- a/apps/els_dap/test/els_dap_general_provider_SUITE.erl
+++ b/apps/els_dap/test/els_dap_general_provider_SUITE.erl
@@ -25,9 +25,6 @@
     project_node_exit/1
 ]).
 
-%% TODO: cleanup after dropping support for OTP 21 and 22
--compile({no_auto_import, [atom_to_binary/1, binary_to_atom/1]}).
-
 %%==============================================================================
 %% Includes
 %%==============================================================================
@@ -89,7 +86,7 @@ init_per_testcase(_TestCase, Config0) ->
 -spec end_per_testcase(atom(), config()) -> ok.
 end_per_testcase(_TestCase, Config) ->
     NodeName = ?config(node, Config),
-    Node = binary_to_atom(NodeName),
+    Node = binary_to_atom(NodeName, utf8),
     unset_all_env(els_core),
     ok = gen_server:stop(?config(provider, Config)),
     gen_server:stop(els_config),
@@ -126,7 +123,7 @@ path_to_test_module(AppDir, Module) ->
 
 -spec wait_for_break(binary(), module(), non_neg_integer()) -> boolean().
 wait_for_break(NodeName, WantModule, WantLine) ->
-    Node = binary_to_atom(NodeName),
+    Node = binary_to_atom(NodeName, utf8),
     Checker = fun() ->
         Snapshots = rpc:call(Node, int, snapshot, []),
         lists:any(
@@ -142,14 +139,6 @@ wait_for_break(NodeName, WantModule, WantLine) ->
         )
     end,
     els_dap_test_utils:wait_for_fun(Checker, 200, 20).
-
--spec atom_to_binary(atom()) -> binary().
-atom_to_binary(Atom) ->
-    list_to_binary(atom_to_list(Atom)).
-
--spec binary_to_atom(binary()) -> atom().
-binary_to_atom(Binary) ->
-    list_to_atom(binary_to_list(Binary)).
 
 %%==============================================================================
 %% Testcases
@@ -373,7 +362,7 @@ set_variable(Config) ->
 breakpoints(Config) ->
     Provider = ?config(provider, Config),
     NodeName = ?config(node, Config),
-    Node = binary_to_atom(NodeName),
+    Node = binary_to_atom(NodeName, utf8),
     DataDir = ?config(data_dir, Config),
     els_provider:handle_request(
         Provider,
@@ -410,7 +399,7 @@ breakpoints(Config) ->
 -spec project_node_exit(config()) -> ok.
 project_node_exit(Config) ->
     NodeName = ?config(node, Config),
-    Node = binary_to_atom(NodeName),
+    Node = binary_to_atom(NodeName, utf8),
     meck:expect(els_utils, halt, 1, meck:val(ok)),
     meck:reset(els_dap_server),
     erlang:monitor_node(Node, true),
@@ -438,8 +427,8 @@ request_launch(AppDir, Node, M, F, A) ->
     request_launch(#{
         <<"projectnode">> => Node,
         <<"cwd">> => AppDir,
-        <<"module">> => atom_to_binary(M),
-        <<"function">> => atom_to_binary(F),
+        <<"module">> => atom_to_binary(M, utf8),
+        <<"function">> => atom_to_binary(F, utf8),
         <<"args">> => unicode:characters_to_binary(io_lib:format("~w", [A]))
     }).
 


### PR DESCRIPTION
- shutdown dap and send events when project node goes down
- ensure, that we don't double monitor nodes
- shutdown project node when we get a disconnect request
- add config for cookie and startup timeout 
