### PR TITLE
[dap] implement shutdown procedure correctly

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -371,7 +371,8 @@ handle_request({<<"variables">>, #{<<"variablesReference">> := Ref
   {Variables, MoreBindings} = build_variables(Type, Bindings),
   { #{<<"variables">> => Variables}
   , State#{ scope_bindings => maps:merge(RestBindings, MoreBindings)}};
-handle_request({<<"disconnect">>, _Params}, State) ->
+handle_request({<<"disconnect">>, _Params}, State = #{project_node := ProjectNode}) ->
+  els_dap_rpc:halt(ProjectNode),
   els_utils:halt(0),
   {#{}, State}.
 

--- a/apps/els_dap/src/els_dap_rpc.erl
+++ b/apps/els_dap/src/els_dap_rpc.erl
@@ -9,6 +9,7 @@
         , continue/2
         , eval/3
         , get_meta/2
+        , halt/1
         , i/2
         , load_binary/4
         , meta/4
@@ -63,6 +64,10 @@ eval(Node, Input, Bindings) ->
 -spec get_meta(node(), pid()) -> {ok, pid()}.
 get_meta(Node, Pid) ->
   rpc:call(Node, dbg_iserver, safe_call, [{get_meta, Pid}]).
+
+-spec halt(node()) -> true.
+halt(Node) ->
+  rpc:cast(Node, erlang, halt, []).
 
 -spec i(node(), module()) -> any().
 i(Node, Module) ->


### PR DESCRIPTION
- shutdown dap and send events when project node goes down
- ensure, that we don't double monitor nodes
- shutdown project node when we get a disconnect request