### PR TITLE
Fix infinite loop when parsing macro in wild attribute name

### DIFF
--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -128,16 +128,26 @@ analyze_attribute(Tree) ->
       [FATree | _] = erl_syntax:tuple_elements(ArgTuple),
       Definition = [], %% ignore definition
       %% concrete will throw an error if `FATRee' contains any macro
-      {AttrName, {AttrName, {erl_syntax:concrete(FATree), Definition}}};
+      try erl_syntax:concrete(FATree) of
+        FA ->
+          {AttrName, {AttrName, {FA, Definition}}}
+      catch _:_ ->
+          throw(syntax_error)
+      end;
     AttrName when AttrName =:= opaque;
                   AttrName =:= type ->
       [ArgTuple] = erl_syntax:attribute_arguments(Tree),
       [TypeTree, _, ArgsListTree] = erl_syntax:tuple_elements(ArgTuple),
       Definition = [], %% ignore definition
       %% concrete will throw an error if `TyperTree' is a macro
-      {AttrName, {AttrName, {erl_syntax:concrete(TypeTree),
-                             Definition,
-                             erl_syntax:list_elements(ArgsListTree)}}};
+      try erl_syntax:concrete(TypeTree) of
+        TypeName ->
+          {AttrName, {AttrName, {TypeName,
+                                 Definition,
+                                 erl_syntax:list_elements(ArgsListTree)}}}
+      catch _:_ ->
+          throw(syntax_error)
+      end;
     _ ->
       erl_syntax_lib:analyze_attribute(Tree)
   end.

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -637,7 +637,7 @@ attribute_name_atom(Tree) ->
     atom ->
       erl_syntax:atom_value(NameNode);
     _ ->
-      Tree
+      NameNode
   end.
 
 -spec attribute_subtrees(atom() | tree(), [tree()]) -> [[tree()]].

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -24,6 +24,7 @@
         , spec_macro/1
         , type_macro/1
         , opaque_macro/1
+        , wild_attrbibute_macro/1
         ]).
 
 %%==============================================================================
@@ -204,6 +205,13 @@ opaque_macro(_Config) ->
   Text = "-opaque o() :: ?M(a, b).",
   ?assertMatch([_], parse_find_pois(Text, type_definition, {o, 0})),
   ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ok.
+
+-spec wild_attrbibute_macro(config()) -> ok.
+wild_attrbibute_macro(_Config) ->
+  Text = "-?M(foo).",
+  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ?assertMatch([_], parse_find_pois(Text, atom, foo)),
   ok.
 
 %%==============================================================================

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -25,6 +25,8 @@
         , type_macro/1
         , opaque_macro/1
         , wild_attrbibute_macro/1
+        , type_name_macro/1
+        , spec_name_macro/1
         ]).
 
 %%==============================================================================
@@ -212,6 +214,25 @@ wild_attrbibute_macro(_Config) ->
   Text = "-?M(foo).",
   ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
   ?assertMatch([_], parse_find_pois(Text, atom, foo)),
+  ok.
+
+type_name_macro(_Config) ->
+  %% Currently els_dodger cannot parse this type definition
+  %% Verify this does not prevent parsing following forms
+  Text = "-type ?M() -> integer() | t(). -spec f() -> any().",
+  ?assertMatch({ok, [#{kind := spec, id := {f, 0}}]}, els_parser:parse(Text)),
+  ok.
+
+spec_name_macro(_Config) ->
+  %% Currently els_dodger cannot parse this
+  %% We can only find a spec-context
+  Text1 = "-spec ?M() -> integer() | t().",
+  ?assertMatch({ok, [#{kind := spec, id := undefined}]}, els_parser:parse(Text1)),
+
+  %% Verify the parser does not crash on macros in spec function names
+  %% and it still returns POIs from the definition body
+  Text2 = "-spec ?MODULE:b() -> integer() | t().",
+  ?assertMatch([_], parse_find_pois(Text2, type_application, {t, 0})),
   ok.
 
 %%==============================================================================


### PR DESCRIPTION
### Description

The infinite loop was triggered during indexing OTP by [`syntax_tools_SUITE_data/syntax_tools_test.erl`](https://github.com/erlang/otp/blob/master/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_test.erl#L17) containing
```
-?attrib([foo2/2]).
```

While running the indexing on OTP I also found that a macro in a spec name caused a crash preventing parsing the whole file.

This was revealed by another test file in syntax_tools (`syntax_tools_SUITE_data/type_specs.erl`) containing

```
-spec ?MODULE:b() -> integer() | t().
```

Fixes #919 
