### PR TITLE
Handle unicode in function clauses when pretty printing

### DIFF
--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -719,7 +719,7 @@ pretty_print_clause(Tree) ->
                   _ ->
                     "when " ++ erl_prettypr:format(Guard)
                 end,
-  PrettyClause = io_lib:format( "(~s) ~s"
+  PrettyClause = io_lib:format( "(~ts) ~ts"
                               , [ string:join(PrettyPatterns, ", ")
                                 , PrettyGuard
                                 ]),

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -27,6 +27,7 @@
         , wild_attrbibute_macro/1
         , type_name_macro/1
         , spec_name_macro/1
+        , unicode_clause_pattern/1
         ]).
 
 %%==============================================================================
@@ -233,6 +234,14 @@ spec_name_macro(_Config) ->
   %% and it still returns POIs from the definition body
   Text2 = "-spec ?MODULE:b() -> integer() | t().",
   ?assertMatch([_], parse_find_pois(Text2, type_application, {t, 0})),
+  ok.
+
+-spec unicode_clause_pattern(config()) -> ok.
+unicode_clause_pattern(_Config) ->
+  %% From OTP compiler's bs_utf_SUITE.erl
+  Text = "match_literal(<<\"Мастер и Маргарита\"/utf8>>) -> mm_utf8.",
+  ?assertMatch([#{data := <<"(<<\"", _/binary>>}],
+               parse_find_pois(Text, function_clause, {match_literal, 1, 1})),
   ok.
 
 %%==============================================================================


### PR DESCRIPTION
### Description

Each `function_clause` POI contains the pretty printed text of the function head
and guards. The pretty printing used to crash if any of those contained unicode
characters.

Found while running indexing through all of OTP. I am afraid this is just one spot, as source code is handled as list of bytes in many places, but Im not an expert in unicode and source code encodings and printable ranges and friends.