### PR TITLE
Fix extracting function spec snippets

### DIFF
--- a/apps/els_core/src/els_text.erl
+++ b/apps/els_core/src/els_text.erl
@@ -6,6 +6,7 @@
 -export([ last_token/1
         , line/2
         , line/3
+        , range/3
         , tokens/1
         ]).
 
@@ -26,6 +27,14 @@ line(Text, LineNum, ColumnNum) ->
   Line = line(Text, LineNum),
   binary:part(Line, {0, ColumnNum}).
 
+%% @doc Extract a snippet from a text, from start location to end location.
+-spec range(text(), {line_num(), column_num()}, {line_num(), column_num()}) -> text().
+range(Text, StartLoc, EndLoc) ->
+  LineStarts = line_starts(Text),
+  StartPos = pos(LineStarts, StartLoc),
+  EndPos = pos(LineStarts, EndLoc),
+  binary:part(Text, StartPos, EndPos - StartPos + 1).
+
 %% @doc Return tokens from text.
 -spec tokens(text()) -> [any()].
 tokens(Text) ->
@@ -41,3 +50,16 @@ last_token(Text) ->
     [] -> {error, empty};
     Tokens -> lists:last(Tokens)
   end.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+
+-spec line_starts(text()) -> [{integer(), any()}].
+line_starts(Text) ->
+  [{-1, 1} | binary:matches(Text, <<"\n">>)].
+
+-spec pos([{integer(), any()}], {line_num(), column_num()}) -> non_neg_integer().
+pos(LineStarts, {LineNum, ColumnNum}) ->
+  {LinePos, _} = lists:nth(LineNum, LineStarts),
+  LinePos + ColumnNum.

--- a/apps/els_lsp/priv/code_navigation/src/hover_docs_caller.erl
+++ b/apps/els_lsp/priv/code_navigation/src/hover_docs_caller.erl
@@ -17,5 +17,7 @@ remote_call_multiple_clauses() ->
 local_call() ->
   ok.
 
+-spec local_call(integer(), any()) -> tuple();
+                (float(), any()) -> tuple().
 local_call(Arg1, Arg2) ->
   {Arg1, Arg2}.

--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -81,10 +81,14 @@ do_index(#{uri := Uri, id := Id, kind := Kind} = Document, Mode) ->
   index_references(Document, Mode).
 
 -spec index_signatures(els_dt_document:item()) -> ok.
-index_signatures(#{id := Id} = Document) ->
+index_signatures(#{id := Id, text := Text} = Document) ->
   Specs  = els_dt_document:pois(Document, [spec]),
-  [ els_dt_signatures:insert(#{ mfa => {Id, F, A}, spec => Spec})
-    || #{id := {F, A}, data := Spec} <- Specs
+  [ begin
+      #{from := From, to := To} = Range,
+      Spec = els_text:range(Text, From, To),
+      els_dt_signatures:insert(#{ mfa => {Id, F, A} , spec => Spec})
+    end
+    || #{id := {F, A}, range := Range} <- Specs
   ],
   ok.
 

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -91,8 +91,7 @@ find_attribute_pois(Tree, Tokens) ->
         {spec, {spec, {{F, A}, _FTs}}} ->
           From = erl_syntax:get_pos(Tree),
           To   = erl_scan:location(lists:last(Tokens)),
-          Data = pretty_print(Tree),
-          [poi({From, To}, spec, {F, A}, Data)];
+          [poi({From, To}, spec, {F, A})];
         {export_type, {export_type, Exports}} ->
           [_ | Atoms] = [T || {atom, _, _} = T <- Tokens],
           ExportTypeEntries =
@@ -699,14 +698,6 @@ skip_type_name_atom(NameNode) ->
      _ ->
        [NameNode]
    end.
--spec pretty_print(tree()) -> binary().
-pretty_print(Tree) ->
-  try
-    els_utils:to_binary(erl_prettypr:format(Tree))
- catch
-   _:_:_ ->
-     <<>>
- end.
 
 -spec pretty_print_clause(tree()) -> binary().
 pretty_print_clause(Tree) ->

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -703,7 +703,10 @@ resolve_application_local(Config) ->
   Expected = Selected#{ documentation =>
                           #{ kind => <<"markdown">>
                            , value =>
-                               <<"## completion_resolve:call_1/0\n\n```erlang\n\n```">>
+                               <<"## completion_resolve:call_1/0\n\n"
+                                 "```erlang\n"
+                                 "-spec call_1() -> 'ok'.\n"
+                                 "```">>
                            }
                       },
   ?assertEqual(Expected, Result).
@@ -718,7 +721,10 @@ resolve_application_remote_self(Config) ->
   Expected = Selected#{ documentation =>
                           #{ kind => <<"markdown">>
                            , value =>
-                               <<"## completion_resolve:call_1/0\n\n```erlang\n\n```">>
+                               <<"## completion_resolve:call_1/0\n\n"
+                                 "```erlang\n"
+                                 "-spec call_1() -> 'ok'.\n"
+                                 "```">>
                            }
                       },
   ?assertEqual(Expected, Result).
@@ -733,7 +739,10 @@ resolve_application_remote_external(Config) ->
   Expected = Selected#{ documentation =>
                           #{ kind => <<"markdown">>
                            , value =>
-                               <<"## completion_resolve_2:call_1/0\n\n```erlang\n\n```">>
+                               <<"## completion_resolve_2:call_1/0\n\n"
+                                 "```erlang\n"
+                                 "-spec call_1() -> 'ok'.\n"
+                                 "```">>
                            }
                       },
   ?assertEqual(Expected, Result).

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -84,6 +84,10 @@ local_call_with_args(Config) ->
   Value = <<"## local_call/2\n\n"
             "```erlang\n\n"
             "  local_call(Arg1, Arg2) \n\n"
+            "```\n\n"
+            "```erlang\n"
+            "-spec local_call(integer(), any()) -> tuple();\n"
+            "                (float(), any()) -> tuple().\n"
             "```">>,
   Expected = #{ kind  => <<"markdown">>
               , value => Value

--- a/apps/els_lsp/test/els_references_SUITE.erl
+++ b/apps/els_lsp/test/els_references_SUITE.erl
@@ -246,8 +246,8 @@ record(Config) ->
 purge_references(_Config) ->
   els_db:clear_tables(),
   Uri   = <<"file:///tmp/foo.erl">>,
-  Text0 = "-spec foo(integer()) -> ok.\nfoo(_X) -> ok.\nbar() -> foo(1).",
-  Text1 = "\n-spec foo(integer()) -> ok.\nfoo(_X)-> ok.\nbar() -> foo(1).",
+  Text0 = <<"-spec foo(integer()) -> ok.\nfoo(_X) -> ok.\nbar() -> foo(1).">>,
+  Text1 = <<"\n-spec foo(integer()) -> ok.\nfoo(_X)-> ok.\nbar() -> foo(1).">>,
   Doc0  = els_dt_document:new(Uri, Text0),
   Doc1  = els_dt_document:new(Uri, Text1),
 


### PR DESCRIPTION
The `spec` POI has no data value any more. Hopefully it was not used elsewhere.

Fixes #922 