### PR TITLE
[dap] add logpoints and fix watchlist

### DIFF
--- a/apps/els_dap/src/els_dap_breakpoints.erl
+++ b/apps/els_dap/src/els_dap_breakpoints.erl
@@ -1,0 +1,98 @@
+-module(els_dap_breakpoints).
+-export([
+    build_source_breakpoints/1,
+    get_function_breaks/2,
+    get_line_breaks/2,
+    do_line_breakpoints/4,
+    do_function_breaks/4,
+    type/3
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("kernel/include/logger.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+
+-type breakpoints() :: #{
+    module() => #{
+        line => #{
+            line() => line_breaks()
+        },
+        function => [function_break()]
+    }
+}.
+-type line() :: non_neg_integer().
+-type line_breaks() ::
+    regular
+    | {log, expression()}.
+-type expression() :: string().
+-type function_break() :: {atom(), non_neg_integer()}.
+
+-export_type([breakpoints/0]).
+
+-spec type(breakpoints(), module(), line()) -> line_breaks().
+type(Breakpoints, Module, Line) ->
+    ?LOG_DEBUG("checking breakpoint type for ~s:~b", [Module, Line]),
+    case Breakpoints of
+        #{Module := #{line := #{Line := Break}}} ->
+            Break;
+        _ ->
+            %% function breaks get handled like regular ones
+            regular
+    end.
+
+%% @doc build regular and log breakpoints from setBreakpoint request
+-spec build_source_breakpoints(Params :: map()) -> {module(), #{line() => line_breaks()}}.
+build_source_breakpoints(Params) ->
+    #{<<"source">> := #{<<"path">> := Path}} = Params,
+    Module = els_uri:module(els_uri:uri(Path)),
+    SourceBreakpoints = maps:get(<<"breakpoints">>, Params, []),
+    _SourceModified = maps:get(<<"sourceModified">>, Params, false),
+    {Module, maps:from_list(lists:map(fun build_source_breakpoint/1, SourceBreakpoints))}.
+
+-spec build_source_breakpoint(map()) -> {line(), 'regular' | {'log', expression()}}.
+build_source_breakpoint(#{<<"line">> := Line, <<"logMessage">> := LogExpr}) ->
+    {Line, {log, LogExpr}};
+build_source_breakpoint(#{<<"line">> := Line}) ->
+    {Line, regular}.
+
+-spec get_function_breaks(module(), breakpoints()) -> [function_break()].
+get_function_breaks(Module, Breaks) ->
+    case Breaks of
+        #{Module := #{function := Functions}} -> Functions;
+        _ -> []
+    end.
+
+-spec get_line_breaks(module(), breakpoints()) -> #{line() => line_breaks()}.
+get_line_breaks(Module, Breaks) ->
+    case Breaks of
+        #{Module := #{line := Lines}} -> Lines;
+        _ -> []
+    end.
+
+-spec do_line_breakpoints(node(), module(), #{line() => line_breaks()}, breakpoints()) ->
+    breakpoints().
+do_line_breakpoints(Node, Module, LineBreakPoints, Breaks) ->
+    maps:map(
+        fun
+            (Line, regular) -> els_dap_rpc:break(Node, Module, Line);
+            (Line, {log, _}) -> els_dap_rpc:break(Node, Module, Line)
+        end,
+        LineBreakPoints
+    ),
+    case Breaks of
+        #{Module := ModBreaks} -> Breaks#{Module => ModBreaks#{line => LineBreakPoints}};
+        _ -> Breaks#{Module => #{line => LineBreakPoints, function => []}}
+    end.
+
+-spec do_function_breaks(node(), module(), [function_break()], breakpoints()) -> breakpoints().
+do_function_breaks(Node, Module, FBreaks, Breaks) ->
+    [els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks],
+    case Breaks of
+        #{Module := ModBreaks} -> Breaks#{Module => ModBreaks#{function => FBreaks}};
+        _ -> Breaks#{Module => #{line => #{}, function => FBreaks}}
+    end.

--- a/apps/els_dap/src/els_dap_breakpoints.erl
+++ b/apps/els_dap/src/els_dap_breakpoints.erl
@@ -1,12 +1,10 @@
 -module(els_dap_breakpoints).
--export([
-    build_source_breakpoints/1,
-    get_function_breaks/2,
-    get_line_breaks/2,
-    do_line_breakpoints/4,
-    do_function_breaks/4,
-    type/3
-]).
+-export([ build_source_breakpoints/1
+        , get_function_breaks/2
+        , get_line_breaks/2
+        , do_line_breakpoints/4
+        , do_function_breaks/4
+        , type/3]).
 
 %%==============================================================================
 %% Includes
@@ -18,17 +16,17 @@
 %%==============================================================================
 
 -type breakpoints() :: #{
-    module() => #{
-        line => #{
-            line() => line_breaks()
-        },
-        function => [function_break()]
-    }
+  module() => #{
+      line => #{
+        line() => line_breaks()
+      },
+      function => [function_break()]
+  }
 }.
 -type line() :: non_neg_integer().
 -type line_breaks() ::
     regular
-    | {log, expression()}.
+  | {log, expression()}.
 -type expression() :: string().
 -type function_break() :: {atom(), non_neg_integer()}.
 
@@ -36,63 +34,63 @@
 
 -spec type(breakpoints(), module(), line()) -> line_breaks().
 type(Breakpoints, Module, Line) ->
-    ?LOG_DEBUG("checking breakpoint type for ~s:~b", [Module, Line]),
-    case Breakpoints of
-        #{Module := #{line := #{Line := Break}}} ->
-            Break;
-        _ ->
-            %% function breaks get handled like regular ones
-            regular
-    end.
+  ?LOG_DEBUG("checking breakpoint type for ~s:~b", [Module, Line]),
+  case Breakpoints of
+    #{Module := #{line := #{Line := Break}}} ->
+      Break;
+    _ ->
+      %% function breaks get handled like regular ones
+      regular
+  end.
 
 %% @doc build regular and log breakpoints from setBreakpoint request
 -spec build_source_breakpoints(Params :: map()) -> {module(), #{line() => line_breaks()}}.
 build_source_breakpoints(Params) ->
-    #{<<"source">> := #{<<"path">> := Path}} = Params,
-    Module = els_uri:module(els_uri:uri(Path)),
-    SourceBreakpoints = maps:get(<<"breakpoints">>, Params, []),
-    _SourceModified = maps:get(<<"sourceModified">>, Params, false),
-    {Module, maps:from_list(lists:map(fun build_source_breakpoint/1, SourceBreakpoints))}.
+  #{<<"source">> := #{<<"path">> := Path}} = Params,
+  Module = els_uri:module(els_uri:uri(Path)),
+  SourceBreakpoints = maps:get(<<"breakpoints">>, Params, []),
+  _SourceModified = maps:get(<<"sourceModified">>, Params, false),
+  {Module, maps:from_list(lists:map(fun build_source_breakpoint/1, SourceBreakpoints))}.
 
 -spec build_source_breakpoint(map()) -> {line(), 'regular' | {'log', expression()}}.
 build_source_breakpoint(#{<<"line">> := Line, <<"logMessage">> := LogExpr}) ->
-    {Line, {log, LogExpr}};
+  {Line, {log, LogExpr}};
 build_source_breakpoint(#{<<"line">> := Line}) ->
-    {Line, regular}.
+  {Line, regular}.
 
 -spec get_function_breaks(module(), breakpoints()) -> [function_break()].
 get_function_breaks(Module, Breaks) ->
-    case Breaks of
-        #{Module := #{function := Functions}} -> Functions;
-        _ -> []
-    end.
+  case Breaks of
+    #{Module := #{function := Functions}} -> Functions;
+    _ -> []
+  end.
 
 -spec get_line_breaks(module(), breakpoints()) -> #{line() => line_breaks()}.
 get_line_breaks(Module, Breaks) ->
-    case Breaks of
-        #{Module := #{line := Lines}} -> Lines;
-        _ -> []
-    end.
+  case Breaks of
+    #{Module := #{line := Lines}} -> Lines;
+    _ -> []
+  end.
 
 -spec do_line_breakpoints(node(), module(), #{line() => line_breaks()}, breakpoints()) ->
-    breakpoints().
+  breakpoints().
 do_line_breakpoints(Node, Module, LineBreakPoints, Breaks) ->
-    maps:map(
-        fun
-            (Line, regular) -> els_dap_rpc:break(Node, Module, Line);
-            (Line, {log, _}) -> els_dap_rpc:break(Node, Module, Line)
-        end,
-        LineBreakPoints
-    ),
-    case Breaks of
-        #{Module := ModBreaks} -> Breaks#{Module => ModBreaks#{line => LineBreakPoints}};
-        _ -> Breaks#{Module => #{line => LineBreakPoints, function => []}}
-    end.
+  maps:map(
+    fun
+      (Line, regular) -> els_dap_rpc:break(Node, Module, Line);
+      (Line, {log, _}) -> els_dap_rpc:break(Node, Module, Line)
+    end,
+    LineBreakPoints
+  ),
+  case Breaks of
+    #{Module := ModBreaks} -> Breaks#{Module => ModBreaks#{line => LineBreakPoints}};
+    _ -> Breaks#{Module => #{line => LineBreakPoints, function => []}}
+  end.
 
 -spec do_function_breaks(node(), module(), [function_break()], breakpoints()) -> breakpoints().
 do_function_breaks(Node, Module, FBreaks, Breaks) ->
-    [els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks],
-    case Breaks of
-        #{Module := ModBreaks} -> Breaks#{Module => ModBreaks#{function => FBreaks}};
-        _ -> Breaks#{Module => #{line => #{}, function => FBreaks}}
-    end.
+  [els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks],
+  case Breaks of
+    #{Module := ModBreaks} -> Breaks#{Module => ModBreaks#{function => FBreaks}};
+    _ -> Breaks#{Module => #{line => #{}, function => FBreaks}}
+  end.

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -417,7 +417,7 @@ handle_info( {int_cb, ThreadPid}
     {log, Expression} ->
       Return = safe_eval(ProjectNode, ThreadPid, Expression, no_update),
       LogMessage = unicode:characters_to_binary(
-        io_lib:format("@~s:~b -> ~w~n", [Module, Line, Return])
+        io_lib:format("~s:~b - ~w~n", [source(Module, ProjectNode), Line, Return])
       ),
       els_dap_server:send_event(<<"output">>, #{ <<"output">> => LogMessage }),
       els_dap_rpc:continue(ProjectNode, ThreadPid)

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -53,7 +53,7 @@
                           #{pos_integer() => {binding_type(), bindings()}}
                          , breakpoints := els_dap_breakpoints:breakpoints()
                          , timeout := timeout()
-                         , status := undefined | running | stepping
+                         , mode := undefined | running | stepping
                          }.
 -type bindings()     :: [{varname(), term()}].
 -type varname()      :: atom() | string().

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -429,7 +429,7 @@ handle_info( {int_cb, ThreadPid}
           running ->
             els_dap_rpc:continue(ProjectNode, ThreadPid);
           _ ->
-            els_dap_server:send_event(<<"stopped">>, #{ <<"reason">> => <<"breakpoint">>
+            els_dap_server:send_event(<<"stopped">>, #{ <<"reason">> => <<"breakp9oint">>
                                                    , <<"threadId">> => ThreadId
                                                    })
         end,
@@ -726,7 +726,7 @@ ensure_connected(Node, Timeout) ->
     true -> ok;
     false ->
       % connect and monitore project node
-      case els_distribution_server:wait_connect_and_monitor(Node, Timeout, hidden) of
+      case els_distribution_server:wait_connect_and_monitor(Node, Timeout) of
         ok -> inject_dap_agent(Node);
         _ -> stop_debugger()
       end

--- a/apps/els_dap/test/els_dap_SUITE.erl
+++ b/apps/els_dap/test/els_dap_SUITE.erl
@@ -3,21 +3,19 @@
 -include("els_dap.hrl").
 
 %% CT Callbacks
--export([
-    suite/0,
-    init_per_suite/1,
-    end_per_suite/1,
-    init_per_testcase/2,
-    end_per_testcase/2,
-    groups/0,
-    all/0
-]).
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , groups/0
+        , all/0
+        ]).
 
 %% Test cases
--export([
-    parse_args/1,
-    log_root/1
-]).
+-export([ parse_args/1
+        , log_root/1
+        ]).
 
 %%==============================================================================
 %% Includes
@@ -35,84 +33,84 @@
 %%==============================================================================
 -spec suite() -> [tuple()].
 suite() ->
-    [{timetrap, {seconds, 30}}].
+  [{timetrap, {seconds, 30}}].
 
 -spec all() -> [atom()].
 all() ->
-    els_test_utils:all(?MODULE).
+  els_test_utils:all(?MODULE).
 
 -spec groups() -> [atom()].
 groups() ->
-    els_test_utils:groups(?MODULE).
+  els_test_utils:groups(?MODULE).
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(_Config) ->
-    [].
+  [].
 
 -spec end_per_suite(config()) -> ok.
 end_per_suite(_Config) ->
-    ok.
+  ok.
 
 -spec init_per_testcase(atom(), config()) -> config().
 init_per_testcase(_TestCase, _Config) ->
-    [].
+  [].
 
 -spec end_per_testcase(atom(), config()) -> ok.
 end_per_testcase(_TestCase, _Config) ->
-    unset_all_env(els_core),
-    ok.
+  unset_all_env(els_core),
+  ok.
 
 %%==============================================================================
 %% Helpers
 %%==============================================================================
 -spec unset_all_env(atom()) -> ok.
 unset_all_env(Application) ->
-    Envs = application:get_all_env(Application),
-    unset_env(Application, Envs).
+  Envs = application:get_all_env(Application),
+  unset_env(Application, Envs).
 
 -spec unset_env(atom(), list({atom(), term()})) -> ok.
 unset_env(_Application, []) ->
-    ok;
+  ok;
 unset_env(Application, [{Par, _Val} | Rest]) ->
-    application:unset_env(Application, Par),
-    unset_env(Application, Rest).
+  application:unset_env(Application, Par),
+  unset_env(Application, Rest).
 
 %%==============================================================================
 %% Testcases
 %%==============================================================================
 -spec parse_args(config()) -> ok.
 parse_args(_Config) ->
-    Args = [
-        "--transport",
-        "tcp",
-        "--port",
-        "9000",
-        "--log-dir",
-        "/test",
-        "--log-level",
-        "error"
+  Args =
+    [ "--transport"
+    , "tcp"
+    , "--port"
+    , "9000"
+    , "--log-dir"
+    , "/test"
+    , "--log-level"
+    , "error"
     ],
-    els_dap:parse_args(Args),
-    ?assertEqual(els_tcp, application:get_env(els_core, transport, undefined)),
-    ?assertEqual(9000, application:get_env(els_core, port, undefined)),
-    ?assertEqual('error', application:get_env(els_core, log_level, undefined)),
-    ok.
+  els_dap:parse_args(Args),
+  ?assertEqual(els_tcp, application:get_env(els_core, transport, undefined)),
+  ?assertEqual(9000, application:get_env(els_core, port, undefined)),
+  ?assertEqual('error', application:get_env(els_core, log_level, undefined)),
+  ok.
 
 -spec log_root(config()) -> ok.
 log_root(_Config) ->
-    meck:new(file, [unstick]),
-    meck:expect(file, get_cwd, fun() -> {ok, "/root/els_dap"} end),
+  meck:new(file, [unstick]),
+  meck:expect(file, get_cwd, fun() -> {ok, "/root/els_dap"} end),
 
-    Args = [
-        "--transport",
-        "tcp",
-        "--port",
-        "9000",
-        "--log-dir",
-        "/somewhere_else/logs"
+  Args =
+    [ "--transport"
+    , "tcp"
+    , "--port"
+    , "9000"
+    , "--log-dir"
+    , "/somewhere_else/logs"
     ],
-    els_dap:parse_args(Args),
-    ?assertEqual("/somewhere_else/logs/els_dap", els_dap:log_root()),
+  els_dap:parse_args(Args),
+  ?assertEqual("/somewhere_else/logs/els_dap", els_dap:log_root()),
 
-    meck:unload(file),
-    ok.
+  meck:unload(file),
+  ok.

--- a/apps/els_dap/test/els_dap_general_provider_SUITE.erl
+++ b/apps/els_dap/test/els_dap_general_provider_SUITE.erl
@@ -1,30 +1,28 @@
 -module(els_dap_general_provider_SUITE).
 
 %% CT Callbacks
--export([
-    suite/0,
-    init_per_suite/1,
-    end_per_suite/1,
-    init_per_testcase/2,
-    end_per_testcase/2,
-    groups/0,
-    all/0
-]).
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , groups/0
+        , all/0
+        ]).
 
 %% Test cases
--export([
-    initialize/1,
-    launch_mfa/1,
-    launch_mfa_with_cookie/1,
-    configuration_done/1,
-    configuration_done_with_breakpoint/1,
-    frame_variables/1,
-    navigation_and_frames/1,
-    set_variable/1,
-    breakpoints/1,
-    project_node_exit/1,
-    log_points/1
-]).
+-export([ initialize/1
+        , launch_mfa/1
+        , launch_mfa_with_cookie/1
+        , configuration_done/1
+        , configuration_done_with_breakpoint/1
+        , frame_variables/1
+        , navigation_and_frames/1
+        , set_variable/1
+        , breakpoints/1
+        , project_node_exit/1
+        , log_points/1
+        ]).
 
 %%==============================================================================
 %% Includes
@@ -42,105 +40,106 @@
 %%==============================================================================
 -spec suite() -> [tuple()].
 suite() ->
-    [{timetrap, {seconds, 30}}].
+  [{timetrap, {seconds, 30}}].
 
 -spec all() -> [atom()].
 all() ->
-    els_dap_test_utils:all(?MODULE).
+  els_dap_test_utils:all(?MODULE).
 
 -spec groups() -> [atom()].
 groups() ->
-    [].
+  [].
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
-    Config.
+  Config.
 
 -spec end_per_suite(config()) -> ok.
 end_per_suite(_Config) ->
-    ok.
+  ok.
 
 -spec init_per_testcase(atom(), config()) -> config().
 init_per_testcase(TestCase, Config) when
-    TestCase =:= undefined orelse
-        TestCase =:= initialize orelse
-        TestCase =:= launch_mfa orelse
-        TestCase =:= launch_mfa_with_cookie orelse
-        TestCase =:= configuration_done orelse
-        TestCase =:= configuration_done_with_breakpoint orelse
-        TestCase =:= log_points
+  TestCase =:= undefined orelse
+    TestCase =:= initialize orelse
+    TestCase =:= launch_mfa orelse
+    TestCase =:= launch_mfa_with_cookie orelse
+    TestCase =:= configuration_done orelse
+    TestCase =:= configuration_done_with_breakpoint orelse
+    TestCase =:= log_points
 ->
-    {ok, DAPProvider} = els_provider:start_link(els_dap_general_provider),
-    els_config:start_link(),
-    meck:expect(els_dap_server, send_event, 2, meck:val(ok)),
-    [{provider, DAPProvider}, {node, node_name()} | Config];
+  {ok, DAPProvider} = els_provider:start_link(els_dap_general_provider),
+  els_config:start_link(),
+  meck:expect(els_dap_server, send_event, 2, meck:val(ok)),
+  [{provider, DAPProvider}, {node, node_name()} | Config];
 init_per_testcase(_TestCase, Config0) ->
-    Config1 = init_per_testcase(undefined, Config0),
-    %% initialize dap, equivalent to configuration_done_with_breakpoint
-    try configuration_done_with_breakpoint(Config1) of
-        ok -> Config1;
-        R -> {user_skip, {error, dap_initialization, R}}
-    catch
-        Class:Reason ->
-            {user_skip, {error, dap_initialization, Class, Reason}}
-    end.
+  Config1 = init_per_testcase(undefined, Config0),
+  %% initialize dap, equivalent to configuration_done_with_breakpoint
+  try configuration_done_with_breakpoint(Config1) of
+    ok -> Config1;
+    R -> {user_skip, {error, dap_initialization, R}}
+  catch
+    Class:Reason ->
+      {user_skip, {error, dap_initialization, Class, Reason}}
+  end.
 
 -spec end_per_testcase(atom(), config()) -> ok.
 end_per_testcase(_TestCase, Config) ->
-    NodeName = ?config(node, Config),
-    Node = binary_to_atom(NodeName, utf8),
-    unset_all_env(els_core),
-    ok = gen_server:stop(?config(provider, Config)),
-    gen_server:stop(els_config),
-    %% kill the project node
-    rpc:cast(Node, erlang, halt, []),
-    ok.
+  NodeName = ?config(node, Config),
+  Node = binary_to_atom(NodeName, utf8),
+  unset_all_env(els_core),
+  ok = gen_server:stop(?config(provider, Config)),
+  gen_server:stop(els_config),
+  %% kill the project node
+  rpc:cast(Node, erlang, halt, []),
+  ok.
 
 %%==============================================================================
 %% Helpers
 %%==============================================================================
 -spec unset_all_env(atom()) -> ok.
 unset_all_env(Application) ->
-    Envs = application:get_all_env(Application),
-    unset_env(Application, Envs).
+  Envs = application:get_all_env(Application),
+  unset_env(Application, Envs).
 
 -spec unset_env(atom(), list({atom(), term()})) -> ok.
 unset_env(_Application, []) ->
-    ok;
+  ok;
 unset_env(Application, [{Par, _Val} | Rest]) ->
-    application:unset_env(Application, Par),
-    unset_env(Application, Rest).
+  application:unset_env(Application, Par),
+  unset_env(Application, Rest).
 
 -spec node_name() -> node().
 node_name() ->
-    unicode:characters_to_binary(
-        io_lib:format("~s~p@localhost", [?MODULE, erlang:unique_integer()])
-    ).
+  unicode:characters_to_binary(
+    io_lib:format("~s~p@localhost", [?MODULE, erlang:unique_integer()])
+  ).
 
 -spec path_to_test_module(file:name(), module()) -> file:name().
 path_to_test_module(AppDir, Module) ->
-    unicode:characters_to_binary(
-        io_lib:format("~s.erl", [filename:join([AppDir, "src", Module])])
-    ).
+  unicode:characters_to_binary(
+    io_lib:format("~s.erl", [filename:join([AppDir, "src", Module])])
+  ).
 
 -spec wait_for_break(binary(), module(), non_neg_integer()) -> boolean().
 wait_for_break(NodeName, WantModule, WantLine) ->
-    Node = binary_to_atom(NodeName, utf8),
-    Checker = fun() ->
-        Snapshots = rpc:call(Node, int, snapshot, []),
-        lists:any(
-            fun
-                ({_, _, break, {Module, Line}}) when
-                    Module =:= WantModule andalso Line =:= WantLine
-                ->
-                    true;
-                (_) ->
-                    false
-            end,
-            Snapshots
-        )
+  Node = binary_to_atom(NodeName, utf8),
+  Checker =
+    fun() ->
+      Snapshots = rpc:call(Node, int, snapshot, []),
+      lists:any(
+        fun
+          ({_, _, break, {Module, Line}}) when
+            Module =:= WantModule andalso Line =:= WantLine
+          ->
+            true;
+          (_) ->
+            false
+        end,
+        Snapshots
+      )
     end,
-    els_dap_test_utils:wait_for_fun(Checker, 200, 20).
+  els_dap_test_utils:wait_for_fun(Checker, 200, 20).
 
 %%==============================================================================
 %% Testcases
@@ -148,366 +147,346 @@ wait_for_break(NodeName, WantModule, WantLine) ->
 
 -spec initialize(config()) -> ok.
 initialize(Config) ->
-    Provider = ?config(provider, Config),
-    els_provider:handle_request(Provider, request_initialize(#{})),
-    ok.
+  Provider = ?config(provider, Config),
+  els_provider:handle_request(Provider, request_initialize(#{})),
+  ok.
 
 -spec launch_mfa(config()) -> ok.
 launch_mfa(Config) ->
-    Provider = ?config(provider, Config),
-    DataDir = ?config(data_dir, Config),
-    Node = ?config(node, Config),
-    els_provider:handle_request(Provider, request_initialize(#{})),
-    els_provider:handle_request(
-        Provider,
-        request_launch(DataDir, Node, els_dap_test_module, entry, [])
-    ),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    ok.
+  Provider = ?config(provider, Config),
+  DataDir = ?config(data_dir, Config),
+  Node = ?config(node, Config),
+  els_provider:handle_request(Provider, request_initialize(#{})),
+  els_provider:handle_request(
+    Provider,
+    request_launch(DataDir, Node, els_dap_test_module, entry, [])
+  ),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  ok.
 
 -spec launch_mfa_with_cookie(config()) -> ok.
 launch_mfa_with_cookie(Config) ->
-    Provider = ?config(provider, Config),
-    DataDir = ?config(data_dir, Config),
-    Node = ?config(node, Config),
-    els_provider:handle_request(Provider, request_initialize(#{})),
-    els_provider:handle_request(
-        Provider,
-        request_launch(DataDir, Node, <<"some_cookie">>, els_dap_test_module, entry, [])
-    ),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    ok.
+  Provider = ?config(provider, Config),
+  DataDir = ?config(data_dir, Config),
+  Node = ?config(node, Config),
+  els_provider:handle_request(Provider, request_initialize(#{})),
+  els_provider:handle_request(
+    Provider,
+    request_launch(DataDir, Node, <<"some_cookie">>, els_dap_test_module, entry, [])
+  ),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  ok.
 
 -spec configuration_done(config()) -> ok.
 configuration_done(Config) ->
-    Provider = ?config(provider, Config),
-    DataDir = ?config(data_dir, Config),
-    Node = ?config(node, Config),
-    els_provider:handle_request(Provider, request_initialize(#{})),
-    els_provider:handle_request(
-        Provider,
-        request_launch(DataDir, Node, els_dap_test_module, entry, [])
-    ),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    els_provider:handle_request(Provider, request_configuration_done(#{})),
-    ok.
+  Provider = ?config(provider, Config),
+  DataDir = ?config(data_dir, Config),
+  Node = ?config(node, Config),
+  els_provider:handle_request(Provider, request_initialize(#{})),
+  els_provider:handle_request(
+    Provider,
+    request_launch(DataDir, Node, els_dap_test_module, entry, [])
+  ),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  els_provider:handle_request(Provider, request_configuration_done(#{})),
+  ok.
 
 -spec configuration_done_with_breakpoint(config()) -> ok.
 configuration_done_with_breakpoint(Config) ->
-    Provider = ?config(provider, Config),
-    DataDir = ?config(data_dir, Config),
-    Node = ?config(node, Config),
-    els_provider:handle_request(Provider, request_initialize(#{})),
-    els_provider:handle_request(
-        Provider,
-        request_launch(DataDir, Node, els_dap_test_module, entry, [5])
-    ),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  Provider = ?config(provider, Config),
+  DataDir = ?config(data_dir, Config),
+  Node = ?config(node, Config),
+  els_provider:handle_request(Provider, request_initialize(#{})),
+  els_provider:handle_request(
+    Provider,
+    request_launch(DataDir, Node, els_dap_test_module, entry, [5])
+  ),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
 
-    els_provider:handle_request(
-        Provider,
-        request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [9, 29])
-    ),
-    els_provider:handle_request(Provider, request_configuration_done(#{})),
-    ?assertEqual(ok, wait_for_break(Node, els_dap_test_module, 9)),
-    ok.
+  els_provider:handle_request(
+    Provider,
+    request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [9, 29])
+  ),
+  els_provider:handle_request(Provider, request_configuration_done(#{})),
+  ?assertEqual(ok, wait_for_break(Node, els_dap_test_module, 9)),
+  ok.
 
 -spec frame_variables(config()) -> ok.
 frame_variables(Config) ->
-    Provider = ?config(provider, Config),
-    %% get thread ID from mocked DAP response
-    #{
-        <<"reason">> := <<"breakpoint">>,
-        <<"threadId">> := ThreadId
-    } = meck:capture(last, els_dap_server, send_event, [<<"stopped">>, '_'], 2),
-    %% get stackframe
-    #{<<"stackFrames">> := [#{<<"id">> := FrameId}]} = els_provider:handle_request(
-        Provider,
-        request_stack_frames(ThreadId)
-    ),
-    %% get scope
-    #{
-        <<"scopes">> := [
-            #{
-                <<"variablesReference">> := VariableRef
-            }
-        ]
-    } = els_provider:handle_request(Provider, request_scope(FrameId)),
-    %% extract variable
-    #{<<"variables">> := [NVar]} = els_provider:handle_request(
-        Provider,
-        request_variable(VariableRef)
-    ),
-    %% at this point there should be only one variable present,
-    ?assertMatch(
-        #{
-            <<"name">> := <<"N">>,
-            <<"value">> := <<"5">>,
-            <<"variablesReference">> := 0
-        },
-        NVar
-    ),
-    ok.
+  Provider = ?config(provider, Config),
+  %% get thread ID from mocked DAP response
+  #{ <<"reason">> := <<"breakpoint">>
+   , <<"threadId">> := ThreadId} =
+    meck:capture(last, els_dap_server, send_event, [<<"stopped">>, '_'], 2),
+  %% get stackframe
+  #{<<"stackFrames">> := [#{<<"id">> := FrameId}]} =
+    els_provider:handle_request( Provider
+                               , request_stack_frames(ThreadId)
+                               ),
+  %% get scope
+  #{<<"scopes">> := [#{<<"variablesReference">> := VariableRef}]} =
+    els_provider:handle_request(Provider, request_scope(FrameId)),
+  %% extract variable
+  #{<<"variables">> := [NVar]} =
+    els_provider:handle_request(Provider, request_variable(VariableRef)),
+  %% at this point there should be only one variable present,
+  ?assertMatch(#{ <<"name">> := <<"N">>
+                , <<"value">> := <<"5">>
+                , <<"variablesReference">> := 0
+                }
+              , NVar),
+  ok.
 
 -spec navigation_and_frames(config()) -> ok.
 navigation_and_frames(Config) ->
-    %% test next, stepIn, continue and check aginst expeted stack frames
-    Provider = ?config(provider, Config),
-    #{<<"threads">> := [#{<<"id">> := ThreadId}]} = els_provider:handle_request(
-        Provider,
-        request_threads()
-    ),
-    %% next
-    %%, reset meck history, to capture next call
-    meck:reset([els_dap_server]),
-    els_provider:handle_request(Provider, request_next(ThreadId)),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    %% check
-    #{<<"stackFrames">> := Frames1} = els_provider:handle_request(
-        Provider,
-        request_stack_frames(ThreadId)
-    ),
-    ?assertMatch([#{<<"line">> := 11, <<"name">> := <<"els_dap_test_module:entry/1">>}], Frames1),
-    %% continue
-    meck:reset([els_dap_server]),
-    els_provider:handle_request(Provider, request_continue(ThreadId)),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    %% check
-    #{<<"stackFrames">> := Frames2} = els_provider:handle_request(
-        Provider,
-        request_stack_frames(ThreadId)
-    ),
-    ?assertMatch(
-        [
-            #{<<"line">> := 9, <<"name">> := <<"els_dap_test_module:entry/1">>},
-            #{<<"line">> := 11, <<"name">> := <<"els_dap_test_module:entry/1">>}
-        ],
-        Frames2
-    ),
-    %% stepIn
-    meck:reset([els_dap_server]),
-    els_provider:handle_request(Provider, request_step_in(ThreadId)),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    %% check
-    #{<<"stackFrames">> := Frames3} = els_provider:handle_request(
-        Provider,
-        request_stack_frames(ThreadId)
-    ),
-    ?assertMatch(
-        [
-            #{
-                <<"line">> := 15,
-                <<"name">> := <<"els_dap_test_module:ds/0">>
-            },
-            #{<<"line">> := 9, <<"name">> := <<"els_dap_test_module:entry/1">>},
-            #{<<"line">> := 11, <<"name">> := <<"els_dap_test_module:entry/1">>}
-        ],
-        Frames3
-    ),
-    ok.
+  %% test next, stepIn, continue and check aginst expeted stack frames
+  Provider = ?config(provider, Config),
+  #{<<"threads">> := [#{<<"id">> := ThreadId}]} =
+    els_provider:handle_request( Provider
+                               , request_threads()
+                               ),
+  %% next
+  %%, reset meck history, to capture next call
+  meck:reset([els_dap_server]),
+  els_provider:handle_request(Provider, request_next(ThreadId)),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  %% check
+  #{<<"stackFrames">> := Frames1} =
+    els_provider:handle_request( Provider
+                               , request_stack_frames(ThreadId)
+                               ),
+  ?assertMatch([#{<<"line">> := 11, <<"name">> := <<"els_dap_test_module:entry/1">>}], Frames1),
+  %% continue
+  meck:reset([els_dap_server]),
+  els_provider:handle_request(Provider, request_continue(ThreadId)),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  %% check
+  #{<<"stackFrames">> := Frames2} =
+    els_provider:handle_request( Provider
+                               , request_stack_frames(ThreadId)
+                               ),
+  ?assertMatch( [ #{<<"line">> := 9, <<"name">> := <<"els_dap_test_module:entry/1">>}
+                , #{<<"line">> := 11, <<"name">> := <<"els_dap_test_module:entry/1">>}
+                ]
+              , Frames2
+              ),
+  %% stepIn
+  meck:reset([els_dap_server]),
+  els_provider:handle_request(Provider, request_step_in(ThreadId)),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  %% check
+  #{<<"stackFrames">> := Frames3} =
+    els_provider:handle_request( Provider
+                               , request_stack_frames(ThreadId)
+                               ),
+  ?assertMatch( [ #{ <<"line">> := 15
+                   , <<"name">> := <<"els_dap_test_module:ds/0">>
+                  },
+                  #{ <<"line">> := 9
+                   , <<"name">> := <<"els_dap_test_module:entry/1">>},
+                  #{ <<"line">> := 11
+                   , <<"name">> := <<"els_dap_test_module:entry/1">>}
+                ]
+              , Frames3
+              ),
+  ok.
 
 -spec set_variable(config()) -> ok.
 set_variable(Config) ->
-    Provider = ?config(provider, Config),
-    #{<<"threads">> := [#{<<"id">> := ThreadId}]} = els_provider:handle_request(
-        Provider,
-        request_threads()
-    ),
-    #{<<"stackFrames">> := [#{<<"id">> := FrameId1}]} = els_provider:handle_request(
-        Provider,
-        request_stack_frames(ThreadId)
-    ),
-    meck:reset([els_dap_server]),
-    Result1 = els_provider:handle_request(
-        Provider,
-        request_evaluate(<<"repl">>, FrameId1, <<"N=1">>)
-    ),
-    ?assertEqual(#{<<"result">> => <<"1">>}, Result1),
+  Provider = ?config(provider, Config),
+  #{<<"threads">> := [#{<<"id">> := ThreadId}]} =
+    els_provider:handle_request( Provider
+                               , request_threads()
+                               ),
+  #{<<"stackFrames">> := [#{<<"id">> := FrameId1}]} =
+    els_provider:handle_request( Provider
+                               , request_stack_frames(ThreadId)
+                               ),
+  meck:reset([els_dap_server]),
+  Result1 =
+    els_provider:handle_request( Provider
+                               , request_evaluate(<<"repl">>, FrameId1, <<"N=1">>)
+                               ),
+  ?assertEqual(#{<<"result">> => <<"1">>}, Result1),
 
-    %% get variable value through hover evaluate
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
-    #{<<"stackFrames">> := [#{<<"id">> := FrameId2}]} = els_provider:handle_request(
-        Provider,
-        request_stack_frames(ThreadId)
-    ),
-    ?assertNotEqual(FrameId1, FrameId2),
-    Result2 = els_provider:handle_request(
-        Provider,
-        request_evaluate(<<"hover">>, FrameId2, <<"N">>)
-    ),
-    ?assertEqual(#{<<"result">> => <<"1">>}, Result2),
-    %% get variable value through scopes
-    #{
-        <<"scopes">> := [
-            #{
-                <<"variablesReference">> := VariableRef
-            }
-        ]
-    } = els_provider:handle_request(Provider, request_scope(FrameId2)),
-    %% extract variable
-    #{<<"variables">> := [NVar]} = els_provider:handle_request(
-        Provider,
-        request_variable(VariableRef)
-    ),
-    %% at this point there should be only one variable present
-    ?assertMatch(
-        #{
-            <<"name">> := <<"N">>,
-            <<"value">> := <<"1">>,
-            <<"variablesReference">> := 0
-        },
-        NVar
-    ),
+  %% get variable value through hover evaluate
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  #{<<"stackFrames">> := [#{<<"id">> := FrameId2}]} =
+    els_provider:handle_request( Provider
+                               , request_stack_frames(ThreadId)
+                               ),
+  ?assertNotEqual(FrameId1, FrameId2),
+  Result2 =
+    els_provider:handle_request( Provider
+                               , request_evaluate(<<"hover">>, FrameId2, <<"N">>)
+                               ),
+  ?assertEqual(#{<<"result">> => <<"1">>}, Result2),
+  %% get variable value through scopes
+  #{ <<"scopes">> := [ #{<<"variablesReference">> := VariableRef} ] } =
+    els_provider:handle_request(Provider, request_scope(FrameId2)),
+  %% extract variable
+  #{<<"variables">> := [NVar]} =
+    els_provider:handle_request( Provider
+                               , request_variable(VariableRef)
+                               ),
+  %% at this point there should be only one variable present
+  ?assertMatch( #{ <<"name">> := <<"N">>
+                 , <<"value">> := <<"1">>
+                 , <<"variablesReference">> := 0
+                 }
+              , NVar
+              ),
     ok.
 
 -spec breakpoints(config()) -> ok.
 breakpoints(Config) ->
-    Provider = ?config(provider, Config),
-    NodeName = ?config(node, Config),
-    Node = binary_to_atom(NodeName, utf8),
-    DataDir = ?config(data_dir, Config),
-    els_provider:handle_request(
-        Provider,
-        request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [9])
-    ),
-    ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
-    els_provider:handle_request(
-        Provider,
-        request_set_function_breakpoints([<<"els_dap_test_module:entry/1">>])
-    ),
-    ?assertMatch(
-        [{{els_dap_test_module, 7}, _}, {{els_dap_test_module, 9}, _}],
-        els_dap_rpc:all_breaks(Node)
-    ),
-    els_provider:handle_request(
-        Provider,
-        request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [])
-    ),
-    ?assertMatch(
-        [{{els_dap_test_module, 7}, _}, {{els_dap_test_module, 9}, _}],
-        els_dap_rpc:all_breaks(Node)
-    ),
-    els_provider:handle_request(
-        Provider,
-        request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [9])
-    ),
-    els_provider:handle_request(
-        Provider,
-        request_set_function_breakpoints([])
-    ),
-    ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
-    ok.
+  Provider = ?config(provider, Config),
+  NodeName = ?config(node, Config),
+  Node = binary_to_atom(NodeName, utf8),
+  DataDir = ?config(data_dir, Config),
+  els_provider:handle_request(
+    Provider,
+    request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [9])
+  ),
+  ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
+  els_provider:handle_request(
+    Provider,
+    request_set_function_breakpoints([<<"els_dap_test_module:entry/1">>])
+  ),
+  ?assertMatch(
+    [{{els_dap_test_module, 7}, _}, {{els_dap_test_module, 9}, _}],
+    els_dap_rpc:all_breaks(Node)
+  ),
+  els_provider:handle_request(
+    Provider,
+    request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [])
+  ),
+  ?assertMatch(
+    [{{els_dap_test_module, 7}, _}, {{els_dap_test_module, 9}, _}],
+    els_dap_rpc:all_breaks(Node)
+  ),
+  els_provider:handle_request(
+    Provider,
+    request_set_breakpoints(path_to_test_module(DataDir, els_dap_test_module), [9])
+  ),
+  els_provider:handle_request(
+    Provider,
+    request_set_function_breakpoints([])
+  ),
+  ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
+  ok.
 
 -spec project_node_exit(config()) -> ok.
 project_node_exit(Config) ->
-    NodeName = ?config(node, Config),
-    Node = binary_to_atom(NodeName, utf8),
-    meck:expect(els_utils, halt, 1, meck:val(ok)),
-    meck:reset(els_dap_server),
-    erlang:monitor_node(Node, true),
-    %% kill node and wait for nodedown message
-    rpc:cast(Node, erlang, halt, []),
-    receive
-        {nodedown, Node} -> ok
-    end,
-    %% wait until els_utils:halt has been called
-    els_dap_test_utils:wait_until_mock_called(els_utils, halt).
-    %% there is a race condition in CI, important is that the process stops
-    % ?assert(meck:called(els_dap_server, send_event, [<<"terminated">>, '_'])),
-    % ?assert(meck:called(els_dap_server, send_event, [<<"exited">>, '_'])).
+  NodeName = ?config(node, Config),
+  Node = binary_to_atom(NodeName, utf8),
+  meck:expect(els_utils, halt, 1, meck:val(ok)),
+  meck:reset(els_dap_server),
+  erlang:monitor_node(Node, true),
+  %% kill node and wait for nodedown message
+  rpc:cast(Node, erlang, halt, []),
+  receive
+    {nodedown, Node} -> ok
+  end,
+  %% wait until els_utils:halt has been called
+  els_dap_test_utils:wait_until_mock_called(els_utils, halt).
+  %% there is a race condition in CI, important is that the process stops
+  % ?assert(meck:called(els_dap_server, send_event, [<<"terminated">>, '_'])),
+  % ?assert(meck:called(els_dap_server, send_event, [<<"exited">>, '_'])).
 
 -spec log_points(config()) -> ok.
 log_points(Config) ->
-    Provider = ?config(provider, Config),
-    DataDir = ?config(data_dir, Config),
-    Node = ?config(node, Config),
-    els_provider:handle_request(Provider, request_initialize(#{})),
-    els_provider:handle_request(
-        Provider,
-        request_launch(DataDir, Node, els_dap_test_module, entry, [5])
-    ),
-    els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
+  Provider = ?config(provider, Config),
+  DataDir = ?config(data_dir, Config),
+  Node = ?config(node, Config),
+  els_provider:handle_request(Provider, request_initialize(#{})),
+  els_provider:handle_request(
+    Provider,
+    request_launch(DataDir, Node, els_dap_test_module, entry, [5])
+  ),
+  els_dap_test_utils:wait_until_mock_called(els_dap_server, send_event),
 
-    els_provider:handle_request(
-        Provider,
-        request_set_breakpoints(
-            path_to_test_module(DataDir, els_dap_test_module),
-            [{9, <<"N">>}, 11]
-        )
-    ),
-    els_provider:handle_request(Provider, request_configuration_done(#{})),
-    ?assertEqual(ok, wait_for_break(Node, els_dap_test_module, 11)),
-    ?assert(meck:called(els_dap_server, send_event, [<<"output">>, '_'])),
-    ok.
+  els_provider:handle_request(
+    Provider,
+    request_set_breakpoints(
+      path_to_test_module(DataDir, els_dap_test_module),
+      [{9, <<"N">>}, 11]
+    )
+  ),
+  els_provider:handle_request(Provider, request_configuration_done(#{})),
+  ?assertEqual(ok, wait_for_break(Node, els_dap_test_module, 11)),
+  ?assert(meck:called(els_dap_server, send_event, [<<"output">>, '_'])),
+  ok.
 
 %%==============================================================================
 %% Requests
 %%==============================================================================
 
 request_initialize(Params) ->
-    {<<"initialize">>, Params}.
+  {<<"initialize">>, Params}.
 
 request_launch(Params) ->
-    {<<"launch">>, Params}.
+  {<<"launch">>, Params}.
 
 request_launch(AppDir, Node, M, F, A) ->
-    request_launch(#{
-        <<"projectnode">> => Node,
-        <<"cwd">> => AppDir,
-        <<"module">> => atom_to_binary(M, utf8),
-        <<"function">> => atom_to_binary(F, utf8),
-        <<"args">> => unicode:characters_to_binary(io_lib:format("~w", [A]))
-    }).
+  request_launch(
+    #{ <<"projectnode">> => Node
+     , <<"cwd">> => AppDir
+     , <<"module">> => atom_to_binary(M, utf8)
+     , <<"function">> => atom_to_binary(F, utf8)
+     , <<"args">> => unicode:characters_to_binary(io_lib:format("~w", [A]))
+     }).
 
 request_launch(AppDir, Node, Cookie, M, F, A) ->
-    {<<"launch">>, Params} = request_launch(AppDir, Node, M, F, A),
-    {<<"launch">>, Params#{<<"cookie">> => Cookie}}.
+  {<<"launch">>, Params} = request_launch(AppDir, Node, M, F, A),
+  {<<"launch">>, Params#{<<"cookie">> => Cookie}}.
 
 request_configuration_done(Params) ->
-    {<<"configurationDone">>, Params}.
+  {<<"configurationDone">>, Params}.
 
 request_set_breakpoints(File, Specs) ->
-    {<<"setBreakpoints">>, #{
-        <<"source">> => #{<<"path">> => File},
-        <<"sourceModified">> => false,
-        <<"breakpoints">> => [
-            case Spec of
-                {Line, Message} -> #{<<"line">> => Line, <<"logMessage">> => Message};
-                Line -> #{<<"line">> => Line}
+  { <<"setBreakpoints">>
+  , #{ <<"source">> => #{<<"path">> => File}
+     , <<"sourceModified">> => false
+     , <<"breakpoints">> =>
+         [  case Spec of
+              {Line, Message} -> #{<<"line">> => Line, <<"logMessage">> => Message};
+              Line -> #{<<"line">> => Line}
             end
-            || Spec <- Specs
-        ]
-    }}.
+         || Spec <- Specs
+         ]
+     }}.
 
 request_set_function_breakpoints(MFAs) ->
-    {<<"setFunctionBreakpoints">>, #{
-        <<"breakpoints">> => [#{<<"name">> => MFA, <<"enabled">> => true} || MFA <- MFAs]
-    }}.
+  {<<"setFunctionBreakpoints">>, #{
+    <<"breakpoints">> => [#{<<"name">> => MFA, <<"enabled">> => true} || MFA <- MFAs]
+  }}.
 
 request_stack_frames(ThreadId) ->
-    {<<"stackTrace">>, #{<<"threadId">> => ThreadId}}.
+  {<<"stackTrace">>, #{<<"threadId">> => ThreadId}}.
 
 request_scope(FrameId) ->
-    {<<"scopes">>, #{<<"frameId">> => FrameId}}.
+  {<<"scopes">>, #{<<"frameId">> => FrameId}}.
 
 request_variable(Ref) ->
-    {<<"variables">>, #{<<"variablesReference">> => Ref}}.
+  {<<"variables">>, #{<<"variablesReference">> => Ref}}.
 
 request_threads() ->
-    {<<"threads">>, #{}}.
+  {<<"threads">>, #{}}.
 
 request_step_in(ThreadId) ->
-    {<<"stepIn">>, #{<<"threadId">> => ThreadId}}.
+  {<<"stepIn">>, #{<<"threadId">> => ThreadId}}.
 
 request_next(ThreadId) ->
-    {<<"next">>, #{<<"threadId">> => ThreadId}}.
+  {<<"next">>, #{<<"threadId">> => ThreadId}}.
 
 request_continue(ThreadId) ->
-    {<<"continue">>, #{<<"threadId">> => ThreadId}}.
+  {<<"continue">>, #{<<"threadId">> => ThreadId}}.
 
 request_evaluate(Context, FrameId, Expression) ->
-    {<<"evaluate">>, #{
-        <<"context">> => Context,
-        <<"frameId">> => FrameId,
-        <<"expression">> => Expression
-    }}.
+  {<<"evaluate">>,
+    #{ <<"context">> => Context
+     , <<"frameId">> => FrameId
+     , <<"expression">> => Expression
+     }
+  }.


### PR DESCRIPTION
This implements debugger based logpoints and fixes the watchlist.

Logpoints don't stop but instead print a message on the console. In practice this is an additional field for the breakpoint.
This implementation
- breaks on the breakpoint
- evaluates the expression
- creates an output event for the console
- continues

Evaluation triggers the callback from the attached project and that was exactly what was messing with the watch list as well. (and this is fixed as a side-effect)