### PR TITLE
Use els_utils:lookup_document for lookup

### DIFF
--- a/apps/els_core/src/els_utils.erl
+++ b/apps/els_core/src/els_utils.erl
@@ -132,8 +132,13 @@ lookup_document(Uri) ->
     {ok, []} ->
       Path = els_uri:path(Uri),
       {ok, Uri} = els_indexing:index_file(Path),
-      {ok, [Document]} = els_dt_document:lookup(Uri),
-      {ok, Document}
+      case els_dt_document:lookup(Uri) of
+        {ok, [Document]} ->
+          {ok, Document};
+        Error ->
+          ?LOG_INFO("Document lookup failed [error=~p] [uri=~p]", [Error, Uri]),
+          {error, Error}
+      end
   end.
 
 -spec macro_string_to_term(list()) -> any().

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -117,12 +117,8 @@ find([Uri|Uris0], Kind, Data, AlreadyVisited) ->
       find(Uris0, Kind, Data, AlreadyVisited);
     false ->
       AlreadyVisited2 = sets:add_element(Uri, AlreadyVisited),
-      case els_dt_document:lookup(Uri) of
-        {ok, [Document]} ->
-          find_in_document([Uri|Uris0], Document, Kind, Data, AlreadyVisited2);
-        {ok, []} ->
-          find(Uris0, Kind, Data, AlreadyVisited2)
-      end
+      {ok, Document} = els_utils:lookup_document(Uri),
+      find_in_document([Uri|Uris0], Document, Kind, Data, AlreadyVisited2)
   end;
 find(Uri, Kind, Data, AlreadyVisited) ->
   find([Uri], Kind, Data, AlreadyVisited).

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -117,8 +117,12 @@ find([Uri|Uris0], Kind, Data, AlreadyVisited) ->
       find(Uris0, Kind, Data, AlreadyVisited);
     false ->
       AlreadyVisited2 = sets:add_element(Uri, AlreadyVisited),
-      {ok, Document} = els_utils:lookup_document(Uri),
-      find_in_document([Uri|Uris0], Document, Kind, Data, AlreadyVisited2)
+      case els_utils:lookup_document(Uri) of
+        {ok, Document} ->
+          find_in_document([Uri|Uris0], Document, Kind, Data, AlreadyVisited2);
+        {error, _Error} ->
+          find(Uris0, Kind, Data, AlreadyVisited2)
+      end
   end;
 find(Uri, Kind, Data, AlreadyVisited) ->
   find([Uri], Kind, Data, AlreadyVisited).

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -142,21 +142,16 @@ parse_escript(Uri) ->
         [els_diagnostics:diagnostic()].
 diagnostics(Path, List, Severity) ->
   Uri = els_uri:uri(els_utils:to_binary(Path)),
-  case els_dt_document:lookup(Uri) of
-    {ok, [Document]} ->
-      lists:flatten([[ diagnostic( Path
-                                 , MessagePath
-                                 , range(Anno)
-                                 , Document
-                                 , Module
-                                 , Desc
-                                 , Severity)
-                       || {Anno, Module, Desc} <- Info]
-                     || {MessagePath, Info} <- List]);
-    Error ->
-      ?LOG_INFO("diagnostics doc lookup failed [Error=~p]", [Error]),
-      []
-  end.
+  {ok, Document} = els_utils:lookup_document(Uri),
+  lists:flatten([[ diagnostic( Path
+                             , MessagePath
+                             , range(Anno)
+                             , Document
+                             , Module
+                             , Desc
+                             , Severity)
+                   || {Anno, Module, Desc} <- Info]
+                 || {MessagePath, Info} <- List]).
 
 -spec diagnostic( string()
                 , string()

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -142,16 +142,20 @@ parse_escript(Uri) ->
         [els_diagnostics:diagnostic()].
 diagnostics(Path, List, Severity) ->
   Uri = els_uri:uri(els_utils:to_binary(Path)),
-  {ok, Document} = els_utils:lookup_document(Uri),
-  lists:flatten([[ diagnostic( Path
-                             , MessagePath
-                             , range(Anno)
-                             , Document
-                             , Module
-                             , Desc
-                             , Severity)
-                   || {Anno, Module, Desc} <- Info]
-                 || {MessagePath, Info} <- List]).
+  case els_utils:lookup_document(Uri) of
+    {ok, Document} ->
+      lists:flatten([[ diagnostic( Path
+                                 , MessagePath
+                                 , range(Anno)
+                                 , Document
+                                 , Module
+                                 , Desc
+                                 , Severity)
+                       || {Anno, Module, Desc} <- Info]
+                     || {MessagePath, Info} <- List]);
+    {error, _Error} ->
+      []
+  end.
 
 -spec diagnostic( string()
                 , string()

--- a/apps/els_lsp/src/els_crossref_diagnostics.erl
+++ b/apps/els_lsp/src/els_crossref_diagnostics.erl
@@ -33,13 +33,17 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  {ok, Document} = els_utils:lookup_document(Uri),
-  POIs = els_dt_document:pois(Document, [ application
-                                        , implicit_fun
-                                        , import_entry
-                                        , export_entry
-                                        ]),
-  [make_diagnostic(POI) || POI <- POIs, not has_definition(POI, Document)].
+  case els_utils:lookup_document(Uri) of
+    {error, _Error} ->
+      [];
+    {ok, Document} ->
+      POIs = els_dt_document:pois(Document, [ application
+                                            , implicit_fun
+                                            , import_entry
+                                            , export_entry
+                                            ]),
+      [make_diagnostic(POI) || POI <- POIs, not has_definition(POI, Document)]
+  end.
 
 -spec source() -> binary().
 source() ->

--- a/apps/els_lsp/src/els_crossref_diagnostics.erl
+++ b/apps/els_lsp/src/els_crossref_diagnostics.erl
@@ -33,17 +33,13 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  case els_dt_document:lookup(Uri) of
-    {ok, []} ->
-      [];
-    {ok, [Document|_]} ->
-      POIs = els_dt_document:pois(Document, [ application
-                                            , implicit_fun
-                                            , import_entry
-                                            , export_entry
-                                            ]),
-      [make_diagnostic(POI) || POI <- POIs, not has_definition(POI, Document)]
-  end.
+  {ok, Document} = els_utils:lookup_document(Uri),
+  POIs = els_dt_document:pois(Document, [ application
+                                        , implicit_fun
+                                        , import_entry
+                                        , export_entry
+                                        ]),
+  [make_diagnostic(POI) || POI <- POIs, not has_definition(POI, Document)].
 
 -spec source() -> binary().
 source() ->

--- a/apps/els_lsp/src/els_folding_range_provider.erl
+++ b/apps/els_lsp/src/els_folding_range_provider.erl
@@ -26,7 +26,7 @@ is_enabled() ->
 -spec handle_request(tuple(), state()) -> {folding_range_result(), state()}.
 handle_request({document_foldingrange, Params}, State) ->
   #{ <<"textDocument">> := #{<<"uri">> := Uri} } = Params,
-  {ok, [Document]} = els_dt_document:lookup(Uri),
+  {ok, Document} = els_utils:lookup_document(Uri),
   POIs = els_dt_document:pois(Document, [folding_range]),
   Response = case [folding_range(Range) || #{range := Range} <- POIs] of
                []     -> null;

--- a/apps/els_lsp/src/els_unused_includes_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_includes_diagnostics.erl
@@ -32,19 +32,15 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  case els_dt_document:lookup(Uri) of
-    {ok, []} ->
-      [];
-    {ok, [Document|_]} ->
-      Includes = els_dt_document:pois(Document, [include, include_lib]),
-      UnusedIncludes = find_unused_includes(Document, Includes),
-      [ els_diagnostics:make_diagnostic(
-          els_protocol:range(inclusion_range(UI, Document))
-         , <<"Unused file: ", (filename:basename(UI))/binary>>
-            , ?DIAGNOSTIC_WARNING
-         , source()
-         ) || UI <- UnusedIncludes ]
-  end.
+  {ok, Document} = els_utils:lookup_document(Uri),
+  Includes = els_dt_document:pois(Document, [include, include_lib]),
+  UnusedIncludes = find_unused_includes(Document, Includes),
+  [ els_diagnostics:make_diagnostic(
+      els_protocol:range(inclusion_range(UI, Document))
+     , <<"Unused file: ", (filename:basename(UI))/binary>>
+        , ?DIAGNOSTIC_WARNING
+     , source()
+     ) || UI <- UnusedIncludes ].
 
 -spec source() -> binary().
 source() ->
@@ -87,26 +83,21 @@ expand_includes(Uri) ->
 expand_includes([], Graph, _Visited) ->
   Graph;
 expand_includes([Uri|Uris], Graph, Visited) ->
-  case els_dt_document:lookup(Uri) of
-    {ok, [Document]} ->
-      IncludedUris = els_diagnostics_utils:included_uris(Document),
-      NonVisitedIncludedUris = [U || U <- IncludedUris
-                                       , not sets:is_element(U, Visited)],
-      Dest = digraph:add_vertex(Graph, Uri),
-      NewGraph = lists:foldl(fun(U, G) ->
-                                 Src = digraph:add_vertex(G, U),
-                                 digraph:add_edge(G, Src, Dest),
-                                 G
-                             end
-                            , Graph
-                            , IncludedUris),
-      expand_includes( Uris ++ NonVisitedIncludedUris
-                     , NewGraph
-                     , sets:add_element(Uri, Visited));
-    {ok, []} ->
-      ?LOG_WARNING("Failed lookup while expanding includes [uri=~p]", [Uri]),
-      []
-  end.
+  {ok, Document} = els_utils:lookup_document(Uri),
+  IncludedUris = els_diagnostics_utils:included_uris(Document),
+  NonVisitedIncludedUris = [U || U <- IncludedUris
+                                   , not sets:is_element(U, Visited)],
+  Dest = digraph:add_vertex(Graph, Uri),
+  NewGraph = lists:foldl(fun(U, G) ->
+                             Src = digraph:add_vertex(G, U),
+                             digraph:add_edge(G, Src, Dest),
+                             G
+                         end
+                        , Graph
+                        , IncludedUris),
+  expand_includes( Uris ++ NonVisitedIncludedUris
+                 , NewGraph
+                 , sets:add_element(Uri, Visited)).
 
 -spec inclusion_range(uri(), els_dt_document:item()) -> poi_range().
 inclusion_range(Uri, Document) ->

--- a/apps/els_lsp/src/els_unused_includes_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_includes_diagnostics.erl
@@ -32,15 +32,19 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  {ok, Document} = els_utils:lookup_document(Uri),
-  Includes = els_dt_document:pois(Document, [include, include_lib]),
-  UnusedIncludes = find_unused_includes(Document, Includes),
-  [ els_diagnostics:make_diagnostic(
-      els_protocol:range(inclusion_range(UI, Document))
-     , <<"Unused file: ", (filename:basename(UI))/binary>>
-        , ?DIAGNOSTIC_WARNING
-     , source()
-     ) || UI <- UnusedIncludes ].
+  case els_utils:lookup_document(Uri) of
+    {error, _Error} ->
+      [];
+    {ok, Document} ->
+      Includes = els_dt_document:pois(Document, [include, include_lib]),
+      UnusedIncludes = find_unused_includes(Document, Includes),
+      [ els_diagnostics:make_diagnostic(
+          els_protocol:range(inclusion_range(UI, Document))
+         , <<"Unused file: ", (filename:basename(UI))/binary>>
+            , ?DIAGNOSTIC_WARNING
+         , source()
+         ) || UI <- UnusedIncludes ]
+  end.
 
 -spec source() -> binary().
 source() ->
@@ -83,21 +87,26 @@ expand_includes(Uri) ->
 expand_includes([], Graph, _Visited) ->
   Graph;
 expand_includes([Uri|Uris], Graph, Visited) ->
-  {ok, Document} = els_utils:lookup_document(Uri),
-  IncludedUris = els_diagnostics_utils:included_uris(Document),
-  NonVisitedIncludedUris = [U || U <- IncludedUris
-                                   , not sets:is_element(U, Visited)],
-  Dest = digraph:add_vertex(Graph, Uri),
-  NewGraph = lists:foldl(fun(U, G) ->
-                             Src = digraph:add_vertex(G, U),
-                             digraph:add_edge(G, Src, Dest),
-                             G
-                         end
-                        , Graph
-                        , IncludedUris),
-  expand_includes( Uris ++ NonVisitedIncludedUris
-                 , NewGraph
-                 , sets:add_element(Uri, Visited)).
+  case els_utils:lookup_document(Uri) of
+    {ok, Document} ->
+      IncludedUris = els_diagnostics_utils:included_uris(Document),
+      NonVisitedIncludedUris = [U || U <- IncludedUris
+                                       , not sets:is_element(U, Visited)],
+      Dest = digraph:add_vertex(Graph, Uri),
+      NewGraph = lists:foldl(fun(U, G) ->
+                                 Src = digraph:add_vertex(G, U),
+                                 digraph:add_edge(G, Src, Dest),
+                                 G
+                             end
+                            , Graph
+                            , IncludedUris),
+      expand_includes( Uris ++ NonVisitedIncludedUris
+                     , NewGraph
+                     , sets:add_element(Uri, Visited));
+    {error, _Error} ->
+      ?LOG_WARNING("Failed lookup while expanding includes [uri=~p]", [Uri]),
+      []
+  end.
 
 -spec inclusion_range(uri(), els_dt_document:item()) -> poi_range().
 inclusion_range(Uri, Document) ->

--- a/apps/els_lsp/src/els_unused_macros_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_macros_diagnostics.erl
@@ -33,13 +33,9 @@ is_default() ->
 run(Uri) ->
   case filename:extension(Uri) of
     <<".erl">> ->
-      case els_dt_document:lookup(Uri) of
-        {ok, []} ->
-          [];
-        {ok, [Document|_]} ->
-          UnusedMacros = find_unused_macros(Document),
-          [make_diagnostic(POI) || POI <- UnusedMacros ]
-      end;
+      {ok, Document} = els_utils:lookup_document(Uri),
+      UnusedMacros = find_unused_macros(Document),
+      [make_diagnostic(POI) || POI <- UnusedMacros ];
     _ ->
       []
   end.

--- a/apps/els_lsp/src/els_unused_macros_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_macros_diagnostics.erl
@@ -33,9 +33,13 @@ is_default() ->
 run(Uri) ->
   case filename:extension(Uri) of
     <<".erl">> ->
-      {ok, Document} = els_utils:lookup_document(Uri),
-      UnusedMacros = find_unused_macros(Document),
-      [make_diagnostic(POI) || POI <- UnusedMacros ];
+      case els_utils:lookup_document(Uri) of
+        {error, _Error} ->
+          [];
+        {ok, Document} ->
+          UnusedMacros = find_unused_macros(Document),
+          [make_diagnostic(POI) || POI <- UnusedMacros ]
+      end;
     _ ->
       []
   end.


### PR DESCRIPTION
### Description

Use els_utils:lookup_document for document lookups to make sure that files that were not yet indexed are indexed on request. Related to https://github.com/erlang-ls/erlang_ls/pull/881

Fixes #928
