### PR TITLE
Let dt_document be a compressed ETS table

### DIFF
--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -72,7 +72,7 @@ name() -> ?MODULE.
 
 -spec opts() -> proplists:proplist().
 opts() ->
-  [set].
+  [set, compressed].
 
 %%==============================================================================
 %% API


### PR DESCRIPTION
This table stores .erl/.hrl module's plaintext contents; it compresses very well

I haven't noticed any performance impact. If we don't do "fullscan" types of queries over this table (so, only key-value lookups), it should be very efficient.

### Description

Before:

![image](https://user-images.githubusercontent.com/422014/110222178-ad41cc80-7ed0-11eb-8474-bb23baa29faa.png)


```erlang
> memory().                                      
[{total,251125176},
 {processes,30997488},
 {processes_used,30995808},
 {system,220127688},
 {atom,2359705},
 {atom_used,2344780},
 {binary,27809064},
 {code,11710823},
 {ets,166721104}]

> [{K, V / 1024.0 / 1024} || {K, V} <- memory()].
[{total,239.54800415039063},
 {processes,29.617919921875},
 {processes_used,29.61713409423828},
 {system,209.93008422851563},
 {atom,2.25039005279541},
 {atom_used,2.236156463623047},
 {binary,26.52086639404297},
 {code,11.16831111907959},
 {ets,158.9976348876953}]  % <----------------- 159 MB

```

After:

```erlang
> memory().                                
[{total,113739616},
 {processes,4921984},
 {processes_used,4920912},
 {system,108817632},
 {atom,2359705},
 {atom_used,2352683},
 {binary,24653720},
 {code,12616675},
 {ets,57525064}]
> [{K, V / 1024.0 / 1024} || {K, V} <- memory()].
[{total,108.48602294921875},
 {processes,4.708183288574219},
 {processes_used,4.708099365234375},
 {system,103.77783966064453},
 {atom,2.25039005279541},
 {atom_used,2.2436933517456055},
 {binary,23.512924194335938},
 {code,12.032198905944824},
 {ets,54.86017608642578}]   % <------  55 MB
```