### PR TITLE
[#941] Enable diagnostics by default

### DIFF
--- a/apps/els_lsp/src/els_bound_var_in_pattern_diagnostics.erl
+++ b/apps/els_lsp/src/els_bound_var_in_pattern_diagnostics.erl
@@ -29,7 +29,7 @@
 
 -spec is_default() -> boolean().
 is_default() ->
-  false.
+  true.
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->

--- a/apps/els_lsp/src/els_unused_includes_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_includes_diagnostics.erl
@@ -28,7 +28,7 @@
 
 -spec is_default() -> boolean().
 is_default() ->
-  false.
+  true.
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->

--- a/apps/els_lsp/src/els_unused_macros_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_macros_diagnostics.erl
@@ -27,7 +27,7 @@
 
 -spec is_default() -> boolean().
 is_default() ->
-  false.
+  true.
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->

--- a/apps/els_lsp/test/els_initialization_SUITE.erl
+++ b/apps/els_lsp/test/els_initialization_SUITE.erl
@@ -128,7 +128,13 @@ initialize_diagnostics_custom(Config) ->
   ConfigPath = filename:join(DataDir, "diagnostics_custom.config"),
   InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
   els_client:initialize(RootUri, InitOpts),
-  Expected = [<<"compiler">>, <<"crossref">>, <<"dialyzer">>],
+  Expected = [ <<"bound_var_in_pattern">>
+             , <<"compiler">>
+             , <<"crossref">>
+             , <<"dialyzer">>
+             , <<"unused_includes">>
+             , <<"unused_macros">>
+             ],
   Result = els_diagnostics:enabled_diagnostics(),
   ?assertEqual(Expected, Result),
   ok.
@@ -141,10 +147,13 @@ initialize_diagnostics_invalid(Config) ->
   InitOpts = #{ <<"erlang">> => #{ <<"config_path">> => ConfigPath }},
   els_client:initialize(RootUri, InitOpts),
   Result = els_diagnostics:enabled_diagnostics(),
-  Expected = [ <<"compiler">>
+  Expected = [ <<"bound_var_in_pattern">>
+             , <<"compiler">>
              , <<"crossref">>
              , <<"dialyzer">>
              , <<"elvis">>
+             , <<"unused_includes">>
+             , <<"unused_macros">>
              ],
   ?assertEqual(Expected, Result),
   ok.


### PR DESCRIPTION
This commit enables a few diagnostics which have been considered
experimental for a while, but they proved to be quite stable:

* bound_var_in_pattern
* unused_includes
* unused_macros

Fixes #941 .
