### PR TITLE
[#921] Fix wrong config file in PropEr tests

### DIFF
--- a/apps/els_lsp/test/prop_statem.erl
+++ b/apps/els_lsp/test/prop_statem.erl
@@ -353,7 +353,7 @@ setup() ->
   HaltFun = fun(_X) -> Self ! halt_called, ok end,
   meck:expect(els_utils, halt, HaltFun),
   application:ensure_all_started(els_lsp),
-  file:write_file("/tmp/els_lsp.config", <<"">>),
+  file:write_file("/tmp/erlang_ls.config", <<"">>),
   ok.
 
 %%==============================================================================


### PR DESCRIPTION
In b0ca70f the config file that is used in the PropEr tests was renamed, causing the warning logs described in the issue. This commit renames the file back to `erlang_ls.config`.

Partially fixes #921 (as I locally now get crash reports from Erlang LS, but the property still holds).