### PR TITLE
[#899] Self-describing specs.

### DIFF
--- a/apps/els_lsp/src/els_code_lens_ct_run_test.erl
+++ b/apps/els_lsp/src/els_code_lens_ct_run_test.erl
@@ -5,29 +5,28 @@
 -module(els_code_lens_ct_run_test).
 
 -behaviour(els_code_lens).
--export([ command/1
-        , command_args/2
+-export([ command/3
         , is_default/0
         , pois/1
         , precondition/1
-        , title/1
         ]).
 
 -include("els_lsp.hrl").
 
--spec command(poi()) -> els_command:command_id().
-command(_POI) ->
-  <<"ct-run-test">>.
-
--spec command_args(els_dt_document:item(), poi()) -> [any()].
-command_args( #{uri := Uri} = _Document
-            , #{id := {F, A}, range := #{from := {Line, _}}} = _POI) ->
-  [#{ module => els_uri:module(Uri)
-    , function => F
-    , arity => A
-    , uri => Uri
-    , line => Line
-    }].
+-spec command(els_dt_document:item(), poi(), els_code_lens:state()) ->
+        els_command:command().
+command(#{uri := Uri} = _Document, POI, _State) ->
+  #{id := {F, A}, range := #{from := {Line, _}}} = POI,
+  Title = <<"Run test">>,
+  CommandId = <<"ct-run-test">>,
+  CommandArgs =   [ #{ module => els_uri:module(Uri)
+                     , function => F
+                     , arity => A
+                     , uri => Uri
+                     , line => Line
+                     }
+                  ],
+  els_command:make_command(Title, CommandId, CommandArgs).
 
 -spec is_default() -> boolean().
 is_default() ->
@@ -48,14 +47,9 @@ precondition(Document) ->
       true
   end.
 
--spec title(poi()) -> binary().
-title(_POI) ->
-  <<"Run test">>.
-
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
-
 -spec is_blacklisted(atom()) -> boolean().
 is_blacklisted(Function) ->
   lists:member(Function, [init_per_suite, end_per_suite, group]).

--- a/apps/els_lsp/src/els_code_lens_server_info.erl
+++ b/apps/els_lsp/src/els_code_lens_server_info.erl
@@ -5,23 +5,21 @@
 -module(els_code_lens_server_info).
 
 -behaviour(els_code_lens).
--export([ command/1
-        , command_args/2
+-export([ command/3
         , is_default/0
         , pois/1
         , precondition/1
-        , title/1
         ]).
 
 -include("els_lsp.hrl").
 
--spec command(poi()) -> els_command:command_id().
-command(_POI) ->
-  <<"server-info">>.
-
--spec command_args(els_dt_document:item(), poi()) -> [any()].
-command_args(_Document, _POI) ->
-  [].
+-spec command(els_dt_document:item(), poi(), els_code_lens:state()) ->
+        els_command:command().
+command(_Document, _POI, _State) ->
+  Title = title(),
+  CommandId = <<"server-info">>,
+  CommandArgs = [],
+  els_command:make_command(Title, CommandId, CommandArgs).
 
 -spec is_default() -> boolean().
 is_default() ->
@@ -36,7 +34,7 @@ pois(_Document) ->
   %% Return a dummy POI on the first line
   [els_poi:new(#{from => {1, 1}, to => {2, 1}}, dummy, dummy)].
 
--spec title(poi()) -> binary().
-title(_POI) ->
+-spec title() -> binary().
+title() ->
   Root = filename:basename(els_uri:path(els_config:get(root_uri))),
   <<"Erlang LS (in ", Root/binary, ") info">>.

--- a/apps/els_lsp/src/els_code_lens_show_behaviour_usages.erl
+++ b/apps/els_lsp/src/els_code_lens_show_behaviour_usages.erl
@@ -5,23 +5,21 @@
 -module(els_code_lens_show_behaviour_usages).
 
 -behaviour(els_code_lens).
--export([ command/1
-        , command_args/2
+-export([ command/3
         , is_default/0
         , pois/1
         , precondition/1
-        , title/1
         ]).
 
 -include("els_lsp.hrl").
 
--spec command(poi()) -> els_command:command_id().
-command(_POI) ->
-  <<"show-behaviour-usages">>.
-
--spec command_args(els_dt_document:item(), poi()) -> [any()].
-command_args(_Document, _POI) ->
-  [].
+-spec command(els_dt_document:item(), poi(), els_code_lens:state()) ->
+        els_command:command().
+command(_Document, POI, _State) ->
+  Title = title(POI),
+  CommandId = <<"show-behaviour-usages">>,
+  CommandArgs = [],
+  els_command:make_command(Title, CommandId, CommandArgs).
 
 -spec is_default() -> boolean().
 is_default() ->
@@ -39,7 +37,7 @@ pois(Document) ->
   els_dt_document:pois(Document, [module]).
 
 -spec title(poi()) -> binary().
-title(#{ id := Id }) ->
+title(#{id := Id} = _POI) ->
   {ok, Refs} = els_dt_references:find_by_id(behaviour, Id),
   Count = length(Refs),
   Msg = io_lib:format("Behaviour used in ~p place(s)", [Count]),

--- a/apps/els_lsp/src/els_providers_sup.erl
+++ b/apps/els_lsp/src/els_providers_sup.erl
@@ -45,8 +45,8 @@ start_link() ->
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
   SupFlags = #{ strategy  => one_for_one
-              , intensity => 1
-              , period    => 5
+              , intensity => 5
+              , period    => 60
               },
   ChildSpecs = [provider_specs(P) || P <- els_provider:enabled_providers()],
   {ok, {SupFlags, ChildSpecs}}.

--- a/apps/els_lsp/test/els_execute_command_SUITE.erl
+++ b/apps/els_lsp/test/els_execute_command_SUITE.erl
@@ -142,10 +142,9 @@ suggest_spec(Config) ->
     = els_client:workspace_executecommand(
         PrefixedCommand
        , [#{ uri => Uri
-           , module => execute_command_suggest_spec
-           , function => without_spec
-           , arity => 2
            , line => 12
+           , spec => <<"-spec without_spec(number(),binary()) -> "
+                       "{number(),binary()}.">>
            }]),
   Expected = [],
   ?assertEqual(Expected, Result),


### PR DESCRIPTION
Instead of showing an "Add spec" button for missing spec, preview the
actual calculated spec by TypEr. Also:

* Simplify the `els_code_lens` behaviour
* Add an optional `init` function for the lenses
* Relax supervision strategy

### Description

Enter a description of your changes here.

Fixes #899 .
