### PR TITLE
[#950] Be able to cancel codeLens requests

### DIFF
--- a/apps/els_lsp/src/els_code_lens_provider.erl
+++ b/apps/els_lsp/src/els_code_lens_provider.erl
@@ -1,15 +1,22 @@
 -module(els_code_lens_provider).
 
 -behaviour(els_provider).
-
--export([ handle_request/2
+-export([ handle_info/2
+        , handle_request/2
+        , init/0
         , is_enabled/0
         , options/0
+        , cancel_request/2
         ]).
 
 -include("els_lsp.hrl").
+-include_lib("kernel/include/logger.hrl").
 
--type state() :: any().
+-type state() :: #{in_progress => [progress_entry()]}.
+-type progress_entry() :: {uri(), job()}.
+-type job() :: pid().
+
+-define(SERVER, ?MODULE).
 
 %%==============================================================================
 %% els_provider functions
@@ -22,18 +29,51 @@ is_enabled() -> true.
 options() ->
   #{ resolveProvider => false }.
 
--spec handle_request(any(), state()) -> {any(), state()}.
+-spec init() -> state().
+init() ->
+  #{ in_progress => [] }.
+
+-spec handle_request(any(), state()) -> {job(), state()}.
 handle_request({document_codelens, Params}, State) ->
+  #{in_progress := InProgress} = State,
   #{ <<"textDocument">> := #{ <<"uri">> := Uri}} = Params,
-  Lenses = lenses(Uri),
-  {Lenses, State}.
+  ?LOG_DEBUG("Starting lenses job [uri=~p]", [Uri]),
+  Job = run_lenses_job(Uri),
+  {Job, State#{in_progress => [{Uri, Job}|InProgress]}}.
+
+-spec handle_info(any(), state()) -> state().
+handle_info({result, Lenses, Job}, State) ->
+  ?LOG_DEBUG("Received lenses result [job=~p]", [Job]),
+  #{ in_progress := InProgress } = State,
+  els_server:send_response(Job, Lenses),
+  State#{ in_progress => lists:keydelete(Job, 2, InProgress) }.
+
+-spec cancel_request(job(), state()) -> state().
+cancel_request(Job, State) ->
+  ?LOG_DEBUG("Cancelling lenses [job=~p]", [Job]),
+  els_background_job:stop(Job),
+  #{ in_progress := InProgress } = State,
+  State#{ in_progress => lists:keydelete(Job, 2, InProgress) }.
 
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec lenses(uri()) -> [els_code_lens:lens()].
-lenses(Uri) ->
+-spec run_lenses_job(uri()) -> pid().
+run_lenses_job(Uri) ->
   {ok, Document} = els_utils:lookup_document(Uri),
-  lists:flatten(
-    [els_code_lens:lenses(Id, Document) ||
-      Id <- els_code_lens:enabled_lenses()]).
+  Config = #{ task =>
+                fun(Doc, _) ->
+                    lists:flatten(
+                      [els_code_lens:lenses(Id, Doc) ||
+                        Id <- els_code_lens:enabled_lenses()])
+                end
+            , entries => [Document]
+            , title => <<"Lenses">>
+            , on_complete =>
+                fun(Lenses) ->
+                    ?SERVER ! {result, Lenses, self()},
+                    ok
+                end
+            },
+  {ok, Pid} = els_background_job:new(Config),
+  Pid.

--- a/apps/els_lsp/src/els_methods.erl
+++ b/apps/els_lsp/src/els_methods.erl
@@ -44,6 +44,7 @@
 -type result()       :: {response, params() | null, state()}
                       | {error, params(), state()}
                       | {noresponse, state()}
+                      | {noresponse, {els_provider:provider(), pid()}, state()}
                       | {notification, binary(), params(), state()}.
 -type request_type() :: notification | request.
 
@@ -373,8 +374,8 @@ textdocument_codeaction(Params, State) ->
 -spec textdocument_codelens(params(), state()) -> result().
 textdocument_codelens(Params, State) ->
   Provider = els_code_lens_provider,
-  Response = els_provider:handle_request(Provider, {document_codelens, Params}),
-  {response, Response, State}.
+  Job = els_provider:handle_request(Provider, {document_codelens, Params}),
+  {noresponse, {Provider, Job}, State}.
 
 %%==============================================================================
 %% textDocument/rename

--- a/apps/els_lsp/test/els_server_SUITE.erl
+++ b/apps/els_lsp/test/els_server_SUITE.erl
@@ -1,0 +1,113 @@
+-module(els_server_SUITE).
+
+%% CT Callbacks
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , groups/0
+        , all/0
+        ]).
+
+%% Test cases
+-export([ cancel_request/1
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+  [{timetrap, {seconds, 30}}].
+
+-spec all() -> [{group, atom()}].
+all() ->
+  [{group, tcp}, {group, stdio}].
+
+-spec groups() -> [atom()].
+groups() ->
+  els_test_utils:groups(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(cancel_request = TestCase, Config0) ->
+  Config = els_test_utils:init_per_testcase(TestCase, Config0),
+  %% Ensure the background job triggered by the code lens will never return
+  meck:new(els_background_job, [no_link, passthrough]),
+  meck:expect(els_background_job, new,
+              fun(C0) ->
+                  C = C0#{ task => fun(_, _) ->
+                                       timer:sleep(infinity)
+                                   end},
+                  meck:passthrough([C])
+              end),
+  [ {mocks, [els_background_job]} | Config].
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) ->
+  Mocks = ?config(mocks, Config),
+  [meck:unload(Mock) || Mock <- Mocks],
+  els_test_utils:end_per_testcase(TestCase, Config).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec cancel_request(config()) -> ok.
+cancel_request(Config) ->
+  %% Trigger a document/CodeLens request in the background
+  Uri = ?config(code_navigation_uri, Config),
+  spawn(fun() -> els_client:document_codelens(Uri) end),
+  %% Extract the current background job (from the lens provider)
+  Job = wait_until_one_lens_job(),
+  %% Verify the background job is triggered
+  ?assert(lists:member(Job, els_background_job:list())),
+  %% Cancel the original request
+  Result = els_client:'$_cancelrequest'(),
+  %% Ensure the previous request is canceled
+  wait_until_no_lens_jobs(),
+  ?assertEqual(ok, Result).
+
+wait_until_one_lens_job() ->
+  Jobs = get_current_lens_jobs(),
+  case Jobs of
+    [Job] ->
+      Job;
+    [] ->
+      timer:sleep(100),
+      wait_until_one_lens_job()
+  end.
+
+-spec wait_until_no_lens_jobs() -> ok.
+wait_until_no_lens_jobs() ->
+  case get_current_lens_jobs() of
+    [] ->
+      ok;
+    _ ->
+      timer:sleep(100),
+      wait_until_no_lens_jobs()
+  end.
+
+-spec get_current_lens_jobs() -> [pid()].
+get_current_lens_jobs() ->
+  #{internal_state := InternalState} = sys:get_state(els_code_lens_provider),
+  #{in_progress := InProgress} = InternalState,
+  [Job || {_Uri, Job} <- InProgress].


### PR DESCRIPTION
### Description

* Add a `$_cancelRequest/0` to the `els_client` to cancel the last issued request
* Handle cancellation requests, instead of ignoring them
* Add optional `cancel_request/2` callback for providers
* Execute `codeLens` requests in a separate process via `els_background_job`
* Implement cancellation for `codeLens` requests
* Add a minimal test

While implementing this, I noticed a bunch of possible refactoring and simplifications when it comes to `els_server`, `els_methods` and `els_provider`, but those will be tackled separately.

Fixes #950, #952.
