### PR TITLE
Add support for renaming variables

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/rename_variable.erl
+++ b/apps/els_lsp/priv/code_navigation/src/rename_variable.erl
@@ -1,0 +1,12 @@
+-module(rename_variable).
+
+foo(Var) ->
+  Var < 0;
+foo(Var) ->
+  Var2 = Var,
+  Var > 0 andalso Var =:= Var2;
+foo(_Var) ->
+  false.
+
+bar(Var) ->
+  Var.

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -3,6 +3,7 @@
 -include("els_lsp.hrl").
 
 -export([ compare/2
+        , in/2
         , range/4
         ]).
 
@@ -16,6 +17,10 @@ compare( #{from := FromA, to := ToA}
   true;
 compare(_, _) ->
   false.
+
+-spec in(poi_range(), poi_range()) -> boolean().
+in(#{from := FromA, to := ToA}, #{from := FromB, to := ToB}) ->
+  FromA >= FromB andalso ToA =< ToB.
 
 -spec range(pos() | {pos(), pos()}, poi_kind(), any(), any()) -> poi_range().
 range({{Line, Column}, {ToLine, ToColumn}}, Name, _, _Data)

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -183,6 +183,7 @@ sources() ->
   , rename
   , rename_usage1
   , rename_usage2
+  , rename_variable
   ].
 
 tests() ->


### PR DESCRIPTION
### Description

Add support for renaming a variable in the scope of a function clause.