### PR TITLE
Global parse_transforms through configuration

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -50,7 +50,8 @@
                | root_uri
                | search_paths
                | code_reload
-               | elvis_config_path.
+               | elvis_config_path
+               | parse_transforms.
 
 -type path()  :: file:filename().
 -type state() :: #{ apps_dirs        => [path()]
@@ -68,6 +69,7 @@
                   , root_uri         => uri()
                   , search_paths     => [path()]
                   , code_reload      => map() | 'disabled'
+                  , parse_transforms => [string()]
                   }.
 
 %%==============================================================================
@@ -106,6 +108,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = add_code_paths(CodePathExtraDirs, RootPath),
   ElvisConfigPath = maps:get("elvis_config_path", Config, undefined),
   BSPEnabled = maps:get("bsp_enabled", Config, false),
+  ParseTransforms = maps:get("parse_transforms", Config, []),
 
   %% Passed by the LSP client
   ok = set(root_uri       , RootUri),
@@ -125,6 +128,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
                                     , CtRunTest)),
   ok = set(elvis_config_path, ElvisConfigPath),
   ok = set(bsp_enabled, BSPEnabled),
+  ok = set(parse_transforms, ParseTransforms),
   %% Calculated from the above
   ok = set(apps_paths     , project_paths(RootPath, AppsDirs, false)),
   ok = set(deps_paths     , project_paths(RootPath, DepsDirs, false)),

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -38,6 +38,7 @@
 -type macro_config()   :: #{string() => string()}.
 -type macro_option()   :: {'d', atom()} | {'d', atom(), any()}.
 -type include_option() :: {'i', string()}.
+-type parse_transform_option() :: {parse_transform, atom()}.
 
 %%==============================================================================
 %% Callback Functions
@@ -302,6 +303,11 @@ include_options() ->
   Paths = els_config:get(include_paths),
   [ {i, Path} || Path <- Paths ].
 
+-spec parse_transform_options() -> [parse_transform_option()].
+parse_transform_options() ->
+  Modules = els_config:get(parse_transforms),
+  [ {parse_transform, list_to_atom(Module)} || Module <- Modules ].
+
 -spec diagnostics_options() -> [any()].
 diagnostics_options() ->
   [basic_validation|diagnostics_options_bare()].
@@ -314,6 +320,7 @@ diagnostics_options_load_code() ->
 diagnostics_options_bare() ->
   lists:append([ macro_options()
                , include_options()
+               , parse_transform_options()
                , [ return_warnings
                  , return_errors
                  ]]).

--- a/apps/els_lsp/src/els_diagnostics_utils.erl
+++ b/apps/els_lsp/src/els_diagnostics_utils.erl
@@ -34,7 +34,9 @@ dependencies([Uri|Uris], Acc, AlreadyProcessed) ->
   case els_utils:lookup_document(Uri) of
     {ok, Document} ->
       Behaviours = els_dt_document:pois(Document, [behaviour]),
-      ParseTransforms = els_dt_document:pois(Document, [parse_transform]),
+      DocumentTransforms = els_dt_document:pois(Document, [parse_transform]),
+      GlobalTransforms = els_config:get(parse_transforms),
+      ParseTransforms = lists:append(DocumentTransforms, GlobalTransforms),
       IncludedUris = included_uris(Document),
       FilteredIncludedUris = exclude_already_processed( IncludedUris
                                                       , AlreadyProcessed


### PR DESCRIPTION
### Description

In some of our work projects, we declare `parse_transform`'s to be "globally" activated through `erl_opts` in `rebar.config`. While we're aware that this is somewhat tricky since that means they're also used to compile our dependencies and the usage is implicit, we have so far preferred this approach over adding a `-compile` attribute to every file we use this in, or adding some sort of global `hrl` file and including that in every module.

The parse transform we use happens to make invalid syntax valid, so our modules won't compile without the parse transform being applied.

_We could potentially go the route of adding a `-compile({parse_transform, cut}).` attribute to every module. However, that's a lot of impact, with the main pro being that our devs can then use `erlang-ls`._

An alternative solution would be to have `erlang-ls` support configuring such parse_transforms in the configuration file; much in the same way that it supports macro-declarations.

This PR adds the minimal code I could figure out to make this _work_.

It's missing any kind of test or documentation.

My goal here is mostly to figure out whether there's any interest in allowing a `parse_transforms` key in `erlang_ls.config`, and if so, whether the direction this implementation takes is good to explore further. If so, I can look into tests and docs.
