### PR TITLE
Show macro definition on hover

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/hover_macro.erl
+++ b/apps/els_lsp/priv/code_navigation/src/hover_macro.erl
@@ -1,0 +1,7 @@
+-module(hover_macro).
+-include("code_navigation.hrl").
+-define(LOCAL_MACRO, local_macro).
+
+f() ->
+  ?LOCAL_MACRO,
+  ?INCLUDED_MACRO_A.

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -304,8 +304,8 @@ attribute(Tree) ->
     preprocessor ->
       Name = erl_syntax:atom_value(erl_syntax:attribute_name(Tree)),
       case {Name, erl_syntax:attribute_arguments(Tree)} of
-        {define, [Define|_]} ->
-          [poi(Pos, define, define_name(Define))];
+        {define, [Define|Value]} ->
+          [poi(Pos, define, define_name(Define), Value)];
         {include, [String]} ->
           [poi(Pos, include, erl_syntax:string_value(String))];
         {include_lib, [String]} ->

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -17,6 +17,8 @@
         , local_call_with_args/1
         , remote_call_multiple_clauses/1
         , no_poi/1
+        , included_macro/1
+        , local_macro/1
         ]).
 
 %%==============================================================================
@@ -109,6 +111,26 @@ remote_call_multiple_clauses(Config) ->
               , value => Value
               },
   ?assertEqual(Expected, Contents),
+  ok.
+
+local_macro(Config) ->
+  Uri = ?config(hover_macro_uri, Config),
+  #{result := Result} = els_client:hover(Uri, 6, 4),
+  Value = <<"```erlang\n?LOCAL_MACRO = local_macro\n```">>,
+  Expected = #{contents => #{ kind  => <<"markdown">>
+                            , value => Value
+                            }},
+  ?assertEqual(Expected, Result),
+  ok.
+
+included_macro(Config) ->
+  Uri = ?config(hover_macro_uri, Config),
+  #{result := Result} = els_client:hover(Uri, 7, 4),
+  Value = <<"```erlang\n?INCLUDED_MACRO_A = included_macro_a\n```">>,
+  Expected = #{contents => #{ kind  => <<"markdown">>
+                            , value => Value
+                            }},
+  ?assertEqual(Expected, Result),
   ok.
 
 no_poi(Config) ->

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -180,6 +180,7 @@ sources() ->
   , format_input
   , hover_docs
   , hover_docs_caller
+  , hover_macro
   , my_gen_server
   , rename
   , rename_function


### PR DESCRIPTION
### Description

Show macro definition on hover.

We now store the define value in the POI, this should be helpful when implementing #829.
