### PR TITLE
return references if no definitions are found

### DIFF
--- a/apps/els_lsp/src/els_definition_provider.erl
+++ b/apps/els_lsp/src/els_definition_provider.erl
@@ -8,6 +8,7 @@
 
 -include("els_lsp.hrl").
 
+
 -type state() :: any().
 
 %%==============================================================================
@@ -27,7 +28,12 @@ handle_request({definition, Params}, State) ->
    } = Params,
   {ok, Document} = els_utils:lookup_document(Uri),
   POIs = els_dt_document:get_element_at_pos(Document, Line + 1, Character + 1),
-  {goto_definition(Uri, POIs), State}.
+  case goto_definition(Uri, POIs) of
+    null ->
+      els_references_provider:handle_request({references, Params}, State);
+    GoTo ->
+      {GoTo, State}
+  end.
 
 -spec goto_definition(uri(), [poi()]) -> map() | null.
 goto_definition(_Uri, []) ->

--- a/apps/els_lsp/test/els_definition_SUITE.erl
+++ b/apps/els_lsp/test/els_definition_SUITE.erl
@@ -389,7 +389,12 @@ type_application_undefined(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   Def = els_client:definition(Uri, 55, 42),
   #{result := Result} =  Def,
-  ?assertEqual(null, Result),
+  Expected = [
+    #{ range => #{'end' => #{character => 49, line => 54},
+                  start => #{character => 33, line => 54}}
+     , uri => Uri}
+  ],
+  ?assertEqual(Expected, Result),
   ok.
 
 -spec type_application_user(config()) -> ok.


### PR DESCRIPTION
### If no definitions can be found, try to return references instead

This is inline with what most other LS are doing, when we jump-to-definition on a definition (or no definition can be found), try to return references instead. If there are no references, give up.
