### PR TITLE
Fix bogus bound variable warnings in fun expression heads

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_bound_var_in_pattern.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_bound_var_in_pattern.erl
@@ -1,6 +1,6 @@
 -module(diagnostics_bound_var_in_pattern).
 
--export([f/1, g/1, h/2]).
+-export([f/1, g/1, h/2, fun_expr/1, named_fun_expr/0]).
 
 f(Var1) ->
   Var1 = 1.
@@ -17,4 +17,15 @@ h(Var3, Var4) ->
       New
   catch Var4 ->
       error
+  end.
+
+fun_expr(New) ->
+  fun(New, Var5) ->
+      Var5 = New
+  end.
+
+named_fun_expr() ->
+  fun F(New, Var6) ->
+      New = Var6,
+      F = Var6
   end.

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -176,10 +176,30 @@ bound_var_in_pattern(Config) ->
           #{'end' => #{character => 12, line => 17},
             start => #{character => 8, line => 17}},
         severity => 4,
+        source => <<"BoundVarInPattern">>},
+      #{message => <<"Bound variable in pattern: Var5">>,
+        range =>
+          #{'end' => #{character => 10, line => 23},
+            start => #{character => 6, line => 23}},
+        severity => 4,
         source => <<"BoundVarInPattern">>}
+      %% erl_syntax_lib:annotate_bindings does not handle named funs correctly
+      %% #{message => <<"Bound variable in pattern: New">>,
+      %%   range =>
+      %%     #{'end' => #{character => 9, line => 28},
+      %%       start => #{character => 6, line => 28}},
+      %%   severity => 4,
+      %%   source => <<"BoundVarInPattern">>},
+      %% #{message => <<"Bound variable in pattern: F">>,
+      %%   range =>
+      %%     #{'end' => #{character => 7, line => 29},
+      %%       start => #{character => 6, line => 29}},
+      %%   severity => 4,
+      %%   source => <<"BoundVarInPattern">>}
     ],
   F = fun(#{message := M1}, #{message := M2}) -> M1 =< M2 end,
-  ?assertEqual(Expected, lists:sort(F, Diagnostics)),
+  Hints = [D || #{severity := ?DIAGNOSTIC_HINT} = D <- Diagnostics],
+  ?assertEqual(Expected, lists:sort(F, Hints)),
   ok.
 
 -spec compiler(config()) -> ok.


### PR DESCRIPTION
This is a workaround for erl_syntax_lib not considering shadowing in fun
expressions.

There is a further issue with named funs where variables from the name and head
are not added to the env of the fun body. This is not fixed by the current
change.

Fixes #982.
