### PR TITLE
[dap] Add basic support for break/logpoint (hit)conditions.

### DIFF
--- a/apps/els_dap/src/els_dap_breakpoints.erl
+++ b/apps/els_dap/src/els_dap_breakpoints.erl
@@ -31,7 +31,8 @@
 -type expression() :: string().
 -type function_break() :: {atom(), non_neg_integer()}.
 
--export_type([breakpoints/0]).
+-export_type([ breakpoints/0
+             , line_breaks/0]).
 
 -spec type(breakpoints(), module(), line()) -> line_breaks().
 type(Breakpoints, Module, Line) ->

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -46,14 +46,16 @@
                          , frames := #{frame_id() => frame()}
                          }.
 -type thread_id()    :: integer().
+-type mode()         :: undefined | running | stepping.
 -type state()        :: #{ threads => #{thread_id() => thread()}
                          , project_node => atom()
                          , launch_params => #{}
                          , scope_bindings =>
                           #{pos_integer() => {binding_type(), bindings()}}
                          , breakpoints := els_dap_breakpoints:breakpoints()
+                         , hits => #{line() => non_neg_integer()}
                          , timeout := timeout()
-                         , mode := undefined | running | stepping
+                         , mode := mode()
                          }.
 -type bindings()     :: [{varname(), term()}].
 -type varname()      :: atom() | string().
@@ -74,6 +76,7 @@ init() ->
    , launch_params => #{}
    , scope_bindings => #{}
    , breakpoints => #{}
+   , hits => #{}
    , timeout => 30
    , mode => undefined}.
 
@@ -411,11 +414,30 @@ handle_request( {<<"disconnect">>, _Params}
   els_utils:halt(0),
   {#{}, State}.
 
+-spec debug_stop(thread_id()) -> mode().
+debug_stop(ThreadId) ->
+  els_dap_server:send_event( <<"stopped">>
+                           , #{ <<"reason">> => <<"breakpoint">>
+                              , <<"threadId">> => ThreadId
+                              }),
+  stepping.
+
+-spec debug_previous_mode(mode(), atom(), pid(), thread_id()) -> mode().
+debug_previous_mode(Mode0, ProjectNode, ThreadPid, ThreadId) ->
+  case Mode0 of
+    running ->
+      els_dap_rpc:continue(ProjectNode, ThreadPid),
+      Mode0;
+    _ ->
+      debug_stop(ThreadId)
+  end.
+
 -spec handle_info(any(), state()) -> state() | no_return().
 handle_info( {int_cb, ThreadPid}
            , #{ threads := Threads
               , project_node := ProjectNode
               , breakpoints := Breakpoints
+              , hits := Hits0
               , mode := Mode0
               } = State
            ) ->
@@ -425,39 +447,73 @@ handle_info( {int_cb, ThreadPid}
             , frames => stack_frames(ThreadPid, ProjectNode)
             },
   {Module, Line} = break_module_line(ThreadPid, ProjectNode),
-
-  %% handle breakpoints
-  Mode1 =
-    case els_dap_breakpoints:type(Breakpoints, Module, Line) of
-      regular ->
-        els_dap_server:send_event( <<"stopped">>
-                                 , #{ <<"reason">> => <<"breakpoint">>
-                                    , <<"threadId">> => ThreadId
-                                    }),
-        stepping;
-      {log, Expression} ->
-        Return = safe_eval(ProjectNode, ThreadPid, Expression, no_update),
-        LogMessage = unicode:characters_to_binary(
-          io_lib:format("~s:~b - ~w~n",
-                        [source(Module, ProjectNode), Line, Return])
-        ),
-        els_dap_server:send_event( <<"output">>
-                                 , #{ <<"output">> => LogMessage }),
-        case Mode0 of
-          running ->
-            els_dap_rpc:continue(ProjectNode, ThreadPid);
-          _ ->
-            els_dap_server:send_event( <<"stopped">>
-                                     , #{ <<"reason">> => <<"breakp9oint">>
-                                        , <<"threadId">> => ThreadId
-                                        })
-        end,
-        %% logpoints don't change the mode
-        Mode0
+  Breakpt = els_dap_breakpoints:type(Breakpoints, Module, Line),
+  %% evaluate condition if exists, otherwise treat as 'true'
+  Condition = case Breakpt of
+    #{condition := CondExpr} ->
+      CondEval = safe_eval(ProjectNode, ThreadPid, CondExpr, no_update),
+      case CondEval of
+        true -> true;
+        false -> false;
+        _ ->
+          WarnCond = unicode:characters_to_binary(
+            io_lib:format(
+              "~s:~b - Breakpoint condition evaluated to non-Boolean: ~w~n",
+              [source(Module, ProjectNode), Line, CondEval])),
+          els_dap_server:send_event( <<"output">>
+                                   , #{ <<"output">> => WarnCond }),
+          false
+      end;
+    _ -> true
     end,
-
-
-  State#{threads => maps:put(ThreadId, Thread, Threads), mode => Mode1};
+  %% update hit count for current line if condition is true
+  HitCount = maps:get(Line, Hits0, 0) + 1,
+  Hits1 = case Condition of
+      true -> maps:put(Line, HitCount, Hits0);
+      false -> Hits0
+    end,
+  %% check if there is hit expression, if yes check along with condition
+  IsHit = case Breakpt of
+      #{hitcond := HitExpr} ->
+        HitEval = safe_eval(ProjectNode, ThreadPid, HitExpr, no_update),
+        case HitEval of
+          N when is_integer(N), N>0 -> Condition and (HitCount rem N =:= 0);
+          _ ->
+            WarnHit = unicode:characters_to_binary(
+              io_lib:format(
+                "~s:~b - Breakpoint hit condition not a non-negative int: ~w~n",
+                [source(Module, ProjectNode), Line, HitEval])),
+            els_dap_server:send_event( <<"output">>
+                                     , #{ <<"output">> => WarnHit }),
+            Condition
+        end;
+      _ -> Condition
+    end,
+  %% finally, either stop or log
+  Stop = case Breakpt of
+      #{logexpr := LogExpr} ->
+        case IsHit of
+          true ->
+            Return = safe_eval(ProjectNode, ThreadPid, LogExpr, no_update),
+            LogMessage = unicode:characters_to_binary(
+              io_lib:format("~s:~b - ~w~n",
+                            [source(Module, ProjectNode), Line, Return])),
+            els_dap_server:send_event( <<"output">>
+                                     , #{ <<"output">> => LogMessage }),
+            false;
+          false -> false
+        end;
+      _ -> IsHit
+    end,
+  Mode1 = case Stop of
+      true -> debug_stop(ThreadId);
+      false -> debug_previous_mode(Mode0, ProjectNode, ThreadPid, ThreadId)
+    end,
+  State#{
+    threads => maps:put(ThreadId, Thread, Threads),
+    mode => Mode1,
+    hits => Hits1
+  };
 handle_info({nodedown, Node}, State) ->
   %% the project node is down, there is nothing left to do then to exit
   ?LOG_NOTICE("project node ~p terminated, ending debug session", [Node]),
@@ -473,6 +529,8 @@ capabilities() ->
   #{ <<"supportsConfigurationDoneRequest">> => true
    , <<"supportsEvaluateForHovers">> => true
    , <<"supportsFunctionBreakpoints">> => true
+   , <<"supportsConditionalBreakpoints">> => true
+   , <<"supportsHitConditionalBreakpoints">> => true
    , <<"supportsLogPoints">> => true}.
 
 %%==============================================================================

--- a/elvis.config
+++ b/elvis.config
@@ -12,6 +12,7 @@
          , ruleset => erl_files
          , rules   => [ {elvis_style, god_modules, #{ignore => [ els_client
                                                                , els_completion_SUITE
+                                                               , els_dap_general_provider_SUITE
                                                                , els_definition_SUITE
                                                                , els_diagnostics_SUITE
                                                                , els_document_highlight_SUITE


### PR DESCRIPTION
### Description

This PR adds basic support for **conditions** and **hitconditions** for break/logpoints in the debugger ([see specification](https://microsoft.github.io/debug-adapter-protocol/specification#Types_SourceBreakpoint)).

**Details**

- A break/logpoint with a **condition** only triggers if the condition expression **evaluates to true**.
- Hitconditions currently must be non-negative integers N, meaning that only **every Nth hit** of a break/logpoint will trigger.
- Note that it is possible to have both a condition and a hitcondition for a break/logpoint, in this case we are only counting hits where the condition is true, and we only trigger at every Nth such hit.
- Note that conditions and hitconditions work the same way both for breakpoints and logpoints. The only difference is that breakpoints will stop, while logpoints will print a message and continue.

**Limitations**

Error handling is currently limited:
- If a condition cannot be evaluated, or does not evaluate to a Boolean, a warning message is displayed in the output and the condition is treated as false.
- If the hitcondition cannot be evaluated, or does not evaluate to a non-negative integer, a warning message is displayed in the output, the hitcondition is disregarded (treated as a hit).

**Testing**

New unit tests were added (`els_dap_general_provider_SUITE.erl`) and manual end-to-end testing was also carried out using the [daptoy project](https://github.com/erlang-ls/daptoy), focusing on all the possible combinations of break/logpoints with conditions and/or hitconditions. Manual testing actually revealed an interesting aspect of the protocol: if a break/logpoint is set without a (hit)condition, then there is no (hit)condition key in the mapping. However, if there is a (hit)condition, but is deleted later, a key is present with an empty value. This is handled correctly, and a unit test was also added for this behavior.
