### PR TITLE
[FEATURE] truncate suggested spec title

### DIFF
--- a/apps/els_lsp/src/els_execute_command_provider.erl
+++ b/apps/els_lsp/src/els_execute_command_provider.erl
@@ -94,6 +94,8 @@ execute_command(<<"function-references">>, [_Params]) ->
   [];
 execute_command(<<"show-behaviour-usages">>, [_Params]) ->
   [];
+execute_command(<<"suggest-spec">>, []) ->
+  [];
 execute_command(<<"suggest-spec">>, [#{ <<"uri">> := Uri
                                       , <<"line">> := Line
                                       , <<"spec">> := Spec

--- a/apps/els_lsp/src/els_typer.erl
+++ b/apps/els_lsp/src/els_typer.erl
@@ -61,7 +61,7 @@
 -record(info, {records = maps:new() :: erl_types:type_table(),
                functions = []       :: [func_info()],
                types = map__new()   :: map_dict()}).
--opaque info() :: #info{}.
+-type info() :: #info{}.
 -export_type([ info/0 ]).
 
 -spec get_info(uri()) -> #info{}.


### PR DESCRIPTION
also use empty command with a spec lens when failed to extract spec

### Description

The only editor that seem to be affected is Emacs. When suggested spec is too long it is wrapped over multiple lines in the editor window. In vim (coc) and Vs Code it is always presented as one very long line. Nonetheless it is probably good to avoid arbitrary long lens titles. This truncates the title to 100 chars by default (the font of the lens is typically smaller than normal text, hence it can be more than 80 chars).

Also fixes a bug when TypEr fails and no spec is available the lens with the error message was still clickable and would be producing a new line of text.

Fixes #960 and #995 .
