### PR TITLE
Support record fields in reference provider

### DIFF
--- a/apps/els_core/src/els_utils.erl
+++ b/apps/els_core/src/els_utils.erl
@@ -8,6 +8,8 @@
         , fold_files/4
         , halt/1
         , lookup_document/1
+        , include_id/1
+        , include_lib_id/1
         , macro_string_to_term/1
         , project_relative/1
         , resolve_paths/3
@@ -88,7 +90,8 @@ cmd_path(Cmd) ->
       Epmd
   end.
 
--spec filename_to_atom(els_dt_document:id()) -> atom().
+%% @doc Convert an 'include'/'include_lib' POI ID to a document index ID
+-spec filename_to_atom(string()) -> atom().
 filename_to_atom(FileName) ->
   list_to_atom(filename:basename(FileName, filename:extension(FileName))).
 
@@ -140,6 +143,23 @@ lookup_document(Uri) ->
           {error, Error}
       end
   end.
+
+%% @doc Convert path to an 'include' POI id
+-spec include_id(file:filename_all()) -> string().
+include_id(Path) ->
+  els_utils:to_list(filename:basename(Path)).
+
+%% @doc Convert path to an 'include_lib' POI id
+-spec include_lib_id(file:filename_all()) -> string().
+include_lib_id(Path) ->
+  Components = filename:split(Path),
+  Length     = length(Components),
+  End        = Length - 1,
+  Beginning  = max(1, Length - 2),
+  [H|T]      = lists:sublist(Components, Beginning, End),
+  %% Strip the app version number from the path
+  Id = filename:join([re:replace(H, "-.*", "", [{return, list}]) | T]),
+  els_utils:to_list(Id).
 
 -spec macro_string_to_term(list()) -> any().
 macro_string_to_term(Value) ->

--- a/apps/els_lsp/priv/code_navigation/src/code_navigation_undefined.erl
+++ b/apps/els_lsp/priv/code_navigation/src/code_navigation_undefined.erl
@@ -1,0 +1,9 @@
+-module(code_navigation_undefined).
+
+-export([f0/0, f1/1]).
+
+f0() ->
+  #undef_rec{undef_field = ?UNDEF_MACRO}.
+
+f1(#undef_rec{undef_field = ?UNDEF_MACRO}) ->
+  ok.

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -177,7 +177,7 @@ include_uris(Document) ->
   POIs = els_dt_document:pois(Document, [include, include_lib]),
   lists:foldl(fun add_include_uri/2, [], POIs).
 
--spec add_include_uri(els_dt_document:item(), [uri()]) -> [uri()].
+-spec add_include_uri(poi(), [uri()]) -> [uri()].
 add_include_uri(#{ id := Id }, Acc) ->
   case els_utils:find_header(els_utils:filename_to_atom(Id)) of
     {ok, Uri}       -> [Uri | Acc];

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -256,11 +256,11 @@ inclusion_range(IncludePath, Document) ->
                      -> [poi_range()].
 inclusion_range(IncludePath, Document, include) ->
   POIs       = els_dt_document:pois(Document, [include]),
-  IncludeId  = include_id(IncludePath),
+  IncludeId  = els_utils:include_id(IncludePath),
   [Range || #{id := Id, range := Range} <- POIs, Id =:= IncludeId];
 inclusion_range(IncludePath, Document, include_lib) ->
   POIs       = els_dt_document:pois(Document, [include_lib]),
-  IncludeId  = include_lib_id(IncludePath),
+  IncludeId  = els_utils:include_lib_id(IncludePath),
   [Range || #{id := Id, range := Range} <- POIs, Id =:= IncludeId];
 inclusion_range(IncludePath, Document, behaviour) ->
   POIs        = els_dt_document:pois(Document, [behaviour]),
@@ -271,20 +271,6 @@ inclusion_range(IncludePath, Document, parse_transform) ->
   ParseTransformId
     = els_uri:module(els_uri:uri(els_utils:to_binary(IncludePath))),
   [Range || #{id := Id, range := Range} <- POIs, Id =:= ParseTransformId].
-
--spec include_id(string()) -> string().
-include_id(Path) ->
-  filename:basename(Path).
-
--spec include_lib_id(string()) -> string().
-include_lib_id(Path) ->
-  Components = filename:split(Path),
-  Length     = length(Components),
-  End        = Length - 1,
-  Beginning  = max(1, Length - 2),
-  [H|T]      = lists:sublist(Components, Beginning, End),
-  %% Strip the app version number from the path
-  filename:join([re:replace(H, "-.*", "", [{return, list}])], filename:join(T)).
 
 -spec macro_options() -> [macro_option()].
 macro_options() ->

--- a/apps/els_lsp/src/els_dt_references.erl
+++ b/apps/els_lsp/src/els_dt_references.erl
@@ -118,5 +118,9 @@ kind_to_category(Kind) when Kind =:= macro;
 kind_to_category(Kind) when Kind =:= record_expr;
                             Kind =:= record ->
   record;
+kind_to_category(Kind) when Kind =:= include ->
+  include;
+kind_to_category(Kind) when Kind =:= include_lib ->
+  include_lib;
 kind_to_category(Kind) when Kind =:= behaviour ->
   behaviour.

--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -102,8 +102,8 @@ index_references(#{uri := Uri} = Document, 'deep', false) ->
   POIs  = els_dt_document:pois(Document, [ application
                                          , behaviour
                                          , implicit_fun
-                                         , macro
-                                         , record_expr
+                                         , include
+                                         , include_lib
                                          , type_application
                                          , import_entry
                                          ]),
@@ -152,10 +152,9 @@ register_reference(Uri, #{id := {F, A}} = POI) ->
   M = els_uri:module(Uri),
   register_reference(Uri, POI#{id => {M, F, A}});
 register_reference(Uri, #{kind := Kind, id := Id, range := Range})
-  when %% Record
-       Kind =:= record_expr;
-       %% Macro
-       Kind =:= macro;
+  when %% Include
+       Kind =:= include;
+       Kind =:= include_lib;
        %% Function
        Kind =:= application;
        Kind =:= implicit_fun;

--- a/apps/els_lsp/src/els_scope.erl
+++ b/apps/els_lsp/src/els_scope.erl
@@ -1,0 +1,79 @@
+%%% @doc Library module to calculate various scoping rules
+-module(els_scope).
+
+-export([ local_and_included_pois/2
+        , local_and_includer_pois/2
+        ]).
+
+-include("els_lsp.hrl").
+
+%% @doc Return POIs of the provided `Kinds' in the document and included files
+-spec local_and_included_pois(els_dt_document:item(), poi_kind() | [poi_kind()])
+                             -> [poi()].
+local_and_included_pois(Document, Kind) when is_atom(Kind) ->
+  local_and_included_pois(Document, [Kind]);
+local_and_included_pois(Document, Kinds) ->
+  lists:flatten([ els_dt_document:pois(Document, Kinds)
+                , included_pois(Document, Kinds)
+                ]).
+
+%% @doc Return POIs of the provided `Kinds' in included files from `Document'
+-spec included_pois(els_dt_document:item(), [poi_kind()]) -> [[map()]].
+included_pois(Document, Kinds) ->
+  POIs  = els_dt_document:pois(Document, [include, include_lib]),
+  [include_file_pois(Name, Kinds) || #{id := Name} <- POIs].
+
+%% @doc Return POIs of the provided `Kinds' in the included file
+-spec include_file_pois(string(), [poi_kind()]) -> [map()].
+include_file_pois(Name, Kinds) ->
+  case els_utils:find_header(els_utils:filename_to_atom(Name)) of
+    {ok, Uri} ->
+      {ok, IncludeDocument} = els_utils:lookup_document(Uri),
+      %% NB: Recursive call to support includes in the include file
+      IncludedInHeader = lists:flatten(included_pois(IncludeDocument, Kinds)),
+      els_dt_document:pois(IncludeDocument, Kinds) ++ IncludedInHeader;
+    {error, _} ->
+      []
+  end.
+
+%% @doc Return POIs of the provided `Kinds' in the local document and files that
+%% (maybe recursively) include it
+-spec local_and_includer_pois(uri(), [poi_kind()]) ->
+        [{uri(), [poi()]}].
+local_and_includer_pois(LocalUri, Kinds) ->
+  [{Uri, find_pois_by_uri(Uri, Kinds)}
+   || Uri <- local_and_includers(LocalUri)].
+
+-spec find_pois_by_uri(uri(), [poi_kind()]) -> [poi()].
+find_pois_by_uri(Uri, Kinds) ->
+  {ok, Document} = els_utils:lookup_document(Uri),
+  els_dt_document:pois(Document, Kinds).
+
+-spec local_and_includers(uri()) -> [uri()].
+local_and_includers(Uri) ->
+  find_includers_loop(Uri, [Uri]).
+
+-spec find_includers_loop(uri(), ordsets:ordset(uri())) ->
+        ordsets:ordset(uri()).
+find_includers_loop(Uri, Acc0) ->
+  Includers = find_includers(Uri),
+  case ordsets:subtract(Includers, Acc0) of
+    [] ->
+      %% no new uris
+      Acc0;
+    New ->
+      Acc1 = ordsets:union(New, Acc0),
+      lists:foldl(fun find_includers_loop/2, Acc1, New)
+  end.
+
+-spec find_includers(uri()) -> [uri()].
+find_includers(Uri) ->
+  IncludeId = els_utils:include_id(els_uri:path(Uri)),
+  IncludeLibId = els_utils:include_lib_id(els_uri:path(Uri)),
+  lists:usort(find_includers(include, IncludeId) ++
+                find_includers(include_lib, IncludeLibId)).
+
+-spec find_includers(poi_kind(), string()) -> [uri()].
+find_includers(Kind, Id) ->
+  {ok, Items} = els_dt_references:find_by_id(Kind, Id),
+  [Uri || #{uri := Uri} <- Items].

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -377,6 +377,10 @@ default_completions(Config) ->
                  , kind             => ?COMPLETION_ITEM_KIND_MODULE
                  , label            => <<"code_navigation_types">>
                  }
+              , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                 , kind             => ?COMPLETION_ITEM_KIND_MODULE
+                 , label            => <<"code_navigation_undefined">>
+                 }
               | Functions ],
 
   DefaultCompletion = els_completion_provider:keywords()

--- a/apps/els_lsp/test/els_rename_SUITE.erl
+++ b/apps/els_lsp/test/els_rename_SUITE.erl
@@ -148,6 +148,7 @@ rename_macro(Config) ->
   Line = 0,
   Char = 13,
   NewName = <<"NEW_AWESOME_NAME">>,
+  NewNameUsage = <<"?NEW_AWESOME_NAME">>,
   #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
   Expected =  #{changes =>
                   #{ binary_to_atom(Uri, utf8) =>
@@ -157,20 +158,20 @@ rename_macro(Config) ->
                                , start => #{character => 8, line => 0}}}
                        ]
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
-                       [ #{ newText => NewName
+                       [ #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 13, line => 15}
-                               , start => #{character => 4, line => 15}}}
-                       , #{ newText => NewName
+                               , start => #{character => 3, line => 15}}}
+                       , #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 25, line => 15}
-                               , start => #{character => 16, line => 15}}}
+                               , start => #{character => 15, line => 15}}}
                        ]
                    , binary_to_atom(?config(rename_usage2_uri, Config), utf8) =>
-                       [ #{ newText => NewName
+                       [ #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 26, line => 11}
-                               , start => #{character => 17, line => 11}}}
+                               , start => #{character => 16, line => 11}}}
                        ]
                    }
                },
@@ -259,6 +260,7 @@ rename_parametrized_macro(Config) ->
   Line = 2,
   Char = 16,
   NewName = <<"NEW_AWESOME_NAME">>,
+  NewNameUsage = <<"?NEW_AWESOME_NAME">>,
   #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
   Expected =  #{changes =>
                   #{ binary_to_atom(Uri, utf8) =>
@@ -268,21 +270,21 @@ rename_parametrized_macro(Config) ->
                                , start => #{character => 8, line => 2}}}
                        ]
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
-                       [ #{ newText => NewName
+                       [ #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 26, line => 18}
-                               , start => #{character => 4, line => 18}}}
-                       , #{ newText => NewName
+                               , start => #{character => 3, line => 18}}}
+                       , #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 54, line => 18}
-                               , start => #{character => 32, line => 18}}}
+                               , start => #{character => 31, line => 18}}}
                        ]
                     , binary_to_atom(
                         ?config(rename_usage2_uri, Config), utf8) =>
-                        [ #{ newText => NewName
+                        [ #{ newText => NewNameUsage
                            , range =>
                                #{ 'end' => #{character => 52, line => 14}
-                                , start => #{character => 30, line => 14}}}
+                                , start => #{character => 29, line => 14}}}
                         ]
                    }
                },
@@ -294,6 +296,7 @@ rename_macro_from_usage(Config) ->
   Line = 15,
   Char = 7,
   NewName = <<"NEW_AWESOME_NAME">>,
+  NewNameUsage = <<"?NEW_AWESOME_NAME">>,
   #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
   Expected =  #{changes =>
                   #{ binary_to_atom(?config(rename_h_uri, Config), utf8) =>
@@ -303,20 +306,20 @@ rename_macro_from_usage(Config) ->
                                , start => #{character => 8, line => 0}}}
                        ]
                    , binary_to_atom(?config(rename_usage1_uri, Config), utf8) =>
-                       [ #{ newText => NewName
+                       [ #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 13, line => 15}
-                               , start => #{character => 4, line => 15}}}
-                       , #{ newText => NewName
+                               , start => #{character => 3, line => 15}}}
+                       , #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 25, line => 15}
-                               , start => #{character => 16, line => 15}}}
+                               , start => #{character => 15, line => 15}}}
                        ]
                    , binary_to_atom(?config(rename_usage2_uri, Config), utf8) =>
-                       [ #{ newText => NewName
+                       [ #{ newText => NewNameUsage
                           , range =>
                               #{ 'end' => #{character => 26, line => 11}
-                               , start => #{character => 17, line => 11}}}
+                               , start => #{character => 16, line => 11}}}
                        ]
                    }
                },

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -148,6 +148,7 @@ sources() ->
   , code_navigation
   , code_navigation_extra
   , code_navigation_types
+  , code_navigation_undefined
   , 'Code.Navigation.Elixirish'
   , completion
   , completion_caller
@@ -204,6 +205,8 @@ escripts() ->
 -spec includes() -> [atom()].
 includes() ->
   [ code_navigation
+  , transitive
+  , definition
   , diagnostics
   , rename
   ].

--- a/apps/els_lsp/test/els_workspace_symbol_SUITE.erl
+++ b/apps/els_lsp/test/els_workspace_symbol_SUITE.erl
@@ -70,6 +70,7 @@ query_multiple(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   ExtraUri = ?config(code_navigation_extra_uri, Config),
   TypesUri = ?config(code_navigation_types_uri, Config),
+  UndefUri = ?config(code_navigation_undefined_uri, Config),
   #{result := Result} = els_client:workspace_symbol(Query),
   Expected = [ #{ kind => ?SYMBOLKIND_MODULE
                 , location =>
@@ -100,6 +101,16 @@ query_multiple(Config) ->
                      , uri  => TypesUri
                      }
                 , name => <<"code_navigation_types">>
+                }
+             , #{ kind => ?SYMBOLKIND_MODULE
+                , location =>
+                    #{ range =>
+                         #{ 'end' => #{character => 0, line => 0}
+                          , start => #{character => 0, line => 0}
+                          }
+                     , uri  => UndefUri
+                     }
+                , name => <<"code_navigation_undefined">>
                 }
              ],
   ?assertEqual(lists:sort(Expected), lists:sort(Result)),

--- a/elvis.config
+++ b/elvis.config
@@ -16,6 +16,7 @@
                                                                , els_definition_SUITE
                                                                , els_diagnostics_SUITE
                                                                , els_document_highlight_SUITE
+                                                               , els_references_SUITE
                                                                , els_methods
                                                                ]}}
                       , {elvis_style, dont_repeat_yourself, #{ ignore => [ els_diagnostics_SUITE


### PR DESCRIPTION
References are only searched in the document containing the definition and
documents that (maybe recursively) include the defining document. The scoping
for macro and record referencing is also changed to the same.