### PR TITLE
Implement support for incremental sync

### DIFF
--- a/apps/els_core/include/els_core.hrl
+++ b/apps/els_core/include/els_core.hrl
@@ -181,6 +181,10 @@
 -define(TEXT_DOCUMENT_SYNC_KIND_FULL, 1).
 -define(TEXT_DOCUMENT_SYNC_KIND_INCREMENTAL, 2).
 
+-type text_document_sync_kind() :: ?TEXT_DOCUMENT_SYNC_KIND_NONE
+                                 | ?TEXT_DOCUMENT_SYNC_KIND_FULL
+                                 | ?TEXT_DOCUMENT_SYNC_KIND_INCREMENTAL.
+
 %%------------------------------------------------------------------------------
 %% Text Document Sync Kind
 %%------------------------------------------------------------------------------

--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -106,6 +106,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = add_code_paths(CodePathExtraDirs, RootPath),
   ElvisConfigPath = maps:get("elvis_config_path", Config, undefined),
   BSPEnabled = maps:get("bsp_enabled", Config, false),
+  IncrementalSync = maps:get("incremental_sync", Config, false),
 
   %% Passed by the LSP client
   ok = set(root_uri       , RootUri),
@@ -125,6 +126,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
                                     , CtRunTest)),
   ok = set(elvis_config_path, ElvisConfigPath),
   ok = set(bsp_enabled, BSPEnabled),
+  ok = set(incremental_sync, IncrementalSync),
   %% Calculated from the above
   ok = set(apps_paths     , project_paths(RootPath, AppsDirs, false)),
   ok = set(deps_paths     , project_paths(RootPath, DepsDirs, false)),

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -27,7 +27,7 @@ goto_definition( Uri
                ) ->
   %% This will naively try to find the definition of a variable by finding the
   %% first occurrence of the variable in the function clause.
-  {ok, [Document]} = els_dt_document:lookup(Uri),
+  {ok, Document} = els_utils:lookup_document(Uri),
   FunPOIs = els_poi:sort(els_dt_document:pois(Document, [function_clause])),
   VarPOIs = els_poi:sort(els_dt_document:pois(Document, [variable])),
   %% Find the function clause we are in

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -44,6 +44,7 @@ handle_request({completion, Params}, State) ->
                             }
    , <<"textDocument">> := #{<<"uri">> := Uri}
    } = Params,
+  ok = els_index_buffer:flush(Uri),
   {ok, #{text := Text} = Document} = els_utils:lookup_document(Uri),
   Context = maps:get( <<"context">>
                     , Params

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -128,7 +128,7 @@ server_capabilities() ->
   #{ capabilities =>
        #{ textDocumentSync =>
             #{ openClose => true
-             , change    => ?TEXT_DOCUMENT_SYNC_KIND_FULL
+             , change    => els_text_synchronization:sync_mode()
              , save      => #{includeText => false}
              }
         , hoverProvider =>

--- a/apps/els_lsp/src/els_index_buffer.erl
+++ b/apps/els_lsp/src/els_index_buffer.erl
@@ -1,0 +1,110 @@
+%% @doc Buffer textedits to avoid spamming indexing for every keystroke
+%%
+%% FIXME: Currently implemented as a simple process.
+%%        Might be nicer to rewrite this as a gen_server
+%% FIXME: Edits are bottlenecked by this single process, so this could slow
+%%        down indexing when making changes in multiple files, this could be
+%%        mitigated by using a worker pool or spawning a process per Uri.
+-module(els_index_buffer).
+
+-export([ start/0
+        , stop/0
+        , apply_edits_async/2
+        , flush/1
+        ]).
+
+-include_lib("kernel/include/logger.hrl").
+-include("els_lsp.hrl").
+
+-define(SERVER, ?MODULE).
+
+-spec start() -> {ok, pid()} | {error, _}.
+start() ->
+  case whereis(?SERVER) of
+    undefined ->
+      Pid = proc_lib:spawn_link(fun loop/0),
+      true = erlang:register(?SERVER, Pid),
+      ?LOG_INFO("[~p] Started.", [?SERVER]),
+      {ok, Pid};
+    Pid ->
+      {error, {already_started, Pid}}
+  end.
+
+-spec stop() -> ok.
+stop() ->
+  ?SERVER ! stop,
+  erlang:unregister(?SERVER),
+  ?LOG_INFO("[~p] Stopped.", [?SERVER]),
+  ok.
+
+-spec apply_edits_async(uri(), [els_text:edit()]) -> ok.
+apply_edits_async(Uri, Edits) ->
+  ?SERVER ! {apply_edits, Uri, Edits},
+  ok.
+
+-spec flush(uri()) -> ok.
+flush(Uri) ->
+  Ref = make_ref(),
+  ?SERVER ! {flush, self(), Ref, Uri},
+  receive
+    {Ref, done} ->
+      ok
+  end.
+
+-spec loop() -> ok.
+loop() ->
+  receive
+    stop -> ok;
+    {apply_edits, Uri, Edits} ->
+      try
+        do_apply_edits(Uri, Edits)
+      catch E:R:St ->
+          ?LOG_ERROR("[~p] Crashed while applying edits ~p: ~p",
+                     [?SERVER, Uri, {E, R, St}])
+      end,
+      loop();
+    {flush, Pid, Ref, Uri} ->
+      try
+        do_flush(Uri)
+      catch E:R:St ->
+          ?LOG_ERROR("[~p] Crashed while flushing ~p: ~p",
+                     [?SERVER, Uri, {E, R, St}])
+      end,
+      Pid ! {Ref, done},
+      loop()
+  end.
+
+-spec do_apply_edits(uri(), [els_text:edit()]) -> ok.
+do_apply_edits(Uri, Edits0) ->
+  ?LOG_DEBUG("[~p] Processing index request for ~p", [?SERVER, Uri]),
+  {ok, [#{text := Text0}]} = els_dt_document:lookup(Uri),
+  ?LOG_DEBUG("[~p] Apply edits: ~p", [?SERVER, Edits0]),
+  Text1 = els_text:apply_edits(Text0, Edits0),
+  Text = receive_all(Uri, Text1),
+  ?LOG_DEBUG("[~p] Started indexing ~p", [?SERVER, Uri]),
+  {Duration, ok} = timer:tc(fun() -> els_indexing:index(Uri, Text, 'deep') end),
+  ?LOG_DEBUG("[~p] Done indexing ~p [duration: ~pms]",
+             [?SERVER, Uri, Duration div 1000]),
+  ok.
+
+-spec do_flush(uri()) -> ok.
+do_flush(Uri) ->
+  ?LOG_DEBUG("[~p] Flushing ~p", [?SERVER, Uri]),
+  {ok, [#{text := Text0}]} = els_dt_document:lookup(Uri),
+  Text = receive_all(Uri, Text0),
+  {Duration, ok} = timer:tc(fun() -> els_indexing:index(Uri, Text, 'deep') end),
+  ?LOG_DEBUG("[~p] Done flushing ~p [duration: ~pms]",
+             [?SERVER, Uri, Duration div 1000]),
+  ok.
+
+-spec receive_all(uri(), binary()) -> binary().
+receive_all(Uri, Text0) ->
+  receive
+    {apply_edits, Uri, Edits} ->
+      ?LOG_DEBUG("[~p] Received more edits ~p.", [?SERVER, Uri]),
+      ?LOG_DEBUG("[~p] Apply edits: ~p", [?SERVER, Edits]),
+      Text = els_text:apply_edits(Text0, Edits),
+      receive_all(Uri, Text)
+  after
+    0 -> Text0
+  end.

--- a/apps/els_lsp/src/els_methods.erl
+++ b/apps/els_lsp/src/els_methods.erl
@@ -192,14 +192,7 @@ textdocument_didopen(Params, State) ->
 
 -spec textdocument_didchange(params(), state()) -> result().
 textdocument_didchange(Params, State) ->
-  ContentChanges = maps:get(<<"contentChanges">>, Params),
-  TextDocument   = maps:get(<<"textDocument">>  , Params),
-  Uri            = maps:get(<<"uri">>           , TextDocument),
-  case ContentChanges of
-    []                      -> ok;
-    [#{<<"text">> := Text}] ->
-      els_indexing:index(Uri, Text, 'deep')
-  end,
+  ok = els_text_synchronization:did_change(Params),
   {noresponse, State}.
 
 %%==============================================================================

--- a/apps/els_lsp/src/els_sup.erl
+++ b/apps/els_lsp/src/els_sup.erl
@@ -75,6 +75,9 @@ init([]) ->
                , #{ id => els_bsp_client
                   , start => {els_bsp_client, start_link, []}
                   }
+               , #{ id => els_index_buffer
+                  , start => {els_index_buffer, start, []}
+                  }
                , #{ id       => els_server
                   , start    => {els_server, start_link, [Transport]}
                   }

--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -1,11 +1,48 @@
 -module(els_text_synchronization).
 
+-include_lib("kernel/include/logger.hrl").
 -include("els_lsp.hrl").
 
--export([ did_open/1
+-export([ sync_mode/0
+        , did_change/1
+        , did_open/1
         , did_save/1
         , did_close/1
         ]).
+
+-spec sync_mode() -> text_document_sync_kind().
+sync_mode() ->
+  case els_config:get(incremental_sync) of
+    true  -> ?TEXT_DOCUMENT_SYNC_KIND_INCREMENTAL;
+    false -> ?TEXT_DOCUMENT_SYNC_KIND_FULL
+  end.
+
+-spec did_change(map()) -> ok.
+did_change(Params) ->
+  ContentChanges = maps:get(<<"contentChanges">>, Params),
+  TextDocument   = maps:get(<<"textDocument">>  , Params),
+  Uri            = maps:get(<<"uri">>           , TextDocument),
+  case ContentChanges of
+    [] ->
+      ok;
+    [Change] when not is_map_key(<<"range">>, Change) ->
+      %% Full text sync
+      #{<<"text">> := Text} = Change,
+      {Duration, ok} =
+        timer:tc(fun() -> els_indexing:index(Uri, Text, 'deep') end),
+      ?LOG_DEBUG("didChange FULLSYNC [size: ~p] [duration: ~pms]\n",
+                 [size(Text), Duration div 1000]),
+      ok;
+    ContentChanges ->
+      %% Incremental sync
+      ?LOG_DEBUG("didChange INCREMENTAL [changes: ~p]", [ContentChanges]),
+      Edits = [to_edit(Change) || Change <- ContentChanges],
+      {Duration, ok} =
+        timer:tc(fun() -> els_index_buffer:apply_edits_async(Uri, Edits) end),
+      ?LOG_DEBUG("didChange INCREMENTAL [duration: ~pms]\n",
+                 [Duration div 1000]),
+      ok
+  end.
 
 -spec did_open(map()) -> ok.
 did_open(Params) ->
@@ -19,9 +56,21 @@ did_open(Params) ->
 
 -spec did_save(map()) -> ok.
 did_save(Params) ->
+  TextDocument = maps:get(<<"textDocument">>, Params),
+  Uri          = maps:get(<<"uri">>         , TextDocument),
+  ok = els_index_buffer:flush(Uri),
   Provider = els_diagnostics_provider,
   els_provider:handle_request(Provider, {run_diagnostics, Params}),
   ok.
 
 -spec did_close(map()) -> ok.
 did_close(_Params) -> ok.
+
+-spec to_edit(map()) -> els_text:edit().
+to_edit(#{<<"text">> := Text, <<"range">> := Range}) ->
+  #{ <<"start">> := #{<<"character">> := FromC, <<"line">> := FromL}
+   , <<"end">> := #{<<"character">> := ToC, <<"line">> := ToL}
+   } = Range,
+  {#{ from => {FromL, FromC}
+    , to => {ToL, ToC}
+    }, els_utils:to_list(Text)}.

--- a/apps/els_lsp/test/els_text_SUITE.erl
+++ b/apps/els_lsp/test/els_text_SUITE.erl
@@ -1,0 +1,157 @@
+-module(els_text_SUITE).
+
+%% CT Callbacks
+-export([ suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        , groups/0
+        , all/0
+        ]).
+
+%% Test cases
+-export([ apply_edits_single_line/1
+        , apply_edits_multi_line/1
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+  [{timetrap, {seconds, 30}}].
+
+-spec all() -> [atom()].
+all() ->
+  [{group, tcp}, {group, stdio}].
+
+-spec groups() -> [atom()].
+groups() ->
+  els_test_utils:groups(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(_TestCase, Config) ->
+  Config.
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(_TestCase, Config) ->
+  Config.
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+apply_edits_single_line(_Config) ->
+  In = <<"a b c">>,
+  C = fun(FromC, ToC, Str) -> {#{from => {0, FromC}, to => {0, ToC}}, Str} end,
+  F = fun els_text:apply_edits/2,
+  ?assertEqual(<<"a b c">>, F(In, [])),
+  ?assertEqual(<<"a b c">>,   F(In, [C(0, 0, "")])),
+  ?assertEqual(<<"_a b c">>,  F(In, [C(0, 0, "_")])),
+  ?assertEqual(<<"_ b c">>,   F(In, [C(0, 1, "_")])),
+  ?assertEqual(<<"__ b c">>,  F(In, [C(0, 1, "__")])),
+  ?assertEqual(<<"__b c">>,   F(In, [C(0, 2, "__")])),
+  ?assertEqual(<<"a _ c">>,   F(In, [C(2, 3, "_")])),
+  ?assertEqual(<<"c">>,       F(In, [C(0, 4, "")])),
+  ?assertEqual(<<"a">>,       F(In, [C(1, 5, "")])),
+  ?assertEqual(<<"">>,        F(In, [C(0, 5, "")])),
+  ?assertEqual(<<"a b c!">>,  F(In, [C(5, 5, "!")])),
+  ?assertEqual(<<>>,          F(<<>>, [ C(0, 0, "")
+                                      , C(0, 0, "")
+                                      ])),
+  ?assertEqual(<<"cba">>,     F(<<>>, [ C(0, 0, "a")
+                                      , C(0, 0, "b")
+                                      , C(0, 0, "c")
+                                      ])),
+  ?assertEqual(<<"abc">>,     F(<<>>, [ C(0, 0, "c")
+                                      , C(0, 0, "b")
+                                      , C(0, 0, "a")
+                                      ])),
+  ?assertEqual(<<"ab">>,      F(In, [ C(0, 0, "a")
+                                    , C(1, 6, "")
+                                    , C(1, 1, "b")
+                                    ])),
+  ?assertEqual(<<"aba b c">>, F(In, [ C(0, 0, "a")
+                                    , C(1, 1, "b")
+                                    ])),
+  ?assertEqual(<<"_ c!">>,    F(In, [ C(0, 3, "")
+                                    , C(0, 0, "_")
+                                    , C(3, 3, "!")
+                                    ])),
+  ok.
+
+apply_edits_multi_line(_Config) ->
+  In = <<"a b c\n"
+         "d e f\n"
+         "g h i\n">>,
+  C = fun(FromL, FromC, ToL, ToC, Str) ->
+          {#{from => {FromL, FromC}, to => {ToL, ToC}}, Str}
+      end,
+  F = fun els_text:apply_edits/2,
+  ?assertEqual(In,              F(In, [])),
+  ?assertEqual(In,              F(In, [C(0, 0, 0, 0, "")])),
+  ?assertEqual(<<"_ b c\n",
+                    "d e f\n",
+                    "g h i\n">>,   F(In, [C(0, 0, 0, 1, "_")])),
+  ?assertEqual(<<"_a b c\n",
+                    "d e f\n",
+                    "g h i\n">>,   F(In, [C(0, 0, 0, 0, "_")])),
+  ?assertEqual(<<"a b c\n",
+                    "_d e f\n",
+                    "g h i\n">>,   F(In, [C(1, 0, 1, 0, "_")])),
+  ?assertEqual(<<"a b c\n",
+                    "d e f\n",
+                    "_g h i\n">>,  F(In, [C(2, 0, 2, 0, "_")])),
+  ?assertEqual(<<"a b c\n",
+                    "d e f\n",
+                    "g h i_\n">>,  F(In, [C(2, 5, 2, 5, "_")])),
+  ?assertEqual(<<"a b c\n",
+                    "d e f\n",
+                    "g h _\n">>,   F(In, [C(2, 4, 2, 5, "_")])),
+  ?assertEqual(<<"a b c\n",
+                    "d e f\n",
+                    "g _ i\n">>,   F(In, [C(2, 2, 2, 3, "_")])),
+  ?assertEqual(<<"a b c\n",
+                    "d e f\n",
+                    "g h i\n",
+                    "_">>,         F(In, [C(3, 0, 3, 0, "_")])),
+  ?assertEqual(<<"_">>,         F(In, [C(0, 0, 3, 0, "_")])),
+  ?assertEqual(<<"a b _\n",
+                    "d e _\n",
+                    "g h _\n">>,   F(In, [ C(0, 4, 0, 5, "_")
+                                         , C(1, 4, 1, 5, "_")
+                                         , C(2, 4, 2, 5, "_")
+                                         ])),
+  ?assertEqual(<<"a b c\n",
+                    "g h i\n">>,   F(In, [C(1, 0, 2, 0, "")])),
+  ?assertEqual(<<"a b h i\n">>, F(In, [C(0, 3, 2, 1, "")])),
+  ?assertEqual(<<"a b _ i\n">>, F(In, [ C(0, 3, 2, 1, "")
+                                      , C(0, 4, 0, 5, "_")
+                                      ])),
+  ?assertEqual(<<"a b h _\n">>, F(In, [ C(0, 3, 2, 1, "")
+                                      , C(0, 6, 0, 7, "_")
+                                      ])),
+  ?assertEqual(<<"a ba\n",
+                    "_\nc\n",
+                    " h i\n">>,    F(In, [ C(0, 3, 2, 1, "a\nb\nc\n")
+                                         , C(1, 0, 1, 1, "_")
+                                         ])),
+  ok.

--- a/elvis.config
+++ b/elvis.config
@@ -23,7 +23,7 @@
                                                                          , els_references_SUITE
                                                                          , els_dap_general_provider_SUITE
                                                                          ]
-                                                             , min_complexity => 10}}
+                                                             , min_complexity => 20}}
                       , {elvis_style, invalid_dynamic_call, #{ignore => [ els_compiler_diagnostics
                                                                         , els_server
                                                                         , els_dap_server


### PR DESCRIPTION
### Description

Implement support for incremental text synchronization.
This should improve the experience when editing large files since we no longer need to transmit the entire text buffer for every change, instead a set of changes are submitted and applied.
To avoid triggering indexing for every update I've added `els_index_buffer` which will accumulate changes and index the accumulated result of the changes.

This feature is disabled by default but can be enabled by adding the follwing line to erlang_ls.config:
```yaml
incremental_sync: true
```

I've only tested these changes with Emacs lsp-mode.
Would be great if people with other editor setups could also test it out.
