### PR TITLE
Show how to install erlang_ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Compile the project:
 
     make
 
-Install erlang_ls built by `make`:
+To install the produced `erlang_ls` escript in `/usr/local/bin`:
 
     make install
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Compile the project:
 
     make
 
+Install erlang_ls built by `make`:
+
+    make install
+
 ## Command-line Arguments
 
 These are the command-line arguments that can be provided to the


### PR DESCRIPTION
### Description

Add missing description to show how to install erlang_ls once `make` was done.


