### PR TITLE
Allow renaming function when pointing at function reference

### DIFF
--- a/apps/els_lsp/src/els_rename_provider.erl
+++ b/apps/els_lsp/src/els_rename_provider.erl
@@ -58,7 +58,9 @@ workspace_edits(Uri, [#{kind := 'define'} = POI| _], NewName) ->
 workspace_edits(Uri, [#{kind := Kind} = POI| _], NewName)
   when Kind =:= macro;
        Kind =:= application;
-       Kind =:= implicit_fun ->
+       Kind =:= implicit_fun;
+       Kind =:= export_entry;
+       Kind =:= import_entry ->
   case els_code_navigation:goto_definition(Uri, POI) of
     {ok, DefUri, DefPOI} ->
       #{changes => changes(DefUri, DefPOI, NewName)};

--- a/apps/els_lsp/src/els_rename_provider.erl
+++ b/apps/els_lsp/src/els_rename_provider.erl
@@ -55,7 +55,10 @@ workspace_edits(Uri, [#{kind := function_clause} = POI| _], NewName) ->
   #{changes => changes(Uri, POI#{kind => function, id => {F, A}}, NewName)};
 workspace_edits(Uri, [#{kind := 'define'} = POI| _], NewName) ->
   #{changes => changes(Uri, POI, NewName)};
-workspace_edits(Uri, [#{kind := 'macro'} = POI| _], NewName) ->
+workspace_edits(Uri, [#{kind := Kind} = POI| _], NewName)
+  when Kind =:= macro;
+       Kind =:= application;
+       Kind =:= implicit_fun ->
   case els_code_navigation:goto_definition(Uri, POI) of
     {ok, DefUri, DefPOI} ->
       #{changes => changes(DefUri, DefPOI, NewName)};

--- a/apps/els_lsp/test/els_rename_SUITE.erl
+++ b/apps/els_lsp/test/els_rename_SUITE.erl
@@ -19,6 +19,8 @@
         , rename_function/1
         , rename_function_quoted_atom/1
         , rename_function_clause/1
+        , rename_function_application/1
+        , rename_function_implicit_fun/1
         , rename_parametrized_macro/1
         , rename_macro_from_usage/1
         ]).
@@ -233,6 +235,64 @@ rename_function_clause(Config) ->
   Char = 2,
   NewName = <<"new_function">>,
   #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
+  Expected = #{changes =>
+                 #{binary_to_atom(Uri, utf8) =>
+                     [ change(NewName, {12, 23}, {12, 26})
+                     , change(NewName, {13, 10}, {13, 13})
+                     , change(NewName, {15, 27}, {15, 30})
+                     , change(NewName, {17, 11}, {17, 14})
+                     , change(NewName, {18, 2}, {18, 5})
+                     , change(NewName, {1, 9}, {1, 12})
+                     , change(NewName, {3, 6}, {3, 9})
+                     , change(NewName, {4, 0}, {4, 3})
+                     , change(NewName, {6, 0}, {6, 3})
+                     , change(NewName, {8, 0}, {8, 3})
+                     ],
+                   binary_to_atom(ImportUri, utf8) =>
+                     [ change(NewName, {7, 18}, {7, 21})
+                     , change(NewName, {2, 26}, {2, 29})
+                     , change(NewName, {6, 2}, {6, 5})
+                     ]}},
+  assert_changes(Expected, Result).
+
+-spec rename_function_application(config()) -> ok.
+rename_function_application(Config) ->
+  Uri = ?config(rename_function_uri, Config),
+  ImportUri = ?config(rename_function_import_uri, Config),
+  Line = 7,
+  Char = 18,
+  NewName = <<"new_function">>,
+  #{result := Result} =
+    els_client:document_rename(ImportUri, Line, Char, NewName),
+  Expected = #{changes =>
+                 #{binary_to_atom(Uri, utf8) =>
+                     [ change(NewName, {12, 23}, {12, 26})
+                     , change(NewName, {13, 10}, {13, 13})
+                     , change(NewName, {15, 27}, {15, 30})
+                     , change(NewName, {17, 11}, {17, 14})
+                     , change(NewName, {18, 2}, {18, 5})
+                     , change(NewName, {1, 9}, {1, 12})
+                     , change(NewName, {3, 6}, {3, 9})
+                     , change(NewName, {4, 0}, {4, 3})
+                     , change(NewName, {6, 0}, {6, 3})
+                     , change(NewName, {8, 0}, {8, 3})
+                     ],
+                   binary_to_atom(ImportUri, utf8) =>
+                     [ change(NewName, {7, 18}, {7, 21})
+                     , change(NewName, {2, 26}, {2, 29})
+                     , change(NewName, {6, 2}, {6, 5})
+                     ]}},
+  assert_changes(Expected, Result).
+
+-spec rename_function_implicit_fun(config()) -> ok.
+rename_function_implicit_fun(Config) ->
+  Uri = ?config(rename_function_uri, Config),
+  ImportUri = ?config(rename_function_import_uri, Config),
+  Line = 13,
+  Char = 10,
+  NewName = <<"new_function">>,
+  #{result := Result} =
+    els_client:document_rename(Uri, Line, Char, NewName),
   Expected = #{changes =>
                  #{binary_to_atom(Uri, utf8) =>
                      [ change(NewName, {12, 23}, {12, 26})

--- a/apps/els_lsp/test/els_rename_SUITE.erl
+++ b/apps/els_lsp/test/els_rename_SUITE.erl
@@ -18,9 +18,6 @@
         , rename_variable/1
         , rename_function/1
         , rename_function_quoted_atom/1
-        , rename_function_clause/1
-        , rename_function_application/1
-        , rename_function_implicit_fun/1
         , rename_parametrized_macro/1
         , rename_macro_from_usage/1
         ]).
@@ -182,10 +179,19 @@ rename_macro(Config) ->
 rename_function(Config) ->
   Uri = ?config(rename_function_uri, Config),
   ImportUri = ?config(rename_function_import_uri, Config),
-  Line = 4,
-  Char = 2,
   NewName = <<"new_function">>,
-  #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
+  %% Function
+  #{result := Result} = els_client:document_rename(Uri, 4, 2, NewName),
+  %% Function clause
+  #{result := Result} = els_client:document_rename(Uri, 6, 2, NewName),
+  %% Application
+  #{result := Result} = els_client:document_rename(ImportUri, 7, 18, NewName),
+  %% Implicit fun
+  #{result := Result} = els_client:document_rename(Uri, 13, 10, NewName),
+  %% Export entry
+  #{result := Result} = els_client:document_rename(Uri, 1, 9, NewName),
+  %% Import entry
+  #{result := Result} = els_client:document_rename(ImportUri, 2, 26, NewName),
   Expected = #{changes =>
                  #{binary_to_atom(Uri, utf8) =>
                      [ change(NewName, {12, 23}, {12, 26})
@@ -224,92 +230,6 @@ rename_function_quoted_atom(Config) ->
                      , change(NewName, {21, 0}, {21, 13})
                      , change(NewName, {23, 0}, {23, 13})
                      , change(NewName, {25, 0}, {25, 13})
-                     ]}},
-  assert_changes(Expected, Result).
-
--spec rename_function_clause(config()) -> ok.
-rename_function_clause(Config) ->
-  Uri = ?config(rename_function_uri, Config),
-  ImportUri = ?config(rename_function_import_uri, Config),
-  Line = 6,
-  Char = 2,
-  NewName = <<"new_function">>,
-  #{result := Result} = els_client:document_rename(Uri, Line, Char, NewName),
-  Expected = #{changes =>
-                 #{binary_to_atom(Uri, utf8) =>
-                     [ change(NewName, {12, 23}, {12, 26})
-                     , change(NewName, {13, 10}, {13, 13})
-                     , change(NewName, {15, 27}, {15, 30})
-                     , change(NewName, {17, 11}, {17, 14})
-                     , change(NewName, {18, 2}, {18, 5})
-                     , change(NewName, {1, 9}, {1, 12})
-                     , change(NewName, {3, 6}, {3, 9})
-                     , change(NewName, {4, 0}, {4, 3})
-                     , change(NewName, {6, 0}, {6, 3})
-                     , change(NewName, {8, 0}, {8, 3})
-                     ],
-                   binary_to_atom(ImportUri, utf8) =>
-                     [ change(NewName, {7, 18}, {7, 21})
-                     , change(NewName, {2, 26}, {2, 29})
-                     , change(NewName, {6, 2}, {6, 5})
-                     ]}},
-  assert_changes(Expected, Result).
-
--spec rename_function_application(config()) -> ok.
-rename_function_application(Config) ->
-  Uri = ?config(rename_function_uri, Config),
-  ImportUri = ?config(rename_function_import_uri, Config),
-  Line = 7,
-  Char = 18,
-  NewName = <<"new_function">>,
-  #{result := Result} =
-    els_client:document_rename(ImportUri, Line, Char, NewName),
-  Expected = #{changes =>
-                 #{binary_to_atom(Uri, utf8) =>
-                     [ change(NewName, {12, 23}, {12, 26})
-                     , change(NewName, {13, 10}, {13, 13})
-                     , change(NewName, {15, 27}, {15, 30})
-                     , change(NewName, {17, 11}, {17, 14})
-                     , change(NewName, {18, 2}, {18, 5})
-                     , change(NewName, {1, 9}, {1, 12})
-                     , change(NewName, {3, 6}, {3, 9})
-                     , change(NewName, {4, 0}, {4, 3})
-                     , change(NewName, {6, 0}, {6, 3})
-                     , change(NewName, {8, 0}, {8, 3})
-                     ],
-                   binary_to_atom(ImportUri, utf8) =>
-                     [ change(NewName, {7, 18}, {7, 21})
-                     , change(NewName, {2, 26}, {2, 29})
-                     , change(NewName, {6, 2}, {6, 5})
-                     ]}},
-  assert_changes(Expected, Result).
-
--spec rename_function_implicit_fun(config()) -> ok.
-rename_function_implicit_fun(Config) ->
-  Uri = ?config(rename_function_uri, Config),
-  ImportUri = ?config(rename_function_import_uri, Config),
-  Line = 13,
-  Char = 10,
-  NewName = <<"new_function">>,
-  #{result := Result} =
-    els_client:document_rename(Uri, Line, Char, NewName),
-  Expected = #{changes =>
-                 #{binary_to_atom(Uri, utf8) =>
-                     [ change(NewName, {12, 23}, {12, 26})
-                     , change(NewName, {13, 10}, {13, 13})
-                     , change(NewName, {15, 27}, {15, 30})
-                     , change(NewName, {17, 11}, {17, 14})
-                     , change(NewName, {18, 2}, {18, 5})
-                     , change(NewName, {1, 9}, {1, 12})
-                     , change(NewName, {3, 6}, {3, 9})
-                     , change(NewName, {4, 0}, {4, 3})
-                     , change(NewName, {6, 0}, {6, 3})
-                     , change(NewName, {8, 0}, {8, 3})
-                     ],
-                   binary_to_atom(ImportUri, utf8) =>
-                     [ change(NewName, {7, 18}, {7, 21})
-                     , change(NewName, {2, 26}, {2, 29})
-                     , change(NewName, {6, 2}, {6, 5})
                      ]}},
   assert_changes(Expected, Result).
 


### PR DESCRIPTION
### Description

Previously functions could only be renamed when pointing at the definition, now a function can be renamed when  pointing at a reference too.
