### PR TITLE
Properly extract line number from dialyzer warning

### DIFF
--- a/apps/els_lsp/src/els_dialyzer_diagnostics.erl
+++ b/apps/els_lsp/src/els_dialyzer_diagnostics.erl
@@ -66,9 +66,10 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec diagnostic({any(), {any(), integer()}, any()}) ->
+-spec diagnostic({any(), {any(), erl_anno:anno()}, any()}) ->
         els_diagnostics:diagnostic().
-diagnostic({_, {_, Line}, _} = Warning) ->
+diagnostic({_, {_, Anno}, _} = Warning) ->
+  Line     = erl_anno:line(Anno),
   Range    = els_protocol:range(#{ from => {Line, 1}
                                  , to   => {Line + 1, 1}
                                  }),


### PR DESCRIPTION
### Description
Dialyzer diagnostics crashes with bad arith on OTP 24.

Seems like this was broken in OTP 24 as the warning now returns a line and
column. Use `erl_anno:line/1` which will handle both `Line` and `{Line, Col}`

Side note: Seems like there are no tests for dialyzer diagnostics.