### PR TITLE
Fix navigation to macros with overloaded arity

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/code_navigation.erl
+++ b/apps/els_lsp/priv/code_navigation/src/code_navigation.erl
@@ -16,7 +16,7 @@
 -record(record_a, {field_a, field_b, 'Field C'}).
 
 -define(MACRO_A, macro_a).
--define(MACRO_WITH_ARGS(X), erlang:display(X)).
+-define(MACRO_A(X), erlang:display(X)).
 
 function_a() ->
   function_b(),
@@ -37,7 +37,7 @@ function_c() ->
 -type type_a() :: any().
 
 function_d() ->
-  ?MACRO_WITH_ARGS(d).
+  ?MACRO_A(d).
 
 function_e() ->
   ?assertEqual(2.0, 4/2).

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -687,10 +687,16 @@ completion_item(#{kind := Kind = record, id := Name}, Data, _) ->
    , data             => Data
    };
 completion_item(#{kind := Kind = define, id := Name}, Data, _) ->
-  #{ label            => atom_to_binary(Name, utf8)
+  #{ label            => macro_label(Name)
    , kind             => completion_item_kind(Kind)
    , data             => Data
    }.
+
+-spec macro_label(atom() | {atom(), non_neg_integer()}) -> binary().
+macro_label({Name, Arity}) ->
+  els_utils:to_binary(io_lib:format("~ts/~p", [Name, Arity]));
+macro_label(Name) ->
+  atom_to_binary(Name, utf8).
 
 -spec snippet_function_call(atom(), [{integer(), string()}]) -> binary().
 snippet_function_call(Function, Args0) ->

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -587,22 +587,32 @@ macros(Config) ->
   TriggerKindInvoked = ?COMPLETION_TRIGGER_KIND_INVOKED,
   Expected = [ #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT
                 , label => <<"INCLUDED_MACRO_A">>
+                , insertText => <<"INCLUDED_MACRO_A">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , data => #{}
                 }
              , #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT
                 , label => <<"MACRO_A">>
+                , insertText => <<"MACRO_A">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , data => #{}
                 }
              , #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT
                 , label => <<"MACRO_A/1">>
+                , insertText => <<"MACRO_A(${1:X})">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , data => #{}
                 }
              , #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT
                 , label => <<"macro_A">>
+                , insertText => <<"macro_A">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , data => #{}
                 }
              , #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT
                 , label => <<"MACRO_FOR_TRANSITIVE_INCLUSION">>
+                , insertText => <<"MACRO_FOR_TRANSITIVE_INCLUSION">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , data => #{}
                 }
              ],

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -594,7 +594,7 @@ macros(Config) ->
                 , data => #{}
                 }
              , #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT
-                , label => <<"MACRO_WITH_ARGS">>
+                , label => <<"MACRO_A/1">>
                 , data => #{}
                 }
              , #{ kind => ?COMPLETION_ITEM_KIND_CONSTANT

--- a/apps/els_lsp/test/els_definition_SUITE.erl
+++ b/apps/els_lsp/test/els_definition_SUITE.erl
@@ -287,7 +287,7 @@ macro_with_args(Config) ->
   Def = els_client:definition(Uri, 40, 9),
   #{result := #{range := Range, uri := DefUri}} = Def,
   ?assertEqual(Uri, DefUri),
-  ?assertEqual( els_protocol:range(#{from => {19, 9}, to => {19, 24}})
+  ?assertEqual( els_protocol:range(#{from => {19, 9}, to => {19, 16}})
               , Range),
   ok.
 

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -74,13 +74,13 @@ parse_invalid_code(_Config) ->
 
 -spec underscore_macro(config()) -> ok.
 underscore_macro(_Config) ->
-  ?assertMatch({ok, [#{id := '_', kind := define} | _]},
+  ?assertMatch({ok, [#{id := {'_', 1}, kind := define} | _]},
                els_parser:parse("-define(_(Text), gettexter:gettext(Text)).")),
   ?assertMatch({ok, [#{id := '_', kind := define} | _]},
                els_parser:parse("-define(_, smth).")),
   ?assertMatch({ok, [#{id := '_', kind := macro}]},
                els_parser:parse("?_.")),
-  ?assertMatch({ok, [#{id := '_', kind := macro} | _]},
+  ?assertMatch({ok, [#{id := {'_', 1}, kind := macro} | _]},
                els_parser:parse("?_(ok).")),
   ok.
 
@@ -185,7 +185,7 @@ assert_recursive_types(Text) ->
 
 -spec callback_macro(config()) -> ok.
 callback_macro(_Config) ->
-  Text = "-callback foo() -> ?M().",
+  Text = "-callback foo() -> ?M.",
   ?assertMatch([_], parse_find_pois(Text, callback, {foo, 0})),
   ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
   ok.
@@ -194,27 +194,28 @@ callback_macro(_Config) ->
 spec_macro(_Config) ->
   Text = "-spec foo() -> ?M().",
   ?assertMatch([_], parse_find_pois(Text, spec, {foo, 0})),
-  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ?assertMatch([_], parse_find_pois(Text, macro, {'M', 0})),
   ok.
 
 -spec type_macro(config()) -> ok.
 type_macro(_Config) ->
-  Text = "-type t() :: ?M(a, b).",
+  Text = "-type t() :: ?M(a, b, c).",
   ?assertMatch([_], parse_find_pois(Text, type_definition, {t, 0})),
-  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ?assertMatch([_], parse_find_pois(Text, macro, {'M', 3})),
   ok.
 
 -spec opaque_macro(config()) -> ok.
 opaque_macro(_Config) ->
   Text = "-opaque o() :: ?M(a, b).",
   ?assertMatch([_], parse_find_pois(Text, type_definition, {o, 0})),
-  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ?assertMatch([_], parse_find_pois(Text, macro, {'M', 2})),
   ok.
 
 -spec wild_attrbibute_macro(config()) -> ok.
 wild_attrbibute_macro(_Config) ->
+  %% This is parsed as -(?M(foo)), rather than -(?M)(foo)
   Text = "-?M(foo).",
-  ?assertMatch([_], parse_find_pois(Text, macro, 'M')),
+  ?assertMatch([_], parse_find_pois(Text, macro, {'M', 1})),
   ?assertMatch([_], parse_find_pois(Text, atom, foo)),
   ok.
 


### PR DESCRIPTION
Macro name should be identified by both name & arity (if available).
Macros can be overloaded on arity. Currently, if that happens, the
navigation is incorrect and points to the first definition with
particular name, regardless of the actual arity.