### PR TITLE
Fix find references for included types

### DIFF
--- a/apps/els_lsp/priv/code_navigation/include/definition.hrl
+++ b/apps/els_lsp/priv/code_navigation/include/definition.hrl
@@ -1,1 +1,2 @@
 -define(MACRO_FOR_TRANSITIVE_INCLUSION, true).
+-type type_b() :: any().

--- a/apps/els_lsp/priv/code_navigation/src/code_navigation_types.erl
+++ b/apps/els_lsp/priv/code_navigation/src/code_navigation_types.erl
@@ -9,3 +9,7 @@
 -export_type([ opaque_type_a/0 ]).
 
 -type user_type_a() :: type_a() | opaque_type_a().
+
+-include("transitive.hrl").
+
+-type user_type_b() :: type_b().

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -731,6 +731,12 @@ types(Config) ->
                 , label            => <<"'INCLUDED_TYPE'/1">>
                 , data             => #{}
                 }
+             , #{ insertText       => <<"type_b()">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                , kind             => ?COMPLETION_ITEM_KIND_TYPE_PARAM
+                , label            => <<"type_b/0">>
+                , data             => #{}
+                }
              ],
 
   DefaultCompletion = els_completion_provider:keywords()
@@ -752,7 +758,17 @@ types_export_list(Config) ->
   Uri = ?config(code_navigation_types_uri, Config),
   Expected = [ #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
                 , kind             => ?COMPLETION_ITEM_KIND_TYPE_PARAM
+                , label            => <<"type_b/0">>
+                , data             => #{}
+                }
+             , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                , kind             => ?COMPLETION_ITEM_KIND_TYPE_PARAM
                 , label            => <<"user_type_a/0">>
+                , data             => #{}
+                }
+             , #{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                , kind             => ?COMPLETION_ITEM_KIND_TYPE_PARAM
+                , label            => <<"user_type_b/0">>
                 , data             => #{}
                 }
              ],

--- a/apps/els_lsp/test/els_references_SUITE.erl
+++ b/apps/els_lsp/test/els_references_SUITE.erl
@@ -31,6 +31,7 @@
         , purge_references/1
         , type_local/1
         , type_remote/1
+        , type_included/1
         ]).
 
 %%==============================================================================
@@ -470,6 +471,22 @@ type_remote(Config) ->
 
   assert_locations(Locations, ExpectedLocations),
 
+  ok.
+
+-spec type_included(config()) -> ok.
+type_included(Config) ->
+  UriTypes = ?config(code_navigation_types_uri, Config),
+  UriHeader = ?config(definition_h_uri, Config),
+
+  ExpectedLocations = [ #{ uri   => UriTypes
+                         , range => #{from => {15, 24}, to => {15, 30}}
+                         }
+                      ],
+  ct:comment("Find references for type_b from a remote usage"),
+  #{result := Locations} = els_client:references(UriTypes, 15, 25),
+  ct:comment("Find references for type_b from definition"),
+  #{result := Locations} = els_client:references(UriHeader, 2, 7),
+  assert_locations(Locations, ExpectedLocations),
   ok.
 
 %%==============================================================================


### PR DESCRIPTION
### Description

Finding references of type definitions in header files didn't show references in source files that included the header.
This should now be fixed.

Based on the similar fixes for records in #1001.
