### PR TITLE
Allow config files to be called erlang_ls.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage: Erlang LS [-v] [-t [<transport>]] [-p [<port>]] [-d [<log_dir>]]
 ## Configuration
 
 It is possible to customize the behaviour of the `erlang_ls` server
-via a configuration file, named `erlang_ls.config` or `erlang_ls.yml`.
+via a configuration file, named `erlang_ls.config` or `erlang_ls.yaml`.
 That file should be placed in the root directory of a
 given project to store the configuration for that project. It is also
 possible to store a system-wide default configuration, which is shared

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Usage: Erlang LS [-v] [-t [<transport>]] [-p [<port>]] [-d [<log_dir>]]
 ## Configuration
 
 It is possible to customize the behaviour of the `erlang_ls` server
-via a configuration file, named `erlang_ls.config`. The
-`erlang_ls.config` file should be placed in the root directory of a
+via a configuration file, named `erlang_ls.config` or `erlang_ls.yml`.
+That file should be placed in the root directory of a
 given project to store the configuration for that project. It is also
 possible to store a system-wide default configuration, which is shared
 across multiple projects.

--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -24,7 +24,7 @@
 %% Macros
 %%==============================================================================
 -define(DEFAULT_CONFIG_FILE, "erlang_ls.config").
--define(ALTERNATIVE_CONFIG_FILE, "erlang_ls.yml").
+-define(ALTERNATIVE_CONFIG_FILE, "erlang_ls.yaml").
 -define( DEFAULT_EXCLUDED_OTP_APPS
        , [ "megaco"
          , "diameter"

--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -24,6 +24,7 @@
 %% Macros
 %%==============================================================================
 -define(DEFAULT_CONFIG_FILE, "erlang_ls.config").
+-define(ALTERNATIVE_CONFIG_FILE, "erlang_ls.yml").
 -define( DEFAULT_EXCLUDED_OTP_APPS
        , [ "megaco"
          , "diameter"
@@ -110,7 +111,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
 
   %% Passed by the LSP client
   ok = set(root_uri       , RootUri),
-  %% Read from the erlang_ls.config file
+  %% Read from the configuration file
   ok = set(config_path    , ConfigPath),
   ok = set(otp_path       , OtpPath),
   ok = set(deps_dirs      , DepsDirs),
@@ -196,13 +197,18 @@ config_paths(RootPath, _Config) ->
 default_config_paths(RootPath) ->
   GlobalConfigDir = filename:basedir(user_config, "erlang_ls"),
   [ filename:join([RootPath, ?DEFAULT_CONFIG_FILE])
+  , filename:join([RootPath, ?ALTERNATIVE_CONFIG_FILE])
   , filename:join([GlobalConfigDir, ?DEFAULT_CONFIG_FILE])
+  , filename:join([GlobalConfigDir, ?ALTERNATIVE_CONFIG_FILE])
   ].
 
 %% @doc Bare `Path' as well as with default config file name suffix.
 -spec possible_config_paths(path()) -> [path()].
 possible_config_paths(Path) ->
-  [ Path, filename:join([Path, ?DEFAULT_CONFIG_FILE]) ].
+  [ Path
+  , filename:join([Path, ?DEFAULT_CONFIG_FILE])
+  , filename:join([Path, ?ALTERNATIVE_CONFIG_FILE])
+  ].
 
 -spec consult_config([path()]) -> {undefined|path(), map()}.
 consult_config([]) -> {undefined, #{}};


### PR DESCRIPTION
### Description

This PR allows erlang-ls users to call their configuration files `erlang_ls.yml` instead of `erlang_ls.config` to avoid mixing them up with config files, as in AdRoll/rebar3_format#259