### PR TITLE
[dap] support "attach"

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -452,7 +452,8 @@ handle_request({<<"disconnect">>, _Params}
       els_dap_rpc:no_break(ProjectNode),
       [els_dap_rpc:continue(ProjectNode, Pid) ||
         {_ThreadID, #{pid := Pid}} <- maps:to_list(Threads)],
-      [els_dap_rpc:n(ProjectNode, Module) || Module <- els_dap_rpc:interpreted(ProjectNode)];
+      [els_dap_rpc:n(ProjectNode, Module) ||
+        Module <- els_dap_rpc:interpreted(ProjectNode)];
     <<"launch">> ->
       els_dap_rpc:halt(ProjectNode)
   end,

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -452,7 +452,7 @@ handle_request({<<"disconnect">>, _Params}
       els_dap_rpc:no_break(ProjectNode),
       [els_dap_rpc:continue(ProjectNode, Pid) ||
         {_ThreadID, #{pid := Pid}} <- maps:to_list(Threads)],
-      [els_dap_rpc:n(Module) || Module <- els_dap_rpc:interpreted()];
+      [els_dap_rpc:n(ProjectNode, Module) || Module <- els_dap_rpc:interpreted(ProjectNode)];
     <<"launch">> ->
       els_dap_rpc:halt(ProjectNode)
   end,

--- a/apps/els_dap/src/els_dap_rpc.erl
+++ b/apps/els_dap/src/els_dap_rpc.erl
@@ -1,6 +1,8 @@
 -module(els_dap_rpc).
 
--export([ all_breaks/1
+-export([ interpreted/1
+        , n/2
+        , all_breaks/1
         , all_breaks/2
         , auto_attach/3
         , break/3
@@ -22,6 +24,14 @@
         , stack_trace/2
         , step/2
         ]).
+
+-spec interpreted(node()) -> any().
+interpreted(Node) ->
+  rpc:call(Node, int, interpreted, []).
+
+-spec n(node(), any()) -> any().
+n(Node, Module) ->
+  rpc:call(Node, int, n, [Module]).
 
 -spec all_breaks(node()) -> any().
 all_breaks(Node) ->


### PR DESCRIPTION
Different from "launch" which will start a shell, "attach" will attach to an existing shell.
See https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Attach

### Description

Add handle_request for "attach"
Change handle_request for "disconnect" if it was "attach" don't stop the node, only stop breakpoints.

Tests see comment.

Fixes # .
