### PR TITLE
Fix file path on Windows

### DIFF
--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -40,7 +40,7 @@ path(Uri) ->
     {true, <<>>} ->
       % Windows drive letter, have to strip the initial slash
       re:replace(
-        Path, "^/([a-zA-Z]:)(.*)", "\\1\\2", [{return, binary}]
+        Path, "^/([a-zA-Z])(:|%3A)(.*)", "\\1:\\3", [{return, binary}]
       );
     {true, _} ->
       <<"//", Host/binary, Path/binary>>;


### PR DESCRIPTION
### Description

Fix file path on Windows, replace `%3A` to `:`.

Fixes #963 and https://github.com/erlang-ls/vscode/issues/54 .
