### PR TITLE
Prevent infinite recursion when enumerating document POIs

### DIFF
--- a/apps/els_lsp/priv/code_navigation/include/transitive.hrl
+++ b/apps/els_lsp/priv/code_navigation/include/transitive.hrl
@@ -1,1 +1,7 @@
+-ifndef(__TRANSITIVE_H__).
+-define(__TRANSITIVE_H__, included).
+
+-include("transitive.hrl").
 -include("definition.hrl").
+
+-endif.

--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -25,6 +25,7 @@
         , pois/1
         , pois/2
         , get_element_at_pos/3
+        , uri/1
         ]).
 
 %%==============================================================================
@@ -162,3 +163,8 @@ get_element_at_pos(Item, Line, Column) ->
   POIs = pois(Item),
   MatchedPOIs = els_poi:match_pos(POIs, {Line, Column}),
   els_poi:sort(MatchedPOIs).
+
+%% @doc Returns the URI of the current document
+-spec uri(item()) -> uri().
+uri(#{ uri := Uri }) ->
+  Uri.

--- a/apps/els_lsp/src/els_fungraph.erl
+++ b/apps/els_lsp/src/els_fungraph.erl
@@ -1,0 +1,45 @@
+-module(els_fungraph).
+
+-type id_fun(NodeT) :: fun((NodeT) -> _NodeID).
+-type edges_fun(NodeT) :: fun((NodeT) -> list(NodeT)).
+
+-opaque graph(NodeT) :: {?MODULE, id_fun(NodeT), edges_fun(NodeT)}.
+
+-export_type([graph/1]).
+
+-export([new/2]).
+-export([traverse/4]).
+
+-spec new(id_fun(NodeT), edges_fun(NodeT)) -> graph(NodeT).
+new(IdFun, EdgesFun) ->
+  {?MODULE, IdFun, EdgesFun}.
+
+-type acc_fun(NodeT, AccT) ::
+  fun((_Node :: NodeT, _From :: NodeT, AccT) -> AccT).
+
+-spec traverse(acc_fun(NodeT, AccT), AccT, NodeT, graph(NodeT)) -> AccT.
+traverse(AccFun, Acc, From, G) ->
+  traverse(AccFun, Acc, [From], sets:new(), G).
+
+-spec traverse(acc_fun(NodeT, AccT), AccT, [NodeT], sets:set(), graph(NodeT)) ->
+  AccT.
+traverse(AccFun, Acc, [Node | Rest], Visited, G = {?MODULE, IdFun, EdgesFun}) ->
+  {AdjacentNodes, VisitedNext} = lists:foldr(
+    fun(Adjacent, {NodesAcc, VisitedAcc}) ->
+      ID = IdFun(Adjacent),
+      case sets:is_element(ID, VisitedAcc) of
+        false -> {[Adjacent | NodesAcc], sets:add_element(ID, VisitedAcc)};
+        true -> {NodesAcc, VisitedAcc}
+      end
+    end,
+    {[], Visited},
+    EdgesFun(Node)
+  ),
+  AccNext = lists:foldl(
+    fun(Adjacent, AccIn) -> AccFun(Adjacent, Node, AccIn) end,
+    Acc,
+    AdjacentNodes
+  ),
+  traverse(AccFun, AccNext, AdjacentNodes ++ Rest, VisitedNext, G);
+traverse(_AccFun, Acc, [], _Visited, _G) ->
+  Acc.

--- a/apps/els_lsp/test/els_fungraph_SUITE.erl
+++ b/apps/els_lsp/test/els_fungraph_SUITE.erl
@@ -1,0 +1,31 @@
+-module(els_fungraph_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0]).
+
+-export([dense_graph_traversal/1]).
+
+-spec all() -> [atom()].
+all() ->
+  [dense_graph_traversal].
+
+-spec dense_graph_traversal(_Config) -> ok.
+dense_graph_traversal(_) ->
+  MaxID = 40,
+  % Visited nodes must be unique
+  ?assertEqual(
+    lists:reverse(lists:seq(1, MaxID)),
+    els_fungraph:traverse(
+      fun(ID, _From, Acc) -> [ID | Acc] end,
+      [],
+      1,
+      els_fungraph:new(
+        fun(ID) -> ID end,
+        fun(ID) ->
+          % Each node has edges to nodes in range [ID; ID * 2]
+          [NextID || NextID <- lists:seq(ID, ID * 2), NextID =< MaxID]
+        end
+      )
+    )
+  ).


### PR DESCRIPTION
### Description

Before this commit recursion in `els_scope:included_pois/2` might become infinite. This can happen for a couple of reasons:
* header mistakenly includes itself,
* header ends up including itself transitively, though inclusion is guarded with `ifndef` and `define` to prevent compiler from
  complaining.
* header includes another header with exactly same filename but  located in a different directory, yet from the point of view of  `els_utils:find_header/1` it's the same header.

This commit introduces simple abstract functional graph concept with traversals over set of nodes reachable from a given node and employs it to gather all POIs reachable through inclusion in the `els_scope` module.