### PR TITLE
[dap] dummy handler for pause

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -365,6 +365,12 @@ handle_request( {<<"next">>, Params}
   Pid = to_pid(ThreadId, Threads),
   ok = els_dap_rpc:next(ProjectNode, Pid),
   {#{}, State};
+handle_request( {<<"pause">>, _}
+              , State
+              ) ->
+  %% pause is not supported by the OTP debugger
+  %% but we cannot disable it in the UI either
+  {#{}, State};
 handle_request( {<<"continue">>, Params}
               , #{ threads := Threads
                  , project_node := ProjectNode


### PR DESCRIPTION
### Description

Clients may send a pause request, and there is no capability that negotiates these. The OTP debugger does not have a notion of pausing a running execution and the DAP currently crashes when someone presses pause.

This implements a noop pause handling.
