### PR TITLE
Fix regression: completion for incomplete export enrty

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/completion_incomplete.erl
+++ b/apps/els_lsp/priv/code_navigation/src/completion_incomplete.erl
@@ -1,0 +1,11 @@
+-module(completion_incomplete).
+
+-export([ function_exported/0
+        , function_
+        ]).
+
+function_exported() ->
+  ok.
+
+function_unexported() ->
+  ok.

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -14,6 +14,7 @@
         , attribute_include/1
         , attribute_include_lib/1
         , attribute_export/1
+        , attribute_export_incomplete/1
         , attribute_export_type/1
         , default_completions/1
         , empty_completions/1
@@ -269,6 +270,36 @@ attribute_export(Config) ->
                 ],
   #{result := Completions} =
     els_client:completion(Uri, 5, 10, TriggerKindInvoked, <<"">>),
+  [?assert(lists:member(E, Completions)) || E <- Expected],
+  [?assertNot(lists:member(E, Completions)) || E <- NotExpected],
+  ok.
+
+-spec attribute_export_incomplete(config()) -> ok.
+attribute_export_incomplete(Config) ->
+  Uri = ?config(completion_incomplete_uri, Config),
+  TriggerKindInvoked = ?COMPLETION_TRIGGER_KIND_INVOKED,
+  Expected = [#{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+               , kind => ?COMPLETION_ITEM_KIND_FUNCTION
+               , label => <<"function_unexported/0">>
+               , data =>
+                   #{ arity => 0
+                    , function => <<"function_unexported">>
+                    , module => <<"completion_incomplete">>
+                    }
+               }
+             ],
+  NotExpected = [#{ insertTextFormat => ?INSERT_TEXT_FORMAT_PLAIN_TEXT
+                  , kind => ?COMPLETION_ITEM_KIND_FUNCTION
+                  , label => <<"function_exported/0">>
+                  , data =>
+                      #{ arity => 0
+                       , function => <<"function_exported">>
+                       , module => <<"completion_incomplete">>
+                       }
+                  }
+                ],
+  #{result := Completions} =
+    els_client:completion(Uri, 4, 18, TriggerKindInvoked, <<"">>),
   [?assert(lists:member(E, Completions)) || E <- Expected],
   [?assertNot(lists:member(E, Completions)) || E <- NotExpected],
   ok.

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -134,6 +134,7 @@ sources() ->
   , completion_resolve_2
   , completion_snippets
   , completion_attributes
+  , completion_incomplete
   , diagnostics
   , diagnostics_bound_var_in_pattern
   , diagnostics_autoimport


### PR DESCRIPTION
The unexpected atom (an incomplete function name) in the export attribute caused
the below crash in the parser. This way the completion provider failed to
determine that the location is in an export context, and used function snippet
with arguments instead of '/arity'.

For example when hitting enter on a completion erlang_ls used to insert
`foo(Arg)` instead of `foo/1`.

```
1> els_parser:parse("-export([foo]).").
2021-06-06T16:40:30.522244+02:00 warning: Please report error parsing form error:{try_clause,foo}:[{els_parser,'-skip_function_entries/1-fun-0-',1,[{file,"/Users/ext.pgomori/git/erlang_ls/apps/els_lsp/src/els_parser.erl"},{line,839}]},{lists,'-filter/2-lc$^0/1-0-',2,[{file,"lists.erl"},{line,1286}]},{els_parser,attribute_subtrees,2,[{file,"/Users/ext.pgomori/git/erlang_ls/apps/els_lsp/src/els_parser.erl"},{line,792}]},{els_parser,fold,3,[{file,"/Users/ext.pgomori/git/erlang_ls/apps/els_lsp/src/els_parser.erl"},{line,687}]},{els_parser,'-parse_forms/1-lc$^0/1-0-',1,[{file,"/Users/ext.pgomori/git/erlang_ls/apps/els_lsp/src/els_parser.erl"},{line,59}]},{els_parser,parse,1,[{file,"/Users/ext.pgomori/git/erlang_ls/apps/els_lsp/src/els_parser.erl"},{line,30}]},{erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},{shell,exprs,7,[{file,"shell.erl"},{line,686}]}], {attribute,#{end_location => {1,16},location => {1,1}},{atom,#{end_location => {1,8},location => {1,2},text => "export"},export},[{list,#{end_location => {1,14},location => {1,9}},[{atom,#{end_location => {1,13},location => {1,10},text => "foo"},foo}]}]}
```

### Description

Enter a description of your changes here.

Fixes # .
