### PR TITLE
[#1031] Find implementations for callback functions

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/implementation.erl
+++ b/apps/els_lsp/priv/code_navigation/src/implementation.erl
@@ -1,0 +1,3 @@
+-module(implementation).
+
+-callback to_be_implemented() -> ok.

--- a/apps/els_lsp/priv/code_navigation/src/implementation_a.erl
+++ b/apps/els_lsp/priv/code_navigation/src/implementation_a.erl
@@ -1,0 +1,8 @@
+-module(implementation_a).
+
+-behaviour(implementation).
+
+-export([ to_be_implemented/0 ]).
+
+to_be_implemented() ->
+  ok.

--- a/apps/els_lsp/priv/code_navigation/src/implementation_b.erl
+++ b/apps/els_lsp/priv/code_navigation/src/implementation_b.erl
@@ -1,0 +1,8 @@
+-module(implementation_b).
+
+-behaviour(implementation).
+
+-export([ to_be_implemented/0 ]).
+
+to_be_implemented() ->
+  ok.

--- a/apps/els_lsp/test/els_implementation_SUITE.erl
+++ b/apps/els_lsp/test/els_implementation_SUITE.erl
@@ -13,6 +13,7 @@
 
 %% Test cases
 -export([ gen_server_call/1
+        , callback/1
         ]).
 
 %%==============================================================================
@@ -61,11 +62,32 @@ end_per_testcase(TestCase, Config) ->
 gen_server_call(Config) ->
   Uri = ?config(my_gen_server_uri, Config),
   #{result := Result} = els_client:implementation(Uri, 30, 10),
-  Expected = #{ range =>
-                  #{ 'end' => #{character => 4, line => 46}
-                   , start => #{character => 0, line => 46}
-                   }
-              , uri => Uri
-              },
+  Expected = [ #{ range =>
+                    #{ 'end' => #{character => 4, line => 46}
+                     , start => #{character => 0, line => 46}
+                     }
+                , uri => Uri
+                }
+             ],
+  ?assertEqual(Expected, Result),
+  ok.
+
+-spec callback(config()) -> ok.
+callback(Config) ->
+  Uri = ?config(implementation_uri, Config),
+  #{result := Result} = els_client:implementation(Uri, 3, 20),
+  Expected = [ #{ range =>
+                    #{ 'end' => #{character => 17, line => 6}
+                     , start => #{character => 0, line => 6}
+                     }
+                , uri => ?config(implementation_a_uri, Config)
+                }
+             , #{ range =>
+                    #{ 'end' => #{character => 17, line => 6}
+                     , start => #{character => 0, line => 6}
+                     }
+                , uri => ?config(implementation_b_uri, Config)
+                }
+             ],
   ?assertEqual(Expected, Result),
   ok.

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -160,6 +160,9 @@ sources() ->
   , hover_docs
   , hover_docs_caller
   , hover_macro
+  , implementation
+  , implementation_a
+  , implementation_b
   , my_gen_server
   , rename
   , rename_function


### PR DESCRIPTION
### Description

Using the info from the DB, we can "jump to implementation" for callback functions. This can be especially useful in presence of _optional_ callbacks which only certain modules implement.

For example, the `els_code_lens` behaviour is used in 5 modules, but only 2 of them implement the `precondition/1` callback:

<img width="689" alt="Screenshot 2021-06-07 at 09 53 09" src="https://user-images.githubusercontent.com/91769/120979998-6df87580-c776-11eb-9ae2-9d6ad9882130.png">

`lsp-find-implementation`

<img width="1070" alt="Screenshot 2021-06-07 at 09 53 36" src="https://user-images.githubusercontent.com/91769/120980055-8072af00-c776-11eb-97f0-daefe650fdfb.png">

Fixes #1031 .
