### PR TITLE
[#992] Cleanup logging

### DIFF
--- a/apps/els_lsp/include/els_lsp.hrl
+++ b/apps/els_lsp/include/els_lsp.hrl
@@ -5,6 +5,6 @@
 
 -define(APP, els_lsp).
 
--define(ELP_LOG_FORMAT, [ "[", level, "] ", "[", time, "] ", mfa, " L", line, " ", pid,  "\n", msg, "\n" ]).
+-define(LSP_LOG_FORMAT, ["[", time, "] ", "[", level, "] ", msg, " [", mfa,  " L", line, "] ", pid, "\n"]).
 
 -endif.

--- a/apps/els_lsp/src/els_background_job.erl
+++ b/apps/els_lsp/src/els_background_job.erl
@@ -98,7 +98,7 @@ start_link(Config) ->
 %%==============================================================================
 -spec init(config()) -> {ok, state()}.
 init(#{entries := Entries, title := Title} = Config) ->
-  ?LOG_INFO("Background job started. [pid=~p] [title=~p]", [self(), Title]),
+  ?LOG_INFO("Background job started ~s", [Title]),
   %% Ensure the terminate function is called on shutdown, allowing the
   %% job to clean up.
   process_flag(trap_exit, true),
@@ -184,7 +184,7 @@ terminate(normal, #{ config := #{on_complete := OnComplete}
     Pid ->
       exit(Pid, kill)
   end,
-  ?LOG_INFO("Background job completed. [pid=~p]", [self()]),
+  ?LOG_INFO("Background job completed.", []),
   OnComplete(InternalState),
   ok;
 terminate(Reason, #{ config := #{on_error := OnError}
@@ -193,8 +193,7 @@ terminate(Reason, #{ config := #{on_error := OnError}
                    , total := Total
                    , progress_enabled := ProgressEnabled
                    }) ->
-  ?LOG_WARNING( "Background job aborted. [reason=~p] [pid=~p]"
-              , [Reason, self()]),
+  ?LOG_WARNING( "Background job aborted. [reason=~p]", [Reason]),
   notify_end(Token, Total, ProgressEnabled),
   OnError(InternalState),
   ok.

--- a/apps/els_lsp/src/els_log_notification.erl
+++ b/apps/els_lsp/src/els_log_notification.erl
@@ -4,22 +4,24 @@
 
 -export([log/2]).
 
--type lsp_message_type() :: 1 | 2 | 3 | 4.
-
 -define(LSP_MESSAGE_TYPE_ERROR, 1).
 -define(LSP_MESSAGE_TYPE_WARNING, 2).
 -define(LSP_MESSAGE_TYPE_INFO, 3).
 -define(LSP_MESSAGE_TYPE_LOG, 4).
 
+-type lsp_message_type() :: ?LSP_MESSAGE_TYPE_ERROR |
+                            ?LSP_MESSAGE_TYPE_WARNING |
+                            ?LSP_MESSAGE_TYPE_INFO |
+                            ?LSP_MESSAGE_TYPE_LOG.
 
 -spec log(logger:log_event(), logger:config_handler()) -> ok.
 log(#{level := Level} = LogEvent, _Config) ->
     try
         Msg = logger_formatter:format( LogEvent
-                                     , #{ template => ?ELP_LOG_FORMAT}),
+                                     , #{ template => ?LSP_LOG_FORMAT}),
         els_server:send_notification(<<"window/logMessage">>, #{
             <<"message">> => unicode:characters_to_binary(Msg),
-            <<"type">> => map_otp_log_level_to_lsp(Level)
+            <<"type">> => otp_log_level_to_lsp(Level)
         })
     catch
         E:R:ST ->
@@ -32,12 +34,12 @@ log(#{level := Level} = LogEvent, _Config) ->
             })
     end.
 
--spec map_otp_log_level_to_lsp(logger:level()) -> lsp_message_type().
-map_otp_log_level_to_lsp(emergency) -> ?LSP_MESSAGE_TYPE_ERROR;
-map_otp_log_level_to_lsp(alert) -> ?LSP_MESSAGE_TYPE_ERROR;
-map_otp_log_level_to_lsp(critical) -> ?LSP_MESSAGE_TYPE_ERROR;
-map_otp_log_level_to_lsp(error) -> ?LSP_MESSAGE_TYPE_ERROR;
-map_otp_log_level_to_lsp(warning) -> ?LSP_MESSAGE_TYPE_WARNING;
-map_otp_log_level_to_lsp(notice) -> ?LSP_MESSAGE_TYPE_INFO;
-map_otp_log_level_to_lsp(info) -> ?LSP_MESSAGE_TYPE_LOG;
-map_otp_log_level_to_lsp(debug) -> ?LSP_MESSAGE_TYPE_LOG.
+-spec otp_log_level_to_lsp(logger:level()) -> lsp_message_type().
+otp_log_level_to_lsp(emergency) -> ?LSP_MESSAGE_TYPE_ERROR;
+otp_log_level_to_lsp(alert) -> ?LSP_MESSAGE_TYPE_ERROR;
+otp_log_level_to_lsp(critical) -> ?LSP_MESSAGE_TYPE_ERROR;
+otp_log_level_to_lsp(error) -> ?LSP_MESSAGE_TYPE_ERROR;
+otp_log_level_to_lsp(warning) -> ?LSP_MESSAGE_TYPE_WARNING;
+otp_log_level_to_lsp(notice) -> ?LSP_MESSAGE_TYPE_INFO;
+otp_log_level_to_lsp(info) -> ?LSP_MESSAGE_TYPE_LOG;
+otp_log_level_to_lsp(debug) -> ?LSP_MESSAGE_TYPE_LOG.

--- a/apps/els_lsp/src/erlang_ls.erl
+++ b/apps/els_lsp/src/erlang_ls.erl
@@ -109,7 +109,7 @@ configure_logging() ->
   Handler = #{ config => #{ file => LogFile }
              , level => LoggingLevel
              , formatter => { logger_formatter
-                            , #{ template => ?ELP_LOG_FORMAT ++ ["\n"] }
+                            , #{ template => ?LSP_LOG_FORMAT }
                             }
              },
   [logger:remove_handler(H) || H <-  logger:get_handler_ids()],


### PR DESCRIPTION
* Use timestamp as first entry
* Move message to the front to improve readibility (left-alignment for
messages)
* Remove un-necessary new lines
* Rename ELP -> LSP
* Remove redundant pid from Background job log messages
* Use macros instead of numeric literals for message types
* Shorten mapping function name
