### PR TITLE
Fix creating macro POIs in function applications

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_macros.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_macros.erl
@@ -4,6 +4,8 @@
 
 -define(USED_MACRO, used_macro).
 -define(UNUSED_MACRO, unused_macro).
+-define(MOD, module). %% MOD was incorrectly reported as unused (#1021)
 
 main() ->
+  ?MOD:foo(),
   ?USED_MACRO.

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -727,7 +727,13 @@ fold2(_, S, []) ->
 
 -spec subtrees(tree(), atom()) -> [[tree()]].
 subtrees(Tree, application) ->
-  [erl_syntax:application_arguments(Tree)];
+  [ case application_mfa(Tree) of
+      undefined ->
+        [erl_syntax:application_operator(Tree)];
+      _ ->
+        []
+    end
+  , erl_syntax:application_arguments(Tree)];
 subtrees(Tree, function) ->
   [erl_syntax:function_clauses(Tree)];
 subtrees(_Tree, implicit_fun) ->

--- a/elvis.config
+++ b/elvis.config
@@ -16,6 +16,7 @@
                                                                , els_definition_SUITE
                                                                , els_diagnostics_SUITE
                                                                , els_document_highlight_SUITE
+                                                               , els_parser_SUITE
                                                                , els_references_SUITE
                                                                , els_methods
                                                                ]}}


### PR DESCRIPTION
### Description

If we don't create a POI for a function application (because module or function is not a literal atom) then potentially create POIs from its subtrees.

Fixes #1021  .
