### PR TITLE
Add support for hover on record expression.

### DIFF
--- a/apps/els_lsp/priv/code_navigation/include/hover_record.hrl
+++ b/apps/els_lsp/priv/code_navigation/include/hover_record.hrl
@@ -1,0 +1,1 @@
+-record(included_record_a, {included_field_a, included_field_b}).

--- a/apps/els_lsp/priv/code_navigation/src/hover_record_expr.erl
+++ b/apps/els_lsp/priv/code_navigation/src/hover_record_expr.erl
@@ -1,0 +1,16 @@
+-module(hover_record_expr).
+-include("hover_record.hrl").
+
+-record(test_record, {
+        field1 = 123,
+        field2 = xyzzy,
+        field3
+}).
+
+f(Record) ->
+  #test_record{field1 = Field1} = Record,
+  Field1.
+
+g(Record) ->
+  #included_record_a{included_field_b = FieldB} = Record,
+  FieldB.

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -559,7 +559,7 @@ record_fields(Document, RecordName) ->
   case find_record_definition(Document, RecordName) of
     [] -> [];
     POIs ->
-      [#{data := Fields} | _] = els_poi:sort(POIs),
+      [#{data := #{field_list := Fields}} | _] = els_poi:sort(POIs),
       [ item_kind_field(atom_to_label(Name))
         || {Name, _} <- Fields
       ]

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -269,7 +269,10 @@ attribute(Tree) ->
                     erl_syntax:record_field_value(FF)}
                end
                || F <- erl_syntax:tuple_elements(Fields)]),
-          [poi(erl_syntax:get_pos(Record), record, RecordName, FieldList)
+          ValueRange = #{ from => get_start_location(Tree),
+                          to => get_end_location(Tree)},
+          Data = #{field_list => FieldList, value_range => ValueRange},
+          [poi(erl_syntax:get_pos(Record), record, RecordName, Data)
           | record_def_fields(Tree, RecordName)];
         _ ->
           []

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -21,6 +21,8 @@
         , weird_macro/1
         , macro_with_zero_args/1
         , macro_with_args/1
+        , local_record/1
+        , included_record/1
         ]).
 
 %%==============================================================================
@@ -165,4 +167,30 @@ no_poi(Config) ->
   Uri = ?config(hover_docs_caller_uri, Config),
   #{result := Result} = els_client:hover(Uri, 10, 1),
   ?assertEqual(null, Result),
+  ok.
+
+local_record(Config) ->
+  Uri = ?config(hover_record_expr_uri, Config),
+  #{result := Result} = els_client:hover(Uri, 11, 4),
+  Value = <<"```erlang\n-record(test_record, {\n"
+            "        field1 = 123,\n"
+            "        field2 = xyzzy,\n"
+            "        field3\n"
+            "}).\n```">>,
+  Expected = #{contents => #{ kind  => <<"markdown">>
+                            , value => Value
+                            }},
+  ?assertEqual(Expected, Result),
+  ok.
+
+included_record(Config) ->
+  Uri = ?config(hover_record_expr_uri, Config),
+  #{result := Result} = els_client:hover(Uri, 15, 4),
+  Value = <<"```erlang\n"
+            "-record(included_record_a, {included_field_a, included_field_b})."
+            "\n```">>,
+  Expected = #{contents => #{ kind  => <<"markdown">>
+                            , value => Value
+                            }},
+  ?assertEqual(Expected, Result),
   ok.

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -161,6 +161,7 @@ sources() ->
   , hover_docs
   , hover_docs_caller
   , hover_macro
+  , hover_record_expr
   , implementation
   , implementation_a
   , implementation_b


### PR DESCRIPTION
With this change you can hover over a record expression, and get a definition of the record.