### PR TITLE
[#990] Show warning to the user in case of missing config file

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -211,7 +211,10 @@ possible_config_paths(Path) ->
   ].
 
 -spec consult_config([path()]) -> {undefined|path(), map()}.
-consult_config([]) -> {undefined, #{}};
+consult_config([]) ->
+  ?LOG_INFO("No config file found."),
+  report_missing_config(),
+  {undefined, #{}};
 consult_config([Path | Paths]) ->
   ?LOG_INFO("Reading config file. path=~p", [Path]),
   Options = [{map_node_format, map}],
@@ -224,6 +227,18 @@ consult_config([Path | Paths]) ->
                   , [Path, Class, Error]),
       consult_config(Paths)
   end.
+
+-spec report_missing_config() -> ok.
+report_missing_config() ->
+  Msg =
+    io_lib:format("The current project is missing an erlang_ls.config file. "
+                  "Need help configuring Erlang LS for your project? "
+                  "Visit: https://erlang-ls.github.io/configuration/", []),
+  els_server:send_notification(<<"window/showMessage">>,
+                               #{ type => ?MESSAGE_TYPE_WARNING,
+                                  message => els_utils:to_binary(Msg)
+                                }),
+  ok.
 
 -spec include_paths(path(), string(), boolean()) -> [string()].
 include_paths(RootPath, IncludeDirs, Recursive) ->


### PR DESCRIPTION
One of the most common issues among new Erlang LS users is the lack of a configuration file. This simple change shows a warning to the user whenever a config file is not found for a project, pointing to the relevant documentation. This should simplify the user experience for new users.

<img width="589" alt="Screenshot 2021-07-07 at 11 05 39" src="https://user-images.githubusercontent.com/91769/124732315-619d3f00-df13-11eb-97f4-7a87124c7fe7.png">
