### PR TITLE
[dap] fix continue request response

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -336,7 +336,9 @@ handle_request( {<<"continue">>, Params}
   #{<<"threadId">> := ThreadId} = Params,
   Pid = to_pid(ThreadId, Threads),
   ok = els_dap_rpc:continue(ProjectNode, Pid),
-  {#{}, State#{mode => running}};
+  { #{<<"allThreadsContinued">> => false}
+  , State#{mode => running}
+  };
 handle_request( {<<"stepIn">>, Params}
               , #{ threads := Threads
                  , project_node := ProjectNode


### PR DESCRIPTION
### Description

The continue requests reponse defines an optional `allThreadsContinued` field
that defaults to true. This breaks the DAP when debugging multiple threads.

The solution is simple, set allThreadsContinued to flase when responding to the continue request.

Fixes #1068
