### PR TITLE
[#1070] Only set the cookie if the provided one is a valid one

### DIFF
--- a/apps/els_core/src/els_distribution_server.erl
+++ b/apps/els_core/src/els_distribution_server.erl
@@ -63,13 +63,17 @@ start_distribution(Name) ->
   NameType = els_config_runtime:get_name_type(),
   start_distribution(Name, RemoteNode, Cookie, NameType).
 
--spec start_distribution(atom(), atom(), atom(),
-                         shortnames | longnames) -> any().
+-spec start_distribution(atom(), atom(), atom(), shortnames | longnames) -> ok.
 start_distribution(Name, RemoteNode, Cookie, NameType) ->
   ?LOG_INFO("Enable distribution [name=~p]", [Name]),
   case net_kernel:start([Name, NameType]) of
     {ok, _Pid} ->
-      erlang:set_cookie(RemoteNode, Cookie),
+      case Cookie of
+        nocookie ->
+          ok;
+        CustomCookie ->
+          erlang:set_cookie(RemoteNode, CustomCookie)
+      end,
       ?LOG_INFO("Distribution enabled [name=~p]", [Name]);
     {error, {already_started, _Pid}} ->
       ?LOG_INFO("Distribution already enabled [name=~p]", [Name]);


### PR DESCRIPTION
### Description

This fixes a recently introduced regression. The `erlang:get_cookie/0`
was moved earlier, to a stage where distribution was not started
yet. Since that function returns `nocookie` in a system with no
distribution, that caused the atom `nocookie` to be erroneously used
as a cookie. A cleaner approach could be used, but that would require
a bit of refactoring. For now this should fix the regression with
minimal code changes.

Fixes #1070 .
