### PR TITLE
Add config option to exclude unused headers from warnings.

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -95,6 +95,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   DepsDirs        = maps:get("deps_dirs", Config, []),
   AppsDirs        = maps:get("apps_dirs", Config, ["."]),
   IncludeDirs     = maps:get("include_dirs", Config, ["include"]),
+  ExcludeUnusedIncludes = maps:get("exclude_unused_includes", Config, []),
   Macros          = maps:get("macros", Config, []),
   DialyzerPltPath = maps:get("plt_path", Config, undefined),
   OtpAppsExclude  = maps:get( "otp_apps_exclude"
@@ -123,6 +124,7 @@ do_initialize(RootUri, Capabilities, {ConfigPath, Config}) ->
   ok = set(deps_dirs      , DepsDirs),
   ok = set(apps_dirs      , AppsDirs),
   ok = set(include_dirs   , IncludeDirs),
+  ok = set(exclude_unused_includes , ExcludeUnusedIncludes),
   ok = set(macros         , Macros),
   ok = set(plt_path       , DialyzerPltPath),
   ok = set(code_reload    , CodeReload),

--- a/apps/els_lsp/src/els_unused_includes_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_includes_diagnostics.erl
@@ -64,7 +64,17 @@ find_unused_includes(#{uri := Uri} = Document) ->
     , type_application
     , export_type_entry
     ]),
-  IncludedUris = els_diagnostics_utils:included_uris(Document),
+  IncludedUris0 = els_diagnostics_utils:included_uris(Document),
+  ExcludeUnusedIncludes =
+      lists:filtermap(
+          fun(Include) ->
+              case els_utils:find_header(els_utils:filename_to_atom(Include)) of
+                  {ok, File} -> {true, File};
+                  {error, _Error} ->
+                      false
+              end
+          end, els_config:get(exclude_unused_includes)),
+  IncludedUris = IncludedUris0 -- ExcludeUnusedIncludes,
   Fun = fun(POI, Acc) ->
             update_unused(Graph, Uri, POI, Acc)
         end,


### PR DESCRIPTION
### Description

A new option is added to the configuration (exclude_unused_includes).
Header files specified by this configuration option are not checked weather
they are used or not.

Workaround for  #1047  and #964.
