### PR TITLE
Fix type mismatch in unused_macros diagnostic.

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_macros.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_macros.erl
@@ -4,6 +4,7 @@
 
 -define(USED_MACRO, used_macro).
 -define(UNUSED_MACRO, unused_macro).
+-define(UNUSED_MACRO_WITH_ARG(C), C).
 -define(MOD, module). %% MOD was incorrectly reported as unused (#1021)
 
 main() ->

--- a/apps/els_lsp/src/els_unused_macros_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_macros_diagnostics.erl
@@ -59,9 +59,14 @@ find_unused_macros(Document) ->
   [POI || #{id := Id} = POI <- Defines, not lists:member(Id, MacroIds)].
 
 -spec make_diagnostic(poi()) -> els_diagnostics:diagnostic().
-make_diagnostic(#{id := Id, range := POIRange}) ->
+make_diagnostic(#{id := POIId, range := POIRange}) ->
   Range = els_protocol:range(POIRange),
-  MacroName = atom_to_binary(Id, utf8),
+  MacroName = case POIId of
+    {Id, Arity} ->
+      els_utils:to_binary(
+        lists:flatten(io_lib:format("~s/~p", [Id, Arity])));
+    Id -> atom_to_binary(Id, utf8)
+  end,
   Message = <<"Unused macro: ", MacroName/binary>>,
   Severity = ?DIAGNOSTIC_WARNING,
   Source = source(),

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -699,6 +699,18 @@ unused_macros(Config) ->
                      }
                 , severity => 2
                 , source => <<"UnusedMacros">>
+                },
+                #{ message => <<"Unused macro: UNUSED_MACRO_WITH_ARG/1">>
+                , range =>
+                    #{ 'end' => #{ character => 29
+                                 , line => 6
+                                 }
+                     , start => #{ character => 8
+                                 , line => 6
+                                 }
+                     }
+                , severity => 2
+                , source => <<"UnusedMacros">>
                 }
              ],
   F = fun(#{message := M1}, #{message := M2}) -> M1 =< M2 end,


### PR DESCRIPTION
### Description

Fixes `badarg` in `els_unused_macros_diagnostic` thrown when unused macro has parameters. 

Error looks like this in Sublime-LSP LSP log:

    :: <-  erlang-ls-debug window/logMessage: {'type': 1, 'message': '[2021-08-24T19:09:15.983514+03:00] [error] crasher: initial call: els_background_job:init/1, pid: <0.211.0>, registered_name: [], error: {badarg,[{erlang,atom_to_binary,[{\'D\',1},utf8],[]},{els_unused_macros_diagnostics,make_diagnostic,1,[{file,"/home/nwalker/pg/erlang_ls/apps/els_lsp/src/els_unused_macros_diagnostics.erl"},{line,64}]}, <SKIPPED>, ancestors: [els_background_job_sup,els_sup,<0.159.0>], message_queue_len: 0, messages: [], links: [<0.181.0>], dictionary: [], trap_exit: true, status: running, heap_size: 10958, stack_size: 28, reductions: 49101; neighbours: [proc_lib:crash_report/4 L525] <0.211.0>\n'}
