### PR TITLE
Fix DAP not finding the source for a module

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -609,9 +609,8 @@ break_line(Pid, Node) ->
 
 -spec source(atom(), atom()) -> binary().
 source(Module, Node) ->
-  CompileOpts = els_dap_rpc:module_info(Node, Module, compile),
+  Source = els_dap_rpc:file(Node, Module),
   els_dap_rpc:clear(Node),
-  Source = proplists:get_value(source, CompileOpts),
   unicode:characters_to_binary(Source).
 
 -spec to_pid(pos_integer(), #{thread_id() => thread()}) -> pid().


### PR DESCRIPTION
### Description

This makes the els_dap_rpc try much harder to find the source, by first
asking `int:file/1`, then `code` and `filelib:find_source/1` and
finally falling back to the current behaviour of using `module_info`
and checking the `source` compilation option.

This allows you to build dependencies/OTP in one place, and run it from
another.