### PR TITLE
[#1047] Mark headers with compiler attributes as used

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_includes_compiler_attribute.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_includes_compiler_attribute.erl
@@ -1,0 +1,8 @@
+%% Issue 1047
+-module(diagnostics_unused_includes_compiler_attribute).
+
+-include_lib("kernel/include/file.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+the_test() ->
+  ok.

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -221,7 +221,12 @@ attribute(Tree) ->
           []
       end;
     {compile, [Arg]} ->
-      find_compile_options_pois(Arg);
+      %% When we encounter a compiler attribute, we include a POI
+      %% indicating the fact. This is useful, for example, to avoid
+      %% marking header files including parse transforms or other
+      %% compiler attributes as unused. See #1047
+      Marker = poi(erl_syntax:get_pos(Arg), compile, unused),
+      [Marker|find_compile_options_pois(Arg)];
     {AttrName, [Arg]} when AttrName =:= export;
                            AttrName =:= export_type ->
       find_export_pois(Tree, AttrName, Arg);

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -154,6 +154,7 @@ sources() ->
   , diagnostics_xref
   , diagnostics_xref_pseudo
   , diagnostics_unused_includes
+  , diagnostics_unused_includes_compiler_attribute
   , diagnostics_unused_macros
   , elvis_diagnostics
   , execute_command_suggest_spec


### PR DESCRIPTION
### Description

Fixes #964 and partially #1047.
