### PR TITLE
[#1086] Temporarily skip coveralls send

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Create Cover Reports
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: rebar3 do cover, coveralls send
+      run: rebar3 do cover
     - name: Produce Documentation
       run: rebar3 edoc
     - name: Publish Documentation


### PR DESCRIPTION
### Description

CI fails due to this step. Let's skip it for now, until a fix is found. We may even consider dropping coveralls altogether and use some other solution, since reports do not seem correct anyway.