### PR TITLE
[#859] Ignore test data directories.

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -283,7 +283,15 @@ project_paths(RootPath, Dirs, Recursive) ->
                                    )
             || Dir <- Dirs
           ],
-  lists:append(Paths).
+  case Recursive of
+    false ->
+      lists:append(Paths);
+    true ->
+      Filter = fun(Path) ->
+                 string:find(Path, "SUITE_data", trailing) =:= nomatch
+               end,
+      lists:filter(Filter, lists:append(Paths))
+  end.
 
 -spec otp_paths(path(), boolean()) -> [string()].
 otp_paths(OtpPath, Recursive) ->


### PR DESCRIPTION
Test data directories may contain erlang files with modules names
that clashes with application or system modules, ignore these
directories.

As one example in otp "lib/dialyzer/test/r9c_SUITE_data/src/" contains
the many files that clashes. This causes among other things that
jump to definition almost always jumps to the wrong place when working
inside OTP.

Fixes #859
