### PR TITLE
Do not recurse in els_utils:fold_files

### DIFF
--- a/apps/els_core/src/els_utils.erl
+++ b/apps/els_core/src/els_utils.erl
@@ -181,7 +181,7 @@ macro_string_to_term(Value) ->
       true
   end.
 
-%% @doc Folds over all files in a directory recursively
+%% @doc Folds over all files in a directory
 %%
 %% Applies function F to each file and the accumulator,
 %% skipping all symlinks.
@@ -249,7 +249,7 @@ do_fold_files(F, Filter, Dir, [File | Rest], Acc0) ->
   %% Symbolic links are not regular files
   Acc  = case filelib:is_regular(Path) of
            true  -> do_fold_file(F, Filter, Path, Acc0);
-           false -> do_fold_dir(F, Filter, Path, Acc0)
+           false -> Acc0
          end,
   do_fold_files(F, Filter, Dir, Rest, Acc).
 


### PR DESCRIPTION
Avoids double recursion, recursion is done in els_config.
This fixes #859 which my previous PR failed to do.

From what I can see els_util:fold_files is only used for indexing and input 
data are the directories from els_config which have already been recursed once.






