### PR TITLE
Bring back `coveralls send` step in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Create Cover Reports
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: rebar3 do cover
+      run: rebar3 do cover, coveralls send
     - name: Produce Documentation
       run: rebar3 edoc
     - name: Publish Documentation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![erlang_ls](images/erlang-ls-logo-small.png?raw=true "Erlang LS")
 
 ![Build](https://github.com/erlang-ls/erlang_ls/workflows/Build/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/erlang-ls/erlang_ls/badge.svg?branch=master)](https://coveralls.io/github/erlang-ls/erlang_ls?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/erlang-ls/erlang_ls/badge.svg?branch=main)](https://coveralls.io/github/erlang-ls/erlang_ls?branch=main)
 
 An Erlang server implementing Microsoft's Language Server Protocol 3.15.
 


### PR DESCRIPTION
Fixes #1086. The authentication warning reports are still there, that's related to some SSL in OTP 24, but the issue with `coveralls` seemed to be a hiccup on their end and not a problem in ours.