### PR TITLE
Added the '-module' attribute snippet

### DIFF
--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -262,6 +262,7 @@ attributes() ->
   , snippet(attribute_import)
   , snippet(attribute_include)
   , snippet(attribute_include_lib)
+  , snippet(attribute_module)
   , snippet(attribute_on_load)
   , snippet(attribute_opaque)
   , snippet(attribute_record)
@@ -373,6 +374,8 @@ snippet(attribute_include) ->
   snippet(<<"-include().">>, <<"include(${1:}).">>);
 snippet(attribute_include_lib) ->
   snippet(<<"-include_lib().">>, <<"include_lib(${1:}).">>);
+snippet(attribute_module) ->
+  snippet(<<"-module().">>, <<"module(${1:Module}).">>);
 snippet(attribute_type) ->
   snippet(<<"-type name() :: definition.">>,
           <<"type ${1:name}() :: ${2:definition}.">>);

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -554,7 +554,8 @@ exported_definitions(Module, POIKind, ExportFormat) ->
 
 -spec module_name(els_dt_document:item()) -> [binary()].
 module_name(#{uri := Uri}) ->
-  ModuleName = filename:basename(lists:last(filename:split(Uri)), ".erl"),
+  ModuleName = filename:basename(lists:last(filename:split(Uri)),
+  filename:extension(Uri)),
   PurifiedName = case binary:match(ModuleName, <<"-">>) of
     nomatch -> ModuleName;
     _ -> list_to_binary(

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -133,6 +133,11 @@ attributes(Config) ->
                 , kind => ?COMPLETION_ITEM_KIND_SNIPPET
                 , label => <<"-include().">>
                 }
+             , #{ insertText => <<"module(${1:Module}).">>
+                , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
+                , kind => ?COMPLETION_ITEM_KIND_SNIPPET
+                , label => <<"-module().">>
+                }
              , #{ insertText => <<"include_lib(${1:}).">>
                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , kind => ?COMPLETION_ITEM_KIND_SNIPPET

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -133,7 +133,7 @@ attributes(Config) ->
                 , kind => ?COMPLETION_ITEM_KIND_SNIPPET
                 , label => <<"-include().">>
                 }
-             , #{ insertText => <<"module(${1:Module}).">>
+             , #{ insertText => <<"module(${1:}).">>
                 , insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET
                 , kind => ?COMPLETION_ITEM_KIND_SNIPPET
                 , label => <<"-module().">>


### PR DESCRIPTION
### Description

I added the `-module(Module)` attribute into the available snippet list.
As for the placeholder I took `Module` because of the [Erlang docs](https://www.erlang.org/doc/reference_manual/modules.html#pre-defined-module-attributes).

Feedback is welcome, thanks!


