### PR TITLE
Fix unicode output via stdout

### DIFF
--- a/apps/els_core/src/els_stdio.erl
+++ b/apps/els_core/src/els_stdio.erl
@@ -23,7 +23,7 @@ start_listener(Cb) ->
 -spec init({function(), atom() | pid()}) -> no_return().
 init({Cb, IoDevice}) ->
   ?LOG_INFO("Starting stdio server..."),
-  ok = io:setopts(IoDevice, [binary]),
+  ok = io:setopts(IoDevice, [binary, {encoding, unicode}]),
   {ok, Server} = application:get_env(els_core, server),
   ok = Server:set_io_device(IoDevice),
   ?MODULE:loop([], IoDevice, Cb, [return_maps]).

--- a/apps/els_lsp/src/els_eep48_docs.erl
+++ b/apps/els_lsp/src/els_eep48_docs.erl
@@ -520,7 +520,7 @@ render_element({b,_,Content},State,Pos,Ind,D) ->
 render_element({pre,_,Content},State,Pos,Ind,D) ->
     %% For pre we make sure to respect the newlines in pre
     {Docs, _} = trimnl(render_docs(Content, [pre|State], Pos, Ind, D)),
-    trimnlnl(["```erlang\n",Docs,"```"]);
+    trimnlnl(["```erlang\n",pad(Ind),Docs,pad(Ind),"```"]);
 
 render_element({ul,[{class,<<"types">>}],Content},State,_Pos,Ind,D) ->
     {Docs, _} = render_docs(Content, [types|State], 0, Ind, D),
@@ -565,7 +565,7 @@ render_element({dl,_,Content},State,Pos,Ind,D) ->
 render_element({dt,_,Content},[dl | _] = State,Pos,Ind,D) ->
     {Docs, NewPos} = render_docs([{b,[],Content}],
                                  [li | State], Pos + 2, Ind + 2, D),
-    trimnl({["", string:trim(Docs, trailing, "\n"), "  "], NewPos});
+    trimnl({["* ", string:trim(Docs, trailing, "\n"), "  "], NewPos});
 render_element({dd,_,Content},[dl | _] = State,Pos,Ind,D) ->
     {Docs, _NewPos} = render_docs(Content, [li | State], Pos+2, Ind + 2, D),
     trimnlnl([pad(2 + Ind - Pos), Docs]);
@@ -630,7 +630,7 @@ nlpad(N) ->
     pad(N,"\n").
 -spec pad(non_neg_integer(), unicode:chardata()) -> unicode:chardata().
 pad(N, Extra) ->
-    Pad = lists:duplicate(N,[160]),
+    Pad = lists:duplicate(N,[$ ]),
     [Extra, Pad].
 
 -spec lastline(unicode:chardata()) -> non_neg_integer().

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -1074,9 +1074,9 @@ resolve_application_remote_otp(Config) ->
             "than `latin1`, each byte written can result in many bytes being "
             "written to the file, as the byte range 0\\.\\.255 can represent "
             "anything between one and four bytes depending on value and UTF "
-            "encoding type\\.\n\nTypical error reasons:\n\n**`ebadf`**  \n"
-            "Â Â The file is not opened for writing\\.\n\n**`enospc`**  \n"
-            "Â Â No space is left on the device\\.\n">>;
+            "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
+            "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
+            "  No space is left on the device\\.\n">>;
             false -> <<"## file:write/2\n\n---\n\n```erlang\n\n  write(File, "
               "Bytes) when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
               "descriptor{module = Module} = Handle, Bytes) \n\n  write(_, _) "

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -174,9 +174,9 @@ remote_call_otp(Config) ->
               "than `latin1`, each byte written can result in many bytes being "
               "written to the file, as the byte range 0\\.\\.255 can represent "
               "anything between one and four bytes depending on value and UTF "
-              "encoding type\\.\n\nTypical error reasons:\n\n**`ebadf`**  \n"
-              "Â Â The file is not opened for writing\\.\n\n**`enospc`**  \n"
-              "Â Â No space is left on the device\\.\n">>;
+              "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
+              "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
+              "  No space is left on the device\\.\n">>;
     false -> <<"## file:write/2\n\n---\n\n```erlang\n\n  write(File, Bytes) "
                "when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
                "descriptor{module = Module} = Handle, Bytes) \n\n  "


### PR DESCRIPTION
Fix problem with unicode output to stdout.

While at it also improve rendering of definition lists with code blocks in them.

Closes #1145 