### PR TITLE
Revert unicode support

### DIFF
--- a/apps/els_core/src/els_stdio.erl
+++ b/apps/els_core/src/els_stdio.erl
@@ -23,14 +23,14 @@ start_listener(Cb) ->
 -spec init({function(), atom() | pid()}) -> no_return().
 init({Cb, IoDevice}) ->
   ?LOG_INFO("Starting stdio server..."),
-  ok = io:setopts(IoDevice, [binary, {encoding, unicode}]),
+  ok = io:setopts(IoDevice, [binary, {encoding, latin1}]),
   {ok, Server} = application:get_env(els_core, server),
   ok = Server:set_io_device(IoDevice),
   ?MODULE:loop([], IoDevice, Cb, [return_maps]).
 
 -spec send(atom() | pid(), binary()) -> ok.
 send(IoDevice, Payload) ->
-  io:format(IoDevice, "~ts", [Payload]).
+  io:format(IoDevice, "~s", [Payload]).
 
 %%==============================================================================
 %% Listener loop function


### PR DESCRIPTION
The support to render unicode broke the latin1 support so until we fix both we fall back to latin1 so that we can open such files...

People really should update their files to be unicode!

For anyone wondering how to update latin1 files to unicode:

```erlang
convert(Filename) ->
  {ok, Latin1} = file:read_file(Filename),
  file:write_file(Filename, unicode:characters_to_binary(re:replace(Latin1,"coding: latin-1",""), latin1, unicode)).
```