### PR TITLE
[#1152] Emit error in case the module name does not coincide with the filename

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_module_name_check.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_module_name_check.erl
@@ -1,0 +1,1 @@
+-module(module_name_check).

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -723,7 +723,41 @@ compile_file(Path, Dependencies) ->
   [code:load_binary(Dependency, Filename, Binary)
    || {{Dependency, Binary, Filename}, _} <- Olds],
   Diagnostics = lists:flatten([ Diags || {_, Diags} <- Olds ]),
-  {Res, Diagnostics}.
+  {Res, Diagnostics ++ module_name_check(Path)}.
+
+%% The module_name error is only emitted by the Erlang compiler during
+%% the "save binary" phase. This phase does not occur when code
+%% generation is disabled (e.g. by using the basic_validation or
+%% strong_validation arguments when invoking the compile:file/2
+%% function), which is exactly the case for the Erlang LS compiler
+%% diagnostics. Therefore, let's replicate the check explicitly.
+%% See issue #1152.
+-spec module_name_check(string()) -> [els_diagnostics:diagnostic()].
+module_name_check(Path) ->
+  Basename = filename:basename(Path, ".erl"),
+  Uri = els_uri:uri(els_utils:to_binary(Path)),
+  case els_dt_document:lookup(Uri) of
+    {ok, [Document]} ->
+      case els_dt_document:pois(Document, [module]) of
+        [#{id := Module, range := Range}] ->
+          case atom_to_list(Module) =:= Basename of
+            true ->
+              [];
+            false ->
+              Message =
+                io_lib:format("Module name '~s' does not match file name '~ts'",
+                              [Module, Basename]),
+              Diagnostic = els_diagnostics:make_diagnostic(
+                             els_protocol:range(Range),
+                             els_utils:to_binary(Message),
+                             ?DIAGNOSTIC_ERROR,
+                             <<"Compiler (via Erlang LS)">>),
+              [Diagnostic]
+          end
+      end;
+    _ ->
+      []
+  end.
 
 %% @doc Load a dependency, return the old version of the code (if any),
 %% so it can be restored.

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -41,6 +41,7 @@
         , unused_macros/1
         , unused_record_fields/1
         , gradualizer/1
+        , module_name_check/1
         ]).
 
 %%==============================================================================
@@ -651,6 +652,20 @@ gradualizer(_Config) ->
                       "but it has type false | true\n">>
                 , range => {{10, 0}, {11, 0}}}
              ],
+  Hints = [],
+  els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
+-spec module_name_check(config()) -> ok.
+module_name_check(_Config) ->
+  Path = src_path("diagnostics_module_name_check.erl"),
+  Source = <<"Compiler (via Erlang LS)">>,
+  Errors = [ #{ message =>
+                  <<"Module name 'module_name_check' does not match "
+                    "file name 'diagnostics_module_name_check'">>
+              , range => {{0, 8}, {0, 25}}
+              }
+           ],
+  Warnings = [],
   Hints = [],
   els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
 


### PR DESCRIPTION
### Description

Fixes #1152 .
