### PR TITLE
Precompute list of enabled diagnostics

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -154,6 +154,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
   ok = set(otp_paths      , otp_paths(OtpPath, false) -- ExcludePaths),
   ok = set(lenses         , Lenses),
   ok = set(diagnostics    , Diagnostics),
+  ok = set(enabled_diagnostics, els_diagnostics:enabled_diagnostics()),
   %% All (including subdirs) paths used to search files with file:path_open/3
   ok = set( search_paths
           , lists:append([ project_paths(RootPath, AppsDirs, true)

--- a/apps/els_lsp/src/els_diagnostics.erl
+++ b/apps/els_lsp/src/els_diagnostics.erl
@@ -90,7 +90,7 @@ make_diagnostic(Range, Message, Severity, Source) ->
 
 -spec run_diagnostics(uri()) -> [pid()].
 run_diagnostics(Uri) ->
-  [run_diagnostic(Uri, Id) || Id <- enabled_diagnostics()].
+  [run_diagnostic(Uri, Id) || Id <- els_config:get(enabled_diagnostics)].
 
 %%==============================================================================
 %% Internal Functions


### PR DESCRIPTION
Little optimization to avoid re-computing the list of enabled diagnostics at every request.