### PR TITLE
Ensure that default node name is valid

### DIFF
--- a/apps/els_core/src/els_config_runtime.erl
+++ b/apps/els_core/src/els_config_runtime.erl
@@ -64,7 +64,8 @@ get_cookie() ->
 default_node_name() ->
   RootUri = els_config:get(root_uri),
   {ok, Hostname} = inet:gethostname(),
-  NodeName = els_utils:to_list(filename:basename(els_uri:path(RootUri))),
+  NodeName = els_distribution_server:normalize_node_name(
+               filename:basename(els_uri:path(RootUri))),
   NodeName ++ "@" ++ Hostname.
 
 -spec default_otp_path() -> string().


### PR DESCRIPTION
This fixes an issue where initialization of els distribution would fail
due to invalid node name if the project directory contains characters
that are not valid in an erlang node name.