### PR TITLE
Fix parsing of define arguments

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/rename_variable.erl
+++ b/apps/els_lsp/priv/code_navigation/src/rename_variable.erl
@@ -18,7 +18,7 @@ baz(Var) ->
 
 -record(foo, {a :: Var,
               b :: [Var]}).
-%% BUG: `Var' in MACRO(`Var') is not considered a variable POI
+
 -define(MACRO(Var), Var + Var).
 
 -type type(Var) :: Var.

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -969,10 +969,14 @@ attribute_subtrees(AttrName, [Exports])
   when AttrName =:= export;
        AttrName =:= export_type ->
   [ skip_function_entries(Exports) ];
-attribute_subtrees(define, [_Name | Definition]) ->
+attribute_subtrees(define, [Name | Definition]) ->
   %% The definition can contain commas, in which case it will look like as if
   %% the attribute would have more than two arguments. Eg.: `-define(M, a, b).'
-  [Definition];
+  Args = case erl_syntax:type(Name) of
+           application -> erl_syntax:application_arguments(Name);
+           _           -> []
+         end,
+  [Args, Definition];
 attribute_subtrees(AttrName, _)
   when AttrName =:= include;
        AttrName =:= include_lib ->

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -12,6 +12,7 @@
         , parse_incomplete_function/1
         , parse_incomplete_spec/1
         , parse_no_tokens/1
+        , define/1
         , underscore_macro/1
         , specs_with_record/1
         , types_with_record/1
@@ -126,6 +127,16 @@ parse_no_tokens(_Config) ->
     "-module(m).\n"
     "%% trailing comment",
   {ok, [#{id := m, kind := module}]} = els_parser:parse(Text3).
+
+-spec define(config()) -> ok.
+define(_Config) ->
+  ?assertMatch({ok, [ #{id := {'MACRO', 2}, kind := define}
+                    , #{id := 'B', kind := variable}
+                    , #{id := 'A', kind := variable}
+                    , #{id := 'B', kind := variable}
+                    , #{id := 'A', kind := variable}
+                    ]},
+               els_parser:parse("-define(MACRO(A, B), A:B()).")).
 
 -spec underscore_macro(config()) -> ok.
 underscore_macro(_Config) ->

--- a/apps/els_lsp/test/els_rename_SUITE.erl
+++ b/apps/els_lsp/test/els_rename_SUITE.erl
@@ -151,10 +151,7 @@ rename_variable(Config) ->
   #{result := Result7} = els_client:document_rename(Uri, 21, 20, NewName),
   Expected7 = #{changes => #{UriAtom => [ change(NewName, {21, 26}, {21, 29})
                                         , change(NewName, {21, 20}, {21, 23})
-                                        %% This should also update, but doesn't
-                                        %% due to bug where Var in MACRO(Var)
-                                        %% isn't considered a variable POI
-                                        %% change(NewName, {22, 14}, {22, 17})
+                                        , change(NewName, {21, 14}, {21, 17})
                                         ]}},
   %% Type
   #{result := Result8} = els_client:document_rename(Uri, 23, 11, NewName),


### PR DESCRIPTION
### Description

Argument variables POIs weren't parsed in macro definition.
This PR fixes that.

Fixes comment in https://github.com/erlang-ls/erlang_ls/pull/1183#discussion_r795205932