### PR TITLE
Allow installing into custom directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 .PHONY: all
 
+PREFIX = '/usr/local'
+
 all:
 	@ echo "Building escript..."
 	@ rebar3 escriptize
 	@ rebar3 as dap escriptize
 
+.PHONY: install
 install: all
 	@ echo "Installing escript..."
-	@ cp _build/default/bin/erlang_ls /usr/local/bin
-	@ cp _build/dap/bin/els_dap /usr/local/bin
+	@ mkdir -p '${PREFIX}/bin'
+	@ cp _build/default/bin/erlang_ls ${PREFIX}/bin
+	@ cp _build/dap/bin/els_dap ${PREFIX}/bin
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ To install the produced `erlang_ls` escript in `/usr/local/bin`:
 
     make install
 
+To install to a different directory set the `PREFIX` environment variable:
+
+    PREFIX=/path/to/directory make -e install
+
 ## Command-line Arguments
 
 These are the command-line arguments that can be provided to the


### PR DESCRIPTION
### Description

Allows the user to install the built package into a different directory than `/usr/local` by setting the `PREFIX` environment variable.

```sh
PREFIX=/usr/local/stow/erlang_ls-0.21.2 make -e install
```

I want to keep my manually installed packages easy to upgrade and remove, so I use [GNU Stow](https://www.gnu.org/software/stow/) for that purpose. I install the package to `/usr/local/stow/<name>` (where `<name>` is some arbitrary name I chose), then have Stow create symlinks into `usr/local`. Stow owns these symlinks and if I want to remove or replace a package it knows exactly which symlinks to remove.

This is much better than having a number of files from various packages lying all around the system. erlang_ls is not bad, it has only two files, but even two files here and two files there can quickly add up.