### PR TITLE
Avoid compiler_diagnostics crash in case module name is invalid

### DIFF
--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -753,7 +753,9 @@ module_name_check(Path) ->
                              ?DIAGNOSTIC_ERROR,
                              <<"Compiler (via Erlang LS)">>),
               [Diagnostic]
-          end
+          end;
+        _ ->
+          []
       end;
     _ ->
       []


### PR DESCRIPTION
Invalid syntax on the module attribute can cause a crash.

