### PR TITLE
Fix handle module name whitespace

### DIFF
--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -32,10 +32,10 @@ module(Uri) ->
 -spec path(uri()) -> path().
 path(Uri) ->
   #{ host := Host
-   , path := Path
+   , path := Path0
    , scheme := <<"file">>
    } = uri_string:normalize(Uri, [return_map]),
-
+  Path = uri_string:percent_decode(Path0),
   case {is_windows(), Host} of
     {true, <<>>} ->
       % Windows drive letter, have to strip the initial slash
@@ -81,3 +81,21 @@ uri_join(List) ->
 is_windows() ->
   {OS, _} = os:type(),
   OS =:= win32.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+path_uri_test_() ->
+  [ ?_assertEqual( <<"/foo/bar.erl">>
+                 , path(<<"file:///foo/bar.erl">>))
+  , ?_assertEqual( <<"/foo/bar baz.erl">>
+                 , path(<<"file:///foo/bar%20baz.erl">>))
+  , ?_assertEqual( <<"/foo/bar.erl">>
+                 , path(uri(path(<<"file:///foo/bar.erl">>))))
+  , ?_assertEqual( <<"/foo/bar baz.erl">>
+                 , path(uri(<<"/foo/bar baz.erl">>)))
+  , ?_assertEqual( <<"file:///foo/bar%20baz.erl">>
+                 , uri(<<"/foo/bar baz.erl">>))
+  ].
+
+-endif.

--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -39,7 +39,7 @@ path(Uri, IsWindows) ->
    , path := Path0
    , scheme := <<"file">>
    } = uri_string:normalize(Uri, [return_map]),
-  Path = uri_string:percent_decode(Path0),
+  Path = percent_decode(Path0),
   case {IsWindows, Host} of
     {true, <<>>} ->
       % Windows drive letter, have to strip the initial slash
@@ -85,6 +85,16 @@ uri_join(List) ->
 is_windows() ->
   {OS, _} = os:type(),
   OS =:= win32.
+
+-if(?OTP_RELEASE >= 23).
+-spec percent_decode(binary()) -> binary().
+percent_decode(Str) ->
+  uri_string:percent_decode(Str).
+-else.
+-spec percent_decode(binary()) -> binary().
+percent_decode(Str) ->
+  http_uri:decode(Str).
+-endif.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/apps/els_lsp/priv/code_navigation/src/diagnostics module name check.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics module name check.erl
@@ -1,0 +1,1 @@
+-module('diagnostics module name check').

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -42,6 +42,7 @@
         , unused_record_fields/1
         , gradualizer/1
         , module_name_check/1
+        , module_name_check_whitespace/1
         ]).
 
 %%==============================================================================
@@ -665,6 +666,15 @@ module_name_check(_Config) ->
               , range => {{0, 8}, {0, 25}}
               }
            ],
+  Warnings = [],
+  Hints = [],
+  els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
+-spec module_name_check_whitespace(config()) -> ok.
+module_name_check_whitespace(_Config) ->
+  Path = src_path("diagnostics module name check.erl"),
+  Source = <<"Compiler (via Erlang LS)">>,
+  Errors = [],
   Warnings = [],
   Hints = [],
   els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).


### PR DESCRIPTION
### Description
Fix false positive module name check diagnostic

Discovered that modules with whitespace in their name could cause false
positives in the module name check diagnostic.
Root cause is in els_uri:path/1, since uri_string:normalize/1 return a percent
encoded path, we need to percent decode that path to get the real path.
