### PR TITLE
Add support for renaming modules

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/rename_module_a.erl
+++ b/apps/els_lsp/priv/code_navigation/src/rename_module_a.erl
@@ -1,0 +1,16 @@
+-module(rename_module_a).
+
+-export([ function_a/0
+        , function_b/0
+        ]).
+-export_type([type_a/0]).
+
+-type type_a() :: any().
+
+-callback function_a() -> type_a().
+
+function_a() ->
+  a.
+
+function_b() ->
+  b.

--- a/apps/els_lsp/priv/code_navigation/src/rename_module_b.erl
+++ b/apps/els_lsp/priv/code_navigation/src/rename_module_b.erl
@@ -1,0 +1,14 @@
+-module(rename_module_b).
+
+-behaviour(rename_module_a).
+-import(rename_module_a, [function_b/0]).
+
+-export([function_a/0]).
+
+-type type_a() :: rename_module_a:type_a().
+
+-spec function_a() -> type_a().
+function_a() ->
+  rename_module_a:function_a(),
+  F = fun rename_module_a:function_a/0,
+  F().

--- a/apps/els_lsp/src/els_references_provider.erl
+++ b/apps/els_lsp/src/els_references_provider.erl
@@ -9,6 +9,7 @@
 %% For use in other providers
 -export([ find_references/2
         , find_scoped_references_for_def/2
+        , find_references_to_module/1
         ]).
 
 %%==============================================================================
@@ -105,16 +106,8 @@ find_references(Uri, Poi = #{kind := Kind})
         find_scoped_references_for_def(Uri, Poi))
   end;
 find_references(Uri, #{kind := module}) ->
-  case els_utils:lookup_document(Uri) of
-    {ok, Doc} ->
-      Exports = els_dt_document:pois(Doc, [export_entry]),
-      ExcludeLocalRefs =
-        fun(Loc) ->
-            maps:get(uri, Loc) =/= Uri
-        end,
-      Refs = lists:flatmap(fun(E) -> find_references(Uri, E) end, Exports),
-      lists:filter(ExcludeLocalRefs, Refs)
-  end;
+  Refs = find_references_to_module(Uri),
+  [location(U, R) || #{uri := U, range := R} <- Refs];
 find_references(_Uri, #{kind := Kind, id := Name})
   when Kind =:= behaviour ->
   find_references_for_id(Kind, Name);
@@ -141,6 +134,27 @@ kind_to_ref_kinds(type_definition) ->
 kind_to_ref_kinds(Kind) ->
   [Kind].
 
+-spec find_references_to_module(uri()) -> [els_dt_references:item()].
+find_references_to_module(Uri) ->
+  M = els_uri:module(Uri),
+  {ok, Doc} = els_utils:lookup_document(Uri),
+  ExportRefs =
+    lists:flatmap(
+      fun(#{id := {F, A}}) ->
+          {ok, Rs} =
+            els_dt_references:find_by_id(export_entry, {M, F, A}),
+          Rs
+      end, els_dt_document:pois(Doc, [export_entry])),
+  ExportTypeRefs =
+    lists:flatmap(
+      fun(#{id := {F, A}}) ->
+          {ok, Rs} =
+            els_dt_references:find_by_id(export_type_entry, {M, F, A}),
+          Rs
+      end, els_dt_document:pois(Doc, [export_type_entry])),
+  {ok, BehaviourRefs} = els_dt_references:find_by_id(behaviour, M),
+  ExcludeLocalRefs = fun(Loc) -> maps:get(uri, Loc) =/= Uri end,
+  lists:filter(ExcludeLocalRefs, ExportRefs ++ ExportTypeRefs ++ BehaviourRefs).
 
 -spec find_references_for_id(poi_kind(), any()) -> [location()].
 find_references_for_id(Kind, Id) ->


### PR DESCRIPTION
### Description
Add support for renaming modules.
Put cursor at modname in `-module(modname)`, and trigger the rename command.
This will rename the .erl file (in the same directory), updated the -module attribute 
and update references to the module such as:
* Function applications 
* Type applications
* Implicit functions
* Imports
* -behaviour attributes

This PR also improves the "find references" functionality for modules, previously it only displayed function references.

There's a small race condition with Emacs `erlang-mode` as it wants to be helpful and suggest that the old filename doesn't match the new module name, you need to answer no when it asks if it should fix the module name.
Personally I have now disabled that check:
`(setq erlang-check-module-name nil)` 
This feature could be handled by erlang_ls with a code action instead as 
we already have a diagnostic to check the module name.
Could be a good beginner task :+1: 