### PR TITLE
Revert "Precompute list of enabled diagnostics"

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -163,7 +163,6 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
   ok = set(otp_paths      , otp_paths(OtpPath, false) -- ExcludePaths),
   ok = set(lenses         , Lenses),
   ok = set(diagnostics    , Diagnostics),
-  ok = set(enabled_diagnostics, els_diagnostics:enabled_diagnostics()),
   %% All (including subdirs) paths used to search files with file:path_open/3
   ok = set( search_paths
           , lists:append([ project_paths(RootPath, AppsDirs, true)

--- a/apps/els_lsp/src/els_diagnostics.erl
+++ b/apps/els_lsp/src/els_diagnostics.erl
@@ -90,7 +90,7 @@ make_diagnostic(Range, Message, Severity, Source) ->
 
 -spec run_diagnostics(uri()) -> [pid()].
 run_diagnostics(Uri) ->
-  [run_diagnostic(Uri, Id) || Id <- els_config:get(enabled_diagnostics)].
+  [run_diagnostic(Uri, Id) || Id <- enabled_diagnostics()].
 
 %%==============================================================================
 %% Internal Functions


### PR DESCRIPTION
This reverts commit 2f6decd8cfe342da60e102b55cde66c4af7f784a.

This change introduced a regression in the debugger, preventing it from starting.
The `els_dap` escript invokes the `els_config` initialization procedure
(see https://github.com/erlang-ls/erlang_ls/commit/4b475b0864f433ccc08c80609478f5b15b9b41b7),
but the new version of the initialization depends on the `els_diagnostics` module,
which is part of the `els_lsp` application, not included in the `els_dap` escript.

For now simply reverting the change, but we should revisit the application structure.
The original idea was for an application to contain the implementation of the JSON-RPC protocol
and for the `els_dap` and `els_lsp` to utilize that as a dependency. That never really happened
and the current application split in Erlang LS in its current form feels a bit arbitrary.
One may argue that Erlang LS could get rid of the umbrella structure and be a single application.

