### PR TITLE
Fix support for renaming modules

### DIFF
--- a/apps/els_lsp/src/els_rename_provider.erl
+++ b/apps/els_lsp/src/els_rename_provider.erl
@@ -60,14 +60,14 @@ workspace_edits(OldUri, [#{kind := module} = POI| _], NewName) ->
                                              , type_application
                                              , behaviour
                                              ]),
-  Changes = [#{ textDocument => #{uri => RefUri}
+  Changes = [#{ textDocument => #{uri => RefUri, version => null}
               , edits => [#{ range => editable_range(RefPOI, module)
                            , newText => NewName
                            }]
               } || {RefUri, RefPOI} <- RefPOIs],
   #{documentChanges =>
       [ %% Update -module attribute
-        #{textDocument => #{uri => OldUri},
+        #{textDocument => #{uri => OldUri, version => null},
           edits => [change(POI, NewName)]
          }
         %% Rename file

--- a/apps/els_lsp/test/els_rename_SUITE.erl
+++ b/apps/els_lsp/test/els_rename_SUITE.erl
@@ -233,26 +233,26 @@ rename_module(Config) ->
   Expected = [
               %% Module attribute
                #{ edits => [change(NewName, {0, 8}, {0, 23})]
-                , textDocument => #{uri => UriA}}
+                , textDocument => #{uri => UriA, version => null}}
               %% Rename file
              , #{ kind => <<"rename">>
                 , newUri => NewUri
                 , oldUri => UriA}
               %% Implicit function
              , #{ edits => [change(NewName, {12, 10}, {12, 25})]
-                , textDocument => #{uri => UriB}}
+                , textDocument => #{uri => UriB, version => null}}
               %% Function application
              , #{ edits => [change(NewName, {11, 2}, {11, 17})]
-                , textDocument => #{uri => UriB}}
+                , textDocument => #{uri => UriB, version => null}}
               %% Import
              , #{ edits => [change(NewName, {3, 8}, {3, 23})]
-                , textDocument => #{uri => UriB}}
+                , textDocument => #{uri => UriB, version => null}}
               %% Type application
              , #{ edits => [change(NewName, {7, 18}, {7, 33})]
-                , textDocument => #{uri => UriB}}
+                , textDocument => #{uri => UriB, version => null}}
               %% Behaviour
              , #{ edits => [change(NewName, {2, 11}, {2, 26})]
-                , textDocument => #{uri => UriB}}
+                , textDocument => #{uri => UriB, version => null}}
              ],
   ?assertEqual([], Result -- Expected),
   ?assertEqual([], Expected -- Result),


### PR DESCRIPTION
The textDocument parameter in a TextDocumentEdit must contain a version, even if null (see the OptionalVersionedTextDocumentIdentifier definition from the LSP specification). Without it, some editors (most notably VS Code) would reject the edits.
