### PR TITLE
Fix unused variable quickaction 

### DIFF
--- a/apps/els_lsp/src/els_code_action_provider.erl
+++ b/apps/els_lsp/src/els_code_action_provider.erl
@@ -77,11 +77,17 @@ unused_variable_action(Uri, Range, Message) ->
   end.
 
 -spec make_unused_variable_action(uri(), range(), binary()) -> [map()].
-make_unused_variable_action(Uri, Range, UnusedVariable) ->
+make_unused_variable_action(Uri, Range0, UnusedVariable) ->
   #{ <<"start">> := #{ <<"character">> := _StartCol
                      , <<"line">>      := StartLine }
-   , <<"end">>   := _End
-   } = Range,
+   , <<"end">>   := #{ <<"character">> := EndCol
+                     , <<"line">>      := EndLine }
+   } = Range0,
+  %% Add +1 to end line because is the same as start line and
+  %% replace_lines_action/5 will add a line instead in that case
+  End = #{ <<"character">> => EndCol, <<"line">> => EndLine+1 },
+  Range = maps:put(<<"end">>, End, Range0),
+
   %% processing messages like "variable 'Foo' is unused"
   {ok, #{text := Bin}} = els_utils:lookup_document(Uri),
   Line = els_utils:to_list(els_text:line(Bin, StartLine)),

--- a/apps/els_lsp/test/els_code_action_SUITE.erl
+++ b/apps/els_lsp/test/els_code_action_SUITE.erl
@@ -58,13 +58,13 @@ end_per_testcase(TestCase, Config) ->
 add_underscore_to_unused_var(Config) ->
   Uri = ?config(code_navigation_uri, Config),
   Diag = #{ message  => <<"variable 'A' is unused">>
-          , range    => #{ 'end' => #{character => 0, line => 80}
+          , range    => #{ 'end' => #{character => 0, line => 79}
                          , start => #{character => 0, line => 79}
                          }
           , severity => 2
           , source   => <<"Compiler">>
           },
-  Range = els_protocol:range(#{from => {80, 1}, to => {81, 1}}),
+  Range = els_protocol:range(#{from => {80, 1}, to => {80, 1}}),
   PrefixedCommand = els_command:with_prefix(<<"replace-lines">>),
   #{result := Result} = els_client:document_codeaction(Uri, Range, [Diag]),
   Expected =


### PR DESCRIPTION
Fixes #1082

The action was created with the same start and end line, which when replaced caused the line to be added instead of replaced

Wanted to add a test to actually verify the change in the file, but couldn't figure out how to get the changes or updated file after doing `els_client:workspace_executecommand/2`