### PR TITLE
Edoc diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
       run: rebar3 do cover, coveralls send
     - name: Produce Documentation
       run: rebar3 edoc
+      if: ${{ matrix.otp-version == '24' }}
     - name: Publish Documentation
       uses: actions/upload-artifact@v2
       with:

--- a/apps/els_lsp/priv/code_navigation/src/edoc_diagnostics.erl
+++ b/apps/els_lsp/priv/code_navigation/src/edoc_diagnostics.erl
@@ -1,0 +1,15 @@
+-module(edoc_diagnostics).
+
+-export([main/0]).
+
+%% @edoc Main function
+main() ->
+  internal().
+
+%% @docc internal
+internal() ->
+  ok.
+
+%% @doc `
+unused() ->
+  ok.

--- a/apps/els_lsp/src/edoc_report.erl
+++ b/apps/els_lsp/src/edoc_report.erl
@@ -1,0 +1,101 @@
+%% =====================================================================
+%% Licensed under the Apache License, Version 2.0 (the "License"); you may
+%% not use this file except in compliance with the License. You may obtain
+%% a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% Alternatively, you may use this file under the terms of the GNU Lesser
+%% General Public License (the "LGPL") as published by the Free Software
+%% Foundation; either version 2.1, or (at your option) any later version.
+%% If you wish to allow use of your version of this file only under the
+%% terms of the LGPL, you should delete the provisions above and replace
+%% them with the notice and other provisions required by the LGPL; see
+%% <http://www.gnu.org/licenses/>. If you do not delete the provisions
+%% above, a recipient may use your version of this file under the terms of
+%% either the Apache License or the LGPL.
+%%
+%% @private
+%% @copyright 2001-2003 Richard Carlsson
+%% @author Richard Carlsson <carlsson.richard@gmail.com>
+%% @see edoc
+%% @end
+%% =====================================================================
+
+%% @doc EDoc verbosity/error reporting.
+
+-module(edoc_report).
+
+%% Avoid warning for local functions error/{1,2,3} clashing with autoimported BIF.
+-compile({no_auto_import, [error/1, error/2, error/3]}).
+-export([error/1,
+	 error/2,
+	 error/3,
+	 report/2,
+	 report/3,
+	 report/4,
+	 warning/1,
+	 warning/2,
+	 warning/3,
+	 warning/4]).
+
+-include("edoc.hrl").
+
+
+error(What) ->
+    error([], What).
+
+error(Where, What) ->
+    error(0, Where, What).
+
+error(Line, Where, S) when is_list(S) ->
+    report(Line, Where, S, []);
+error(Line, Where, {S, D}) when is_list(S) ->
+    report(Line, Where, S, D);
+error(Line, Where, {format_error, M, D}) ->
+    report(Line, Where, M:format_error(D), []).
+
+warning(S) ->
+    warning(S, []).
+
+warning(S, Vs) ->
+    warning([], S, Vs).
+
+warning(Where, S, Vs) ->
+    warning(0, Where, S, Vs).
+
+warning(L, Where, S, Vs) ->
+    report(L, Where, "warning: " ++ S, Vs).
+
+report(S, Vs) ->
+    report([], S, Vs).
+
+report(Where, S, Vs) ->
+    report(0, Where, S, Vs).
+
+report(L, Where, S, Vs) ->
+    io:put_chars(where(Where)),
+    if is_integer(L), L > 0 ->
+	    io:fwrite("at line ~w: ", [L]);
+       true ->
+	    ok
+    end,
+    io:fwrite(S, Vs),
+    io:nl().
+
+where({File, module}) ->
+    io_lib:fwrite("~ts, in module header: ", [File]);
+where({File, footer}) ->
+    io_lib:fwrite("~ts, in module footer: ", [File]);
+where({File, header}) ->
+    io_lib:fwrite("~ts, in header file: ", [File]);
+where({File, {F, A}}) ->
+    io_lib:fwrite("~ts, function ~ts/~w: ", [File, F, A]);
+where([]) ->
+    io_lib:fwrite("~s: ", [?APPLICATION]);
+where(File) when is_list(File) ->
+    File ++ ": ".

--- a/apps/els_lsp/src/edoc_report.erl
+++ b/apps/els_lsp/src/edoc_report.erl
@@ -33,69 +33,69 @@
 %% Avoid warning for local functions error/{1,2,3} clashing with autoimported BIF.
 -compile({no_auto_import, [error/1, error/2, error/3]}).
 -export([error/1,
-	 error/2,
-	 error/3,
-	 report/2,
-	 report/3,
-	 report/4,
-	 warning/1,
-	 warning/2,
-	 warning/3,
-	 warning/4]).
+         error/2,
+         error/3,
+         report/2,
+         report/3,
+         report/4,
+         warning/1,
+         warning/2,
+         warning/3,
+         warning/4]).
 
--include("edoc.hrl").
+-include_lib("edoc/src/edoc.hrl").
 
 
 error(What) ->
-    error([], What).
+  error([], What).
 
 error(Where, What) ->
-    error(0, Where, What).
+  error(0, Where, What).
 
 error(Line, Where, S) when is_list(S) ->
-    report(Line, Where, S, []);
+  report(Line, Where, S, []);
 error(Line, Where, {S, D}) when is_list(S) ->
-    report(Line, Where, S, D);
+  report(Line, Where, S, D);
 error(Line, Where, {format_error, M, D}) ->
-    report(Line, Where, M:format_error(D), []).
+  report(Line, Where, M:format_error(D), []).
 
 warning(S) ->
-    warning(S, []).
+  warning(S, []).
 
 warning(S, Vs) ->
-    warning([], S, Vs).
+  warning([], S, Vs).
 
 warning(Where, S, Vs) ->
-    warning(0, Where, S, Vs).
+  warning(0, Where, S, Vs).
 
 warning(L, Where, S, Vs) ->
-    report(L, Where, "warning: " ++ S, Vs).
+  report(L, Where, "warning: " ++ S, Vs).
 
 report(S, Vs) ->
-    report([], S, Vs).
+  report([], S, Vs).
 
 report(Where, S, Vs) ->
-    report(0, Where, S, Vs).
+  report(0, Where, S, Vs).
 
 report(L, Where, S, Vs) ->
-    io:put_chars(where(Where)),
-    if is_integer(L), L > 0 ->
+  io:put_chars(where(Where)),
+  if is_integer(L), L > 0 ->
 	    io:fwrite("at line ~w: ", [L]);
-       true ->
+     true ->
 	    ok
-    end,
-    io:fwrite(S, Vs),
-    io:nl().
+  end,
+  io:fwrite(S, Vs),
+  io:nl().
 
 where({File, module}) ->
-    io_lib:fwrite("~ts, in module header: ", [File]);
+  io_lib:fwrite("~ts, in module header: ", [File]);
 where({File, footer}) ->
-    io_lib:fwrite("~ts, in module footer: ", [File]);
+  io_lib:fwrite("~ts, in module footer: ", [File]);
 where({File, header}) ->
-    io_lib:fwrite("~ts, in header file: ", [File]);
+  io_lib:fwrite("~ts, in header file: ", [File]);
 where({File, {F, A}}) ->
-    io_lib:fwrite("~ts, function ~ts/~w: ", [File, F, A]);
+  io_lib:fwrite("~ts, function ~ts/~w: ", [File, F, A]);
 where([]) ->
-    io_lib:fwrite("~s: ", [?APPLICATION]);
+  io_lib:fwrite("~s: ", [?APPLICATION]);
 where(File) when is_list(File) ->
-    File ++ ": ".
+  File ++ ": ".

--- a/apps/els_lsp/src/els_diagnostics.erl
+++ b/apps/els_lsp/src/els_diagnostics.erl
@@ -61,6 +61,7 @@ available_diagnostics() ->
   , <<"compiler">>
   , <<"crossref">>
   , <<"dialyzer">>
+  , <<"edoc">>
   , <<"gradualizer">>
   , <<"elvis">>
   , <<"unused_includes">>

--- a/apps/els_lsp/src/els_edoc_diagnostics.erl
+++ b/apps/els_lsp/src/els_edoc_diagnostics.erl
@@ -1,0 +1,93 @@
+%%==============================================================================
+%% Edoc diagnostics
+%%==============================================================================
+-module(els_edoc_diagnostics).
+
+%%==============================================================================
+%% Behaviours
+%%==============================================================================
+-behaviour(els_diagnostics).
+
+%%==============================================================================
+%% Exports
+%%==============================================================================
+-export([ is_default/0
+        , run/1
+        , source/0
+        ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("els_lsp.hrl").
+
+%%==============================================================================
+%% Callback Functions
+%%==============================================================================
+
+-spec is_default() -> boolean().
+is_default() ->
+  false.
+
+%% The edoc application currently does not offer an API to
+%% programmatically return a list of warnings and errors. Instead,
+%% it simply outputs the warnings and errors to the standard
+%% output.
+%% We created an issue for the OTP team to address this:
+%% https://github.com/erlang-ls/erlang_ls/issues/384
+%% Meanwhile, hackity-hack!
+%% Let's override the reporting module for edoc (edoc_report)
+%% and (ab)use the process dictionary to collect the list of
+%% warnings and errors.
+-spec run(uri()) -> [els_diagnostics:diagnostic()].
+run(Uri) ->
+  Paths = [els_utils:to_list(els_uri:path(Uri))],
+  Fun = fun(Dir) ->
+            Options = edoc_options(Dir),
+            put(edoc_diagnostics, []),
+            try
+              edoc:run(Paths, Options)
+            catch
+              _:_:_ ->
+                ok
+            end,
+            [make_diagnostic(L, Format, Args, Severity) ||
+              {L, _Where, Format, Args, Severity}
+                <- get(edoc_diagnostics), L =/= 0]
+        end,
+  tempdir:mktmp(Fun).
+
+-spec source() -> binary().
+source() ->
+  <<"Edoc">>.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+-spec edoc_options(string()) -> proplists:proplist().
+edoc_options(Dir) ->
+  Macros = [{N, V} || {'d', N, V} <- els_compiler_diagnostics:macro_options()],
+  Includes = [I || {i, I} <- els_compiler_diagnostics:include_options()],
+  [ {preprocess, true}
+  , {macros, Macros}
+  , {includes, Includes}
+  , {dir, Dir}
+  ].
+
+-spec make_diagnostic(pos_integer(), string(), [any()], warning | error) ->
+        els_diagnostics:diagnostic().
+make_diagnostic(Line, Format, Args, Severity0) ->
+  Severity = severity(Severity0),
+  Message = els_utils:to_binary(io_lib:format(Format, Args)),
+  els_diagnostics:make_diagnostic( els_protocol:range(#{ from => {Line, 1}
+                                                       , to => {Line + 1, 1}
+                                                       })
+                                 , Message
+                                 , Severity
+                                 , source()).
+
+-spec severity(warning | error) -> els_diagnostics:severity().
+severity(warning) ->
+  ?DIAGNOSTIC_WARNING;
+severity(error) ->
+  ?DIAGNOSTIC_ERROR.

--- a/apps/els_lsp/src/els_lsp.app.src
+++ b/apps/els_lsp/src/els_lsp.app.src
@@ -6,6 +6,7 @@
     {applications, [
         kernel,
         stdlib,
+        edoc,
         docsh,
         elvis_core,
         rebar3_format,

--- a/apps/els_lsp/test/els_test.erl
+++ b/apps/els_lsp/test/els_test.erl
@@ -79,7 +79,9 @@ assert_diagnostics(Source, Expected, Diagnostics, Severity) ->
   Filtered = [D || #{severity := S} = D <- Diagnostics, S =:= Severity],
   Simplified = [simplify_diagnostic(D) || D  <- Filtered],
   FixedExpected = [maybe_fix_range(Source, D) || D <- Expected],
-  ?assertEqual(FixedExpected, Simplified, Filtered).
+  ?assertEqual(lists:sort(FixedExpected),
+               lists:sort(Simplified),
+               Filtered).
 
 -spec simplify_diagnostic(els_diagnostics:diagnostic()) ->
         simplified_diagnostic().

--- a/elvis.config
+++ b/elvis.config
@@ -34,6 +34,7 @@
                                                                         , els_tcp
                                                                         , els_dap_test_utils
                                                                         , els_test_utils
+                                                                        , edoc_report
                                                                         ]}}
                       , {elvis_text_style, line_length, #{limit => 80, skip_comments => false}}
                       , {elvis_style, operator_spaces, #{ rules => [ {right, ","}


### PR DESCRIPTION
### Description

This PR introduce support for [edoc](https://www.erlang.org/doc/apps/edoc/chapter.html) diagnostics.

<img width="928" alt="Screenshot 2022-02-19 at 15 50 56" src="https://user-images.githubusercontent.com/91769/154806614-ed66ceee-9e32-42b4-9775-b658968caedf.png">

There are a couple of limitations in the current `edoc` API:

* The list of errors and warnings is simply printed out using the `stdio` and not returned to the caller
* The process exits at the first error occurrence

An issue has been [created](https://github.com/erlang/otp/issues/5056) for the OTP team to address these.
The current solution (ab)uses the process dictionary, a fork of the `edoc_report` module and a try/catch to temporarily circumvent these limitations.

This diagnostics backend is disabled by default. To enable it, add the following to your `erlang_ls.config`:

```
diagnostics:
  enabled:
    - edoc
```

Fixes #384.
