### PR TITLE
Avoid negative line numbers in elvis diagnostics.

### DIFF
--- a/apps/els_lsp/src/els_elvis_diagnostics.erl
+++ b/apps/els_lsp/src/els_elvis_diagnostics.erl
@@ -91,8 +91,11 @@ format_item(_Name, []) ->
 -spec diagnostic(any(), any(), integer(), [any()],
                  els_diagnostics:severity()) -> [map()].
 diagnostic(Name, Msg, Ln, Info, Severity) ->
+  %% Avoid negative line numbers
+  DiagLine = make_protocol_line(Ln),
   FMsg    = io_lib:format(Msg, Info),
-  Range   = els_protocol:range(#{from => {Ln, 1}, to => {Ln + 1, 1}}),
+  Range   = els_protocol:range(#{ from => {DiagLine, 1}
+                                , to   => {DiagLine + 1, 1}}),
   Message = els_utils:to_binary(FMsg),
   [#{ range    => Range
     , severity => Severity
@@ -101,6 +104,12 @@ diagnostic(Name, Msg, Ln, Info, Severity) ->
     , message  => Message
     , relatedInformation => []
     }].
+
+-spec make_protocol_line(Line :: number()) -> number().
+make_protocol_line(Line) when Line =< 0 ->
+  1;
+make_protocol_line(Line) ->
+  Line.
 
 -spec get_elvis_config_path() -> file:filename_all().
 get_elvis_config_path() ->


### PR DESCRIPTION
### Description

I noticed that elvis will set line number to 0 for the atom_naming_convention diagnostic, which results in ErlangLS sending -1 as line number to the LSP client. This makes at least VS code not show any other elvis diagnostics, even other diagnostics with valid line numbers.

This fix will set line number to 1 if we get 0 or below from elvis.

Will try to make a pull request to elvis_core as well to make it send an actual line number, but I think this precaution can still be good.