### PR TITLE
Update Gradualizer to the current master

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
        , {ephemeral,     "2.0.4"}
        , {tdiff,         "0.1.2"}
        , {uuid,          "2.0.1", {pkg, uuid_erl}}
-       , {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {ref, "e93db1c"}}}
+       , {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {ref, "6e89b4e"}}}
        ]
 }.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,7 @@
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},2},
  {<<"gradualizer">>,
   {git,"https://github.com/josefs/Gradualizer.git",
-       {ref,"e93db1c6725760def005c69d72f53b1a889b4c2f"}},
+       {ref,"6e89b4e1cd489637a848cc5ca55058c8a241bf7d"}},
   0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"3.0.0">>},0},
  {<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.2.1">>},1},


### PR DESCRIPTION
This updates Gradualizer to the tip of the current master branch, therefore brings in a number of fixes:
- https://github.com/josefs/Gradualizer/pull/383 - this prevents Gradualizer running in the ErlangLS BEAM instance from hogging CPU if it encounters some rare form causing the typechecker to fall into an infinite loop; in other words, it turns non-termination into a warning reported as any other diagnostic; overall, it greatly improves the UX and robustness
- https://github.com/josefs/Gradualizer/pull/384 - this fixes a bug where location of undefined/unexported types would be reported as line 0
- https://github.com/josefs/Gradualizer/pull/385 - this adds the Git commit sha to Gradualizer version, which makes comparing the behaviour of different builds much more convenient
- https://github.com/josefs/Gradualizer/pull/389 - this fixes inconsistency between map patterns and non-map patterns in function heads of unspecced functions; the former would lead to a warning, whereas the latter wouldn't; none of them cause a warning now.