### PR TITLE
Reload project-specific files on every Graudalizer diagnostic run

### DIFF
--- a/apps/els_lsp/src/els_gradualizer_diagnostics.erl
+++ b/apps/els_lsp/src/els_gradualizer_diagnostics.erl
@@ -32,16 +32,20 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  case start_and_load() of
-    true ->
-      Path = unicode:characters_to_list(els_uri:path(Uri)),
-      Includes = [{i, I} || I <- els_config:get(include_paths)],
-      Opts = [return_errors] ++ Includes,
-      Errors = gradualizer:type_check_files([Path], Opts),
-      lists:flatmap(fun analyzer_error/1, Errors);
-    false ->
-      []
-  end.
+  Files = lists:flatmap(
+            fun(Dir) ->
+                filelib:wildcard(filename:join(Dir, "*.erl"))
+            end,
+            els_config:get(apps_paths) ++ els_config:get(deps_paths)),
+  ?LOG_INFO("Importing files into gradualizer_db: ~p", [Files]),
+  ok = gradualizer_db:import_erl_files(Files,
+                                       els_config:get(include_paths)),
+  Path = unicode:characters_to_list(els_uri:path(Uri)),
+  Includes = [{i, I} || I <- els_config:get(include_paths)],
+  Opts = [return_errors] ++ Includes,
+  Errors = gradualizer:type_check_files([Path], Opts),
+  ?LOG_INFO("Gradualizer diagnostics: ~p", [Errors]),
+  lists:flatmap(fun analyzer_error/1, Errors).
 
 -spec source() -> binary().
 source() ->
@@ -50,25 +54,6 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
-
--spec start_and_load() -> boolean().
-start_and_load() ->
-  try application:ensure_all_started(gradualizer) of
-    {ok, [gradualizer]} ->
-      Files = lists:flatmap(
-                fun(Dir) ->
-                    filelib:wildcard(filename:join(Dir, "*.erl"))
-                end,
-                els_config:get(apps_paths) ++ els_config:get(deps_paths)),
-      ok = gradualizer_db:import_erl_files(Files,
-                                           els_config:get(include_paths)),
-      true;
-    {ok, []} ->
-      true
-  catch E:R ->
-          ?LOG_ERROR("Could not start gradualizer: ~p ~p", [E, R]),
-          false
-  end.
 
 -spec analyzer_error(any()) -> any().
 analyzer_error({_Path, Error}) ->


### PR DESCRIPTION
The check to determine if project files should be imported into Gradualizer comes from the time when the integration relied on Gradualizer being available through ERL_LIBS and would only be started by the diagnostic being called.

Now that Gradualizer is a dependency of ErlangLS, it's running on each startup since ErlangLS itself. This means the check never succeeds, therefore the project specific files necessary for properly setting up the typechecker are never loaded. This leads to false positives being reported such as missing remote types or record definitions.

Reimporting the project files on each run might be a bit redundant, but it seems to work reasonably well in practice. Dogfooding this solution shows it doesn't lead to visible unnecessary load on the system.