### PR TITLE
add completion for clauses

### DIFF
--- a/apps/els_core/include/els_core.hrl
+++ b/apps/els_core/include/els_core.hrl
@@ -134,6 +134,15 @@
                             | ?INSERT_TEXT_FORMAT_SNIPPET.
 
 %%------------------------------------------------------------------------------
+%% Insert Text Mode
+%%------------------------------------------------------------------------------
+
+-define(INSERT_TEXT_MODE_AS_IS, 1).
+-define(INSERT_TEXT_MODE_ADJUST_INDENTATION, 2).
+
+-type insert_text_mode() :: ?INSERT_TEXT_MODE_AS_IS
+                          | ?INSERT_TEXT_MODE_ADJUST_INDENTATION.
+%%------------------------------------------------------------------------------
 %% Text Edit
 %%------------------------------------------------------------------------------
 -type text_edit() :: #{ range   := range()
@@ -308,6 +317,7 @@
                             , kind => completion_item_kind()
                             , insertText => binary()
                             , insertTextFormat => insert_text_format()
+                            , insertTextMode => insert_text_mode()
                             , data => map()
                             }.
 

--- a/apps/els_lsp/priv/code_navigation/src/completion_clause.erl
+++ b/apps/els_lsp/priv/code_navigation/src/completion_clause.erl
@@ -1,0 +1,13 @@
+-module(completion_clause).
+
+-export([f/1]).
+
+f(Arg1) ->
+    case Arg1 of
+        42 -> fun (1) -> one;
+                  (2) -> two
+              end;
+        _ -> ok
+    end;
+f(_) ->
+    ok.

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -897,7 +897,10 @@ format_macro({Name0, _Arity}, Args, SnippetSupport) ->
 format_macro(Name, none, _SnippetSupport) ->
   atom_to_binary(Name, utf8).
 
--spec snippet_function_clause(atom(), [{integer(), string()}], boolean()) -> binary().
+-spec snippet_function_clause( atom()
+                             , [{integer()
+                             , string()}]
+                             , boolean()) -> binary().
 snippet_function_clause(Name, Args, SnippetSupport) ->
   FunctionSnippet = format_args(atom_to_label(Name), Args, SnippetSupport),
   Clause = ["\n", FunctionSnippet, " -> "],

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -714,7 +714,9 @@ completion_item(#{kind := Kind, id := {F, A}, data := POIData}, Data, false)
    , insertTextFormat => Format
    , data             => Data
    };
-completion_item(#{kind := function_clause, id := {F, A}, data := POIData}, Data, false) ->
+completion_item( #{kind := function_clause, id := {F, A}, data := POIData}
+               , Data
+               , false) ->
   ArgsNames = maps:get(args, POIData),
   Label = io_lib:format("function clause for ~p/~p", [F, A]),
   #{ label            => els_utils:to_binary(Label)

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -665,7 +665,7 @@ clause_completion_snipppets(fun_clause) ->
     , true)
   , clause_completion_snippet(
       <<"(Args) when Guard ->">>
-    , <<"\n$){1:Args})${2: when ${3:Guard}} ->\n\t">>
+    , <<"\n$({1:Args})${2: when ${3:Guard}} ->\n\t">>
     , false)].
 
 -spec clause_completion_snippet(binary(), binary(), boolean()) -> map().

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -616,7 +616,7 @@ last_clause(POIs, Line, WantName, WantArity) ->
                , undefined
                , SortedClauses).
 
--spec clause_completion_type(erlfmt_scan:token()) -> function | 'fun' | other.
+-spec clause_completion_type([erlfmt_scan:token()]) -> function | 'fun' | other.
 clause_completion_type(Tokens) ->
   [_ | BodyToken] =
     lists:dropwhile( fun ({'->', _}) -> false;
@@ -653,6 +653,7 @@ process_token(T, Stack) ->
       Stack
   end.
 
+-spec clause_completion_snipppets(other_clause | fun_clause) -> map().
 clause_completion_snipppets(other_clause) ->
   #{ label            => els_utils:to_binary("new clause")
    , kind             => completion_item_kind(snippet)

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -30,7 +30,10 @@ in(#{from := FromA, to := ToA}, #{from := FromB, to := ToB}) ->
   FromA >= FromB andalso ToA =< ToB.
 
 -spec in_range(Line :: line(), Column :: column(), POI :: poi()) -> boolean().
-in_range(Line, Column, #{data := #{wrapping_range := #{from := {FromLine, FromColumn}, to := {ToLine, ToColumn}}}}) ->
+in_range( Line
+        , Column
+        , #{ data := #{wrapping_range := #{from := {FromLine, FromColumn}
+           , to := {ToLine, ToColumn}}}}) ->
          (FromLine < Line andalso Line < ToLine)
   orelse (FromLine =:= Line andalso FromColumn =< Column)
   orelse (Line =:= ToLine andalso Column =< ToColumn).

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -2,8 +2,11 @@
 
 -include("els_lsp.hrl").
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([ compare/2
         , in/2
+        , in_range/3
         , range/4
         , range/1
         , line/1
@@ -25,6 +28,12 @@ compare(_, _) ->
 -spec in(poi_range(), poi_range()) -> boolean().
 in(#{from := FromA, to := ToA}, #{from := FromB, to := ToB}) ->
   FromA >= FromB andalso ToA =< ToB.
+
+-spec in_range(Line :: line(), Column :: column(), POI :: poi()) -> boolean().
+in_range(Line, Column, #{data := #{wrapping_range := #{from := {FromLine, FromColumn}, to := {ToLine, ToColumn}}}}) ->
+         (FromLine < Line andalso Line < ToLine)
+  orelse (FromLine =:= Line andalso FromColumn =< Column)
+  orelse (Line =:= ToLine andalso Column =< ToColumn).
 
 -spec range(pos() | {pos(), pos()} | erl_anno:anno(), poi_kind(), any(), any())
    -> poi_range().

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -32,11 +32,13 @@ in(#{from := FromA, to := ToA}, #{from := FromB, to := ToB}) ->
 -spec in_range(Line :: line(), Column :: column(), POI :: poi()) -> boolean().
 in_range( Line
         , Column
-        , #{ data := #{wrapping_range := #{from := {FromLine, FromColumn}
-           , to := {ToLine, ToColumn}}}}) ->
+        , #{ data := #{wrapping_range := #{ from := {FromLine, FromColumn}
+                                          , to := {ToLine, ToColumn}}}}
+        ) ->
          (FromLine < Line andalso Line < ToLine)
   orelse (FromLine =:= Line andalso FromColumn =< Column)
-  orelse (Line =:= ToLine andalso Column =< ToColumn).
+  orelse (Line =:= ToLine andalso Column =< ToColumn);
+in_range(_, _, _) -> false.
 
 -spec range(pos() | {pos(), pos()} | erl_anno:anno(), poi_kind(), any(), any())
    -> poi_range().


### PR DESCRIPTION
### Description

Adds completion support for clauses. The trigger is `;` ~~and it currently only support top-level functions. What's missing is completion for:~~
- ~~funs~~
- ~~receives~~
- ~~try / catch~~
- ~~case~~

## Example

![Screenshot 2022-04-04 at 15 54 19](https://user-images.githubusercontent.com/292239/161571726-3b08be73-4eda-47f0-b19f-f5922e59f251.png)

results into 

![Screenshot 2022-04-04 at 15 54 26](https://user-images.githubusercontent.com/292239/161571747-b609215f-677c-4fc7-b94e-7628d5f378f5.png)

