### PR TITLE
Document versioning

### DIFF
--- a/apps/els_lsp/src/els_db.erl
+++ b/apps/els_lsp/src/els_db.erl
@@ -8,9 +8,17 @@
         , lookup/2
         , match/2
         , match_delete/2
+        , select_delete/2
         , tables/0
         , write/2
+        , conditional_write/4
         ]).
+
+%%==============================================================================
+%% Type Definitions
+%%==============================================================================
+-type condition() :: fun((tuple()) -> boolean()).
+-export_type([ condition/0 ]).
 
 %%==============================================================================
 %% Exported functions
@@ -44,9 +52,18 @@ match(Table, Pattern) when is_tuple(Pattern) ->
 match_delete(Table, Pattern) when is_tuple(Pattern) ->
   els_db_server:match_delete(Table, Pattern).
 
+-spec select_delete(atom(), any()) -> ok.
+select_delete(Table, MS) ->
+  els_db_server:select_delete(Table, MS).
+
 -spec write(atom(), tuple()) -> ok.
 write(Table, Object) when is_tuple(Object) ->
   els_db_server:write(Table, Object).
+
+-spec conditional_write(atom(), any(), tuple(), condition()) ->
+        ok | {error, any()}.
+conditional_write(Table, Key, Object, Condition) when is_tuple(Object) ->
+  els_db_server:conditional_write(Table, Key, Object, Condition).
 
 -spec clear_table(atom()) -> ok.
 clear_table(Table) ->

--- a/apps/els_lsp/src/els_db_server.erl
+++ b/apps/els_lsp/src/els_db_server.erl
@@ -2,7 +2,6 @@
 %%% @doc The db gen_server.
 %%% @end
 %%%=============================================================================
-
 -module(els_db_server).
 
 %%==============================================================================
@@ -13,8 +12,15 @@
         , delete/2
         , delete_object/2
         , match_delete/2
+        , select_delete/2
         , write/2
+        , conditional_write/4
         ]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("kernel/include/logger.hrl").
 
 %%==============================================================================
 %% Callbacks for the gen_server behaviour
@@ -55,9 +61,18 @@ delete_object(Table, Key) ->
 match_delete(Table, Pattern) ->
   gen_server:call(?SERVER, {match_delete, Table, Pattern}).
 
+-spec select_delete(atom(), any()) -> ok.
+select_delete(Table, MS) ->
+  gen_server:call(?SERVER, {select_delete, Table, MS}).
+
 -spec write(atom(), tuple()) -> ok.
 write(Table, Object) ->
   gen_server:call(?SERVER, {write, Table, Object}).
+
+-spec conditional_write(atom(), any(), tuple(), els_db:condition()) ->
+        ok | {error, any()}.
+conditional_write(Table, Key, Object, Condition) ->
+  gen_server:call(?SERVER, {conditional_write, Table, Key, Object, Condition}).
 
 %%==============================================================================
 %% Callbacks for the gen_server behaviour
@@ -81,9 +96,29 @@ handle_call({delete_object, Table, Key}, _From, State) ->
 handle_call({match_delete, Table, Pattern}, _From, State) ->
   true = ets:match_delete(Table, Pattern),
   {reply, ok, State};
+handle_call({select_delete, Table, MS}, _From, State) ->
+  ets:select_delete(Table, MS),
+  {reply, ok, State};
 handle_call({write, Table, Object}, _From, State) ->
   true = ets:insert(Table, Object),
-  {reply, ok, State}.
+  {reply, ok, State};
+handle_call({conditional_write, Table, Key, Object, Condition}, _From, State) ->
+  case ets:lookup(Table, Key) of
+    [Entry] ->
+      case Condition(Entry) of
+        true ->
+          true = ets:insert(Table, Object),
+          {reply, ok, State};
+        false ->
+          ?LOG_DEBUG("Skip insertion due to invalid condition "
+                     "[table=~p] [key=~p]",
+                     [Table, Key]),
+          {reply, {error, condition_not_satisfied}, State}
+      end;
+    [] ->
+      true = ets:insert(Table, Object),
+      {reply, ok, State}
+  end.
 
 -spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast(_Request, State) ->

--- a/apps/els_lsp/src/els_dt_signatures.erl
+++ b/apps/els_lsp/src/els_dt_signatures.erl
@@ -18,8 +18,10 @@
 %%==============================================================================
 
 -export([ insert/1
+        , versioned_insert/1
         , lookup/1
         , delete_by_uri/1
+        , versioned_delete_by_uri/2
         ]).
 
 %%==============================================================================
@@ -27,6 +29,7 @@
 %%==============================================================================
 -include("els_lsp.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
 
 %%==============================================================================
 %% Item Definition
@@ -34,11 +37,13 @@
 
 -record(els_dt_signatures, { mfa  :: mfa()  | '_' | {atom(), '_', '_'}
                            , spec :: binary() | '_'
+                           , version :: version() | '_'
                            }).
 -type els_dt_signatures() :: #els_dt_signatures{}.
-
+-type version() :: null | integer().
 -type item() :: #{ mfa  := mfa()
                  , spec := binary()
+                 , version := version()
                  }.
 -export_type([ item/0 ]).
 
@@ -58,19 +63,37 @@ opts() ->
 %%==============================================================================
 
 -spec from_item(item()) -> els_dt_signatures().
-from_item(#{ mfa := MFA, spec := Spec }) ->
-  #els_dt_signatures{ mfa = MFA, spec = Spec }.
+from_item(#{ mfa := MFA
+           , spec := Spec
+           , version := Version
+           }) ->
+  #els_dt_signatures{ mfa = MFA
+                    , spec = Spec
+                    , version = Version
+                    }.
 
 -spec to_item(els_dt_signatures()) -> item().
-to_item(#els_dt_signatures{ mfa = MFA, spec = Spec }) ->
+to_item(#els_dt_signatures{ mfa = MFA
+                          , spec = Spec
+                          , version = Version
+                          }) ->
   #{ mfa  => MFA
    , spec => Spec
+   , version => Version
    }.
 
 -spec insert(item()) -> ok | {error, any()}.
 insert(Map) when is_map(Map) ->
   Record = from_item(Map),
   els_db:write(name(), Record).
+
+-spec versioned_insert(item()) -> ok | {error, any()}.
+versioned_insert(#{mfa := MFA, version := Version} = Map) ->
+  Record = from_item(Map),
+  Condition = fun(#els_dt_signatures{version = CurrentVersion}) ->
+                  CurrentVersion =:= null orelse Version >= CurrentVersion
+              end,
+  els_db:conditional_write(name(), MFA, Record, Condition).
 
 -spec lookup(mfa()) -> {ok, [item()]}.
 lookup({M, _F, _A} = MFA) ->
@@ -85,6 +108,25 @@ delete_by_uri(Uri) ->
       Module = els_uri:module(Uri),
       Pattern = #els_dt_signatures{mfa = {Module, '_', '_'}, _ = '_'},
       ok = els_db:match_delete(name(), Pattern);
+    _ ->
+      ok
+  end.
+
+-spec versioned_delete_by_uri(uri(), version()) -> ok.
+versioned_delete_by_uri(Uri, Version) ->
+  case filename:extension(Uri) of
+    <<".erl">> ->
+      Module = els_uri:module(Uri),
+      MS = ets:fun2ms(
+             fun(#els_dt_signatures{mfa = {M, _, _}, version = CurrentVersion})
+                 when M =:= Module,
+                      CurrentVersion =:= null orelse CurrentVersion < Version
+                      ->
+                 true;
+                (_) ->
+                 false
+             end),
+      ok = els_db:select_delete(name(), MS);
     _ ->
       ok
   end.


### PR DESCRIPTION
This PR introduce _versioning_ for documents, signatures and references. Versioning is available as part of the LSP specification. Versioning is currently supported by all major LSP clients (Emacs, VS Code, etc).

Whenever a module is indexed for the first time, the version is originally set to `null`. This allows the server to function even with LSP clients not specifying versions on change (but they will be exposed to all sorts of race conditions).

LSP clients, whenever sending a _change_ event for a document (`didChange`, `didChangeWatchedFile`), they normally include a version, which is guaranteed to be strictly incrementing (even if there can be gaps between two subsequent versions).

Whenever a change is detected, the language server immediately stores the new version of the text in the DB and triggers a new indexing process in the background. Subsequent changes will cause existing jobs to abort, to avoid un-necessary indexing of files which already changed and triggered a new process.

On completion, the asynchronous indexing process will verify if the current version has changed in the meantime and discard its own results if that's the case. Notice that the background process will confirm its write to DB in three cases:

* If the current version in the DB is `null` (the document has never changed)
* If the current version in the DB is older
* If the version is the same (text is already stored, but the current process has been parsing POIs, references and signatures for exactly that version)

Words (used to reduce the number of candidates for finding references) are also recomputed when storing the changed information.

Since ETS does not support transactions, writes to the DB are serialized via a single process (the `els_db_server` _gen_server_). The _lookup-and-insert_ is performed within the same callback function to avoid a clear race condition.
While the current implementation is not ideal and will most likely be improved over time, it still represents an improvement compared to the current situation, where race conditions are extremely common during completion and on text change, especially for _fast typers_.

The `MD5` property of the document has been removed since not used any longer.