### PR TITLE
Folding for records

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/code_navigation.erl
+++ b/apps/els_lsp/priv/code_navigation/src/code_navigation.erl
@@ -122,3 +122,8 @@ macro_b(_X, _Y) ->
 
 function_mb() ->
   ?MACRO_B(m, b).
+
+-record(folding_record, { field_a
+                        , field_b
+                        , field_c
+                        }).

--- a/apps/els_lsp/src/els_folding_range_provider.erl
+++ b/apps/els_lsp/src/els_folding_range_provider.erl
@@ -27,8 +27,10 @@ is_enabled() ->
 handle_request({document_foldingrange, Params}, State) ->
   #{ <<"textDocument">> := #{<<"uri">> := Uri} } = Params,
   {ok, Document} = els_utils:lookup_document(Uri),
-  POIs = els_dt_document:pois(Document, [folding_range]),
-  Response = case [folding_range(Range) || #{range := Range} <- POIs] of
+  POIs = els_dt_document:pois(Document, [function]),
+  FoldingRanges = [folding_range(Range) ||
+                   #{data := #{folding_range := Range = #{}}} <- POIs],
+  Response = case FoldingRanges of
                []     -> null;
                Ranges -> Ranges
              end,

--- a/apps/els_lsp/src/els_folding_range_provider.erl
+++ b/apps/els_lsp/src/els_folding_range_provider.erl
@@ -27,7 +27,7 @@ is_enabled() ->
 handle_request({document_foldingrange, Params}, State) ->
   #{ <<"textDocument">> := #{<<"uri">> := Uri} } = Params,
   {ok, Document} = els_utils:lookup_document(Uri),
-  POIs = els_dt_document:pois(Document, [function]),
+  POIs = els_dt_document:pois(Document, [function, record]),
   FoldingRanges = [folding_range(Range) ||
                    #{data := #{folding_range := Range = #{}}} <- POIs],
   Response = case FoldingRanges of

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -385,9 +385,15 @@ attribute(Tree) ->
 -spec record_attribute_pois(tree(), tree(), atom(), tree()) -> [poi()].
 record_attribute_pois(Tree, Record, RecordName, Fields) ->
   FieldList = record_def_field_name_list(Fields),
-  ValueRange = #{ from => get_start_location(Tree),
-                  to => get_end_location(Tree)},
-  Data = #{field_list => FieldList, value_range => ValueRange},
+  {StartLine, StartColumn} = get_start_location(Tree),
+  {EndLine, EndColumn} = get_end_location(Tree),
+  ValueRange = #{ from => {StartLine, StartColumn},
+                  to => {EndLine, EndColumn}},
+  FoldRange = maybe_fold_range(StartLine, EndLine),
+  Data = #{ field_list => FieldList
+          , value_range => ValueRange
+          , folding_range => FoldRange
+          },
   [poi(erl_syntax:get_pos(Record), record, RecordName, Data)
   | record_def_fields(Fields, RecordName)].
 
@@ -1141,8 +1147,8 @@ get_end_location(Tree) ->
   Anno = erl_syntax:get_pos(Tree),
   proplists:get_value(end_location, erl_anno:to_term(Anno)).
 
-%% It only makes sense to fold a function if the function contains
-%% at least one line apart from its signature.
+%% It only makes sense to fold if it contains at least
+%% more than one line
 -spec maybe_fold_range(erl_anno:line(), erl_anno:line()) ->
   els_core:poi_range() | unfoldable.
 maybe_fold_range(StartLine, EndLine) when EndLine > StartLine ->

--- a/apps/els_lsp/test/els_foldingrange_SUITE.erl
+++ b/apps/els_lsp/test/els_foldingrange_SUITE.erl
@@ -161,6 +161,11 @@ folding_range(Config) ->
                 , startCharacter => ?END_OF_LINE
                 , startLine      => 122
                 }
+             , #{ endCharacter   => ?END_OF_LINE
+                , endLine        => 128
+                , startCharacter => ?END_OF_LINE
+                , startLine      => 125
+                }
              ],
   ?assertEqual(Expected, Result),
   ok.


### PR DESCRIPTION
Issue #1209 

This PR is meant to improve folding of code by removing the need of `folding_range` PIOs and instead having it as a field in `data` for the others PIOs.

Later in `els_folding_range_provider` we can lookup the specific kind of PIOs we want to enable folding for, for now `function` and `record`





