### PR TITLE
Revert shutdown strategy for background jobs

### DIFF
--- a/apps/els_lsp/src/els_background_job_sup.erl
+++ b/apps/els_lsp/src/els_background_job_sup.erl
@@ -42,6 +42,6 @@ init([]) ->
   ChildSpecs = [#{ id       => els_background_job
                  , start    => {els_background_job, start_link, []}
                  , restart  => temporary
-                 , shutdown => brutal_kill
+                 , shutdown => 5000
                  }],
   {ok, {SupFlags, ChildSpecs}}.


### PR DESCRIPTION
To have the ability to terminate gracefully

