### PR TITLE
Make edoc an optional dependency

### DIFF
--- a/apps/els_lsp/src/els_lsp.app.src
+++ b/apps/els_lsp/src/els_lsp.app.src
@@ -18,6 +18,9 @@
         els_core,
         gradualizer
     ]},
+    {optional_applications, [
+        edoc
+    ]},
     {env, []},
     {modules, []},
     {maintainers, []},


### PR DESCRIPTION
Some distributions may not include it, and as it's not installed via hex,
startup will fail.
