### PR TITLE
Do not reload file from disk on save

### DIFF
--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -52,9 +52,7 @@ did_open(Params) ->
   ok.
 
 -spec did_save(map()) -> ok.
-did_save(Params) ->
-  #{<<"textDocument">> := #{<<"uri">> := Uri}} = Params,
-  reload_from_disk(Uri),
+did_save(_Params) ->
   ok.
 
 -spec did_change_watched_files(map()) -> ok.


### PR DESCRIPTION
The current version of Erlang LS reloads from disk the file on save.
Since didSave/didChange methods are notifications (i.e. handled asynchronously by the server),
the following race condition could be caused by the sequence:

SAVE -> CHANGE -> SAVE

Especially in presence of auto-save.
While the server is still processing the first SAVE, the version read from disk is the result
of the CHANGE being already applied, so the CHANGE operation could fail as invalid.

There's actually very little meaning in reloading the file from disk during save, since all
changes are sent to the server via CHANGE notifications.
