### PR TITLE
Use version from didOpen, use text from editor as source of truth

### DIFF
--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -46,9 +46,13 @@ did_change(Params) ->
 -spec did_open(map()) -> ok.
 did_open(Params) ->
   #{<<"textDocument">> := #{ <<"uri">> := Uri
-                           , <<"text">> := Text}} = Params,
+                           , <<"text">> := Text
+                           , <<"version">> := Version
+                           }} = Params,
   {ok, Document} = els_utils:lookup_document(Uri),
-  els_indexing:deep_index(Document#{text => Text}),
+  NewDocument = Document#{text => Text, version => Version},
+  els_dt_document:insert(NewDocument),
+  els_indexing:deep_index(NewDocument),
   ok.
 
 -spec did_save(map()) -> ok.


### PR DESCRIPTION
Without this change, the server could read an outdated version of the text from disk and
try to apply changes to it. This was a very common scenario in case a file was already opened
in the editor with pending changes, not yet saved to disk. A reload of the server would cause
the server to incorrectly rely on the version on disk.

The version is also used now, so that eventual background jobs on outdated versions of the code
would abort.

### Description

Enter a description of your changes here.

Fixes # .
