### PR TITLE
Do not crash if module is not available while fetching specs

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/hover_nonexisting.erl
+++ b/apps/els_lsp/priv/code_navigation/src/hover_nonexisting.erl
@@ -1,0 +1,6 @@
+-module(hover_nonexisting).
+
+-export([main/0]).
+
+main() ->
+  nonexisting:main().

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -161,10 +161,7 @@ find_in_document([Uri|Uris0], Document, Kind, Data, AlreadyVisited) ->
         {ok, U, P} -> {ok, U, P};
         {error, not_found} ->
           find(lists:usort(include_uris(Document) ++ Uris0), Kind, Data,
-               AlreadyVisited);
-        {error, Other} ->
-          ?LOG_INFO("find_in_document: [uri=~p] [error=~p]", [Uri, Other]),
-          {error, not_found}
+               AlreadyVisited)
       end;
     Definitions ->
       {ok, Uri, hd(els_poi:sort(Definitions))}
@@ -188,7 +185,7 @@ beginning() ->
 
 %% @doc check for a match in any of the module imported functions.
 -spec maybe_imported(els_dt_document:item(), poi_kind(), any()) ->
-        {ok, uri(), poi()} | {error, any()}.
+        {ok, uri(), poi()} | {error, not_found}.
 maybe_imported(Document, function, {F, A}) ->
   POIs = els_dt_document:pois(Document, [import_entry]),
   case [{M, F, A} || #{id := {M, FP, AP}} <- POIs, FP =:= F, AP =:= A] of
@@ -196,7 +193,7 @@ maybe_imported(Document, function, {F, A}) ->
     [{M, F, A}|_] ->
       case els_utils:find_module(M) of
         {ok, Uri0}      -> find(Uri0, function, {F, A});
-        {error, Error} -> {error, Error}
+        {error, not_found} -> {error, not_found}
       end
   end;
 maybe_imported(_Document, _Kind, _Data) ->

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -33,6 +33,7 @@
         , local_opaque/1
         , remote_opaque/1
         , nonexisting_type/1
+        , nonexisting_module/1
         ]).
 
 %%==============================================================================
@@ -366,6 +367,15 @@ nonexisting_type(Config) ->
   Uri = ?config(hover_type_uri, Config),
   #{result := Result} = els_client:hover(Uri, 22, 10),
   Expected = null,
+  ?assertEqual(Expected, Result),
+  ok.
+
+nonexisting_module(Config) ->
+  Uri = ?config(hover_nonexisting_uri, Config),
+  #{result := Result} = els_client:hover(Uri, 6, 12),
+  Expected =  #{contents =>
+                  #{kind => <<"markdown">>,
+                    value => <<"## nonexisting:main/0">>}},
   ?assertEqual(Expected, Result),
   ok.
 


### PR DESCRIPTION
If the user was hovering a fully qualified function for a non-existing module, the server would crash instead of showing no results.
