### PR TITLE
Solidify provider process

### DIFF
--- a/apps/els_core/src/els_stdio.erl
+++ b/apps/els_core/src/els_stdio.erl
@@ -22,7 +22,7 @@ start_listener(Cb) ->
 
 -spec init({function(), atom() | pid()}) -> no_return().
 init({Cb, IoDevice}) ->
-  ?LOG_INFO("Starting stdio server..."),
+  ?LOG_INFO("Starting stdio server... [io_device=~p]", [IoDevice]),
   ok = io:setopts(IoDevice, [binary, {encoding, latin1}]),
   {ok, Server} = application:get_env(els_core, server),
   ok = Server:set_io_device(IoDevice),

--- a/apps/els_lsp/src/els_sup.erl
+++ b/apps/els_lsp/src/els_sup.erl
@@ -66,11 +66,11 @@ init([]) ->
                , #{ id    => els_snippets_server
                   , start => {els_snippets_server, start_link, []}
                   }
-               , #{ id       => els_provider
-                  , start    => {els_provider, start_link, []}
-                  }
                , #{ id       => els_server
                   , start    => {els_server, start_link, []}
+                  }
+               , #{ id       => els_provider
+                  , start    => {els_provider, start_link, []}
                   }
                ],
   {ok, {SupFlags, ChildSpecs}}.


### PR DESCRIPTION
Since the main supervision strategy is rest_for_one, move the els_provider
process after the els_server one (restarting the els_server process currently
results in a node crash anyway). There is no need to restart the els_server
in case of els_provider failure, especially considering that the provider
process is the most likely to fail.

Also, give the provider a chance to cleanup on restart, by cancelling
pending jobs.

Finally, since it can now happen that, after a restart, the provider
receives messages (results or diagnostics) by background jobs, ensure
that such responses are handled correctly: results are propagated to
the server (no change) while diagnostics are ignored.
