### PR TITLE
Avoid race condition around POIs extraction

### DIFF
--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -185,8 +185,7 @@ new(Uri, Text, Id, Kind, Source, Version) ->
 %% @doc Returns the list of POIs for the current document
 -spec pois(item()) -> [poi()].
 pois(#{ uri := Uri, pois := ondemand }) ->
-  els_indexing:ensure_deeply_indexed(Uri),
-  {ok, #{pois := POIs}} = els_utils:lookup_document(Uri),
+  #{pois := POIs} = els_indexing:ensure_deeply_indexed(Uri),
   POIs;
 pois(#{ pois := POIs }) ->
   POIs.

--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -95,7 +95,8 @@ reload_from_disk(Uri) ->
 -spec background_index(els_dt_document:item()) -> {ok, pid()}.
 background_index(#{uri := Uri} = Document) ->
   Config = #{ task => fun (Doc, _State) ->
-                          els_indexing:deep_index(Doc)
+                          els_indexing:deep_index(Doc),
+                          ok
                       end
             , entries => [Document]
             , title => <<"Indexing ", Uri/binary>>

--- a/apps/els_lsp/test/els_test_utils.erl
+++ b/apps/els_lsp/test/els_test_utils.erl
@@ -131,7 +131,7 @@ includes() ->
 -spec index_file(binary()) -> [{atom(), any()}].
 index_file(Path) ->
   Uri = els_uri:uri(Path),
-  ok = els_indexing:ensure_deeply_indexed(Uri),
+  els_indexing:ensure_deeply_indexed(Uri),
   {ok, Text} = file:read_file(Path),
   ConfigId = config_id(Path),
   [ {atoms_append(ConfigId, '_path'), Path}


### PR DESCRIPTION
The deep_index function does not store the result of the indexing if a
new version of the document is present in the DB. This could lead to a
race condition where the caller of the ensure_deeply_index function
expects POIs to be expanded but, since the document is re-read from
the DB, they could still be un-expanded.

With this change, the ensure_deeply_index function returns a version
of the document with POIs always expanded, even if they may be
slightly outdated.

