### PR TITLE
Track open files

### DIFF
--- a/apps/els_core/src/els_provider.erl
+++ b/apps/els_core/src/els_provider.erl
@@ -48,7 +48,9 @@
 -type request()  :: {atom() | binary(), map()}.
 -type state() :: #{ in_progress := [progress_entry()]
                   , in_progress_diagnostics := [diagnostic_entry()]
+                  , open_buffers := [buffer()]
                   }.
+-type buffer() :: uri().
 -type progress_entry() :: {uri(), job()}.
 -type diagnostic_entry() :: #{ uri := uri()
                              , pending := [job()]
@@ -97,7 +99,10 @@ init(unused) ->
   %% Ensure the terminate function is called on shutdown, allowing the
   %% job to clean up.
   process_flag(trap_exit, true),
-  {ok, #{in_progress => [], in_progress_diagnostics => []}}.
+  {ok, #{ in_progress => []
+        , in_progress_diagnostics => []
+        , open_buffers => []
+        }}.
 
 -spec handle_call(any(), {pid(), any()}, state()) ->
   {reply, any(), state()}.

--- a/apps/els_core/src/els_provider.erl
+++ b/apps/els_core/src/els_provider.erl
@@ -48,7 +48,7 @@
 -type request()  :: {atom() | binary(), map()}.
 -type state() :: #{ in_progress := [progress_entry()]
                   , in_progress_diagnostics := [diagnostic_entry()]
-                  , open_buffers := [buffer()]
+                  , open_buffers := sets:set(buffer())
                   }.
 -type buffer() :: uri().
 -type progress_entry() :: {uri(), job()}.
@@ -101,7 +101,7 @@ init(unused) ->
   process_flag(trap_exit, true),
   {ok, #{ in_progress => []
         , in_progress_diagnostics => []
-        , open_buffers => []
+        , open_buffers => sets:new()
         }}.
 
 -spec handle_call(any(), {pid(), any()}, state()) ->

--- a/apps/els_lsp/src/els_methods.erl
+++ b/apps/els_lsp/src/els_methods.erl
@@ -190,7 +190,7 @@ textdocument_didopen(Params, #{open_buffers := OpenBuffers} = State) ->
   Provider = els_text_synchronization_provider,
   Request  = {did_open, Params},
   noresponse = els_provider:handle_request(Provider, Request),
-  {noresponse, State#{open_buffers => [Uri|lists:delete(Uri, OpenBuffers)]}}.
+  {noresponse, State#{open_buffers => sets:add_element(Uri, OpenBuffers)}}.
 
 %%==============================================================================
 %% textDocument/didchange
@@ -226,7 +226,7 @@ textdocument_didclose(Params, #{open_buffers := OpenBuffers} = State) ->
   Provider = els_text_synchronization_provider,
   Request  = {did_close, Params},
   noresponse = els_provider:handle_request(Provider, Request),
-  {noresponse, State#{open_buffers => lists:delete(Uri, OpenBuffers)}}.
+  {noresponse, State#{open_buffers => sets:del_element(Uri, OpenBuffers)}}.
 
 %%==============================================================================
 %% textdocument/documentSymbol
@@ -455,7 +455,7 @@ workspace_didchangewatchedfiles(Params0, State) ->
   #{open_buffers := OpenBuffers} = State,
   #{<<"changes">> := Changes0} = Params0,
   Changes = [C || #{<<"uri">> := Uri} = C <- Changes0,
-                  not lists:member(Uri, OpenBuffers)],
+                  not sets:is_element(Uri, OpenBuffers)],
   Params = Params0#{<<"changes">> => Changes},
   Provider = els_text_synchronization_provider,
   Request  = {did_change_watched_files, Params},

--- a/apps/els_lsp/src/els_server.erl
+++ b/apps/els_lsp/src/els_server.erl
@@ -103,7 +103,7 @@ reset_internal_state() ->
 init([]) ->
   ?LOG_INFO("Starting els_server..."),
   State = #state{ request_id     = 0
-                , internal_state = #{}
+                , internal_state = #{open_buffers => []}
                 , pending        = []
                 },
   {ok, State}.

--- a/apps/els_lsp/src/els_server.erl
+++ b/apps/els_lsp/src/els_server.erl
@@ -103,7 +103,7 @@ reset_internal_state() ->
 init([]) ->
   ?LOG_INFO("Starting els_server..."),
   State = #state{ request_id     = 0
-                , internal_state = #{open_buffers => []}
+                , internal_state = #{open_buffers => sets:new()}
                 , pending        = []
                 },
   {ok, State}.


### PR DESCRIPTION
It can happen that some files are opened in the editor. If these files
have pending changes (unsaved), we should consider them as the "source
of truth" when it comes to text edits flowing from the IDE to the
language server.

In case of an external operation (e.g. a checkout or rebase in a
version control system), Erlang LS inconditionally reloads changed
files from disk. This is an incorrect behaviour, since subsequent
operations applied via the IDE to a non up-to-date version of the
buffer can result in errors. The language server should ignore such
external operations when the file is opened in the editor.

Eventual inconsistencies between the disk-copy and the IDE-copy of the
file will be resolved in the context of the IDE (e.g. in VS Code the
user is warned about the situation on save) and text edits from
the IDE can always be trusted.
