### PR TITLE
Do not read file from disk on didOpen

### DIFF
--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -27,6 +27,7 @@
 
 -export([
     new/3,
+    new/4,
     pois/1,
     pois/2,
     get_element_at_pos/3,
@@ -168,9 +169,12 @@ delete(Uri) ->
 
 -spec new(uri(), binary(), source()) -> item().
 new(Uri, Text, Source) ->
+    new(Uri, Text, Source, _Version = null).
+
+-spec new(uri(), binary(), source(), version()) -> item().
+new(Uri, Text, Source, Version) ->
     Extension = filename:extension(Uri),
     Id = binary_to_atom(filename:basename(Uri, Extension), utf8),
-    Version = null,
     case Extension of
         <<".erl">> ->
             new(Uri, Text, Id, module, Source, Version);

--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -53,10 +53,9 @@ did_open(Params) ->
             <<"version">> := Version
         }
     } = Params,
-    {ok, Document} = els_utils:lookup_document(Uri),
-    NewDocument = Document#{text => Text, version => Version},
-    els_dt_document:insert(NewDocument),
-    els_indexing:deep_index(NewDocument),
+    Document = els_dt_document:new(Uri, Text, _Source = app, Version),
+    els_dt_document:insert(Document),
+    els_indexing:deep_index(Document),
     ok.
 
 -spec did_save(map()) -> ok.


### PR DESCRIPTION
According to [the specs](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen) the language server should not try to access the file from disk:

> The server must not try to read the document’s content using the document’s Uri.

Erlang LS erroneously does that. This can cause a server crash if the file is not available in the location specified by the Uri.
Using `app` as default source since the only side effect is to index references and signatures for the document, which is not a big problem if it is done also for a dependency or a file which is part of OTP.

Fixes #1296 