### PR TITLE
Improve create undefined function quick action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ end_of_line = LF
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 80

--- a/apps/els_lsp/priv/code_navigation/src/code_action.erl
+++ b/apps/els_lsp/priv/code_navigation/src/code_action.erl
@@ -20,5 +20,6 @@ function_c() ->
 
 -include_lib("stdlib/include/assert.hrl").
 function_d() ->
-  e(),
+  foobar(),
+  foobar(x,y,z),
   ok.


### PR DESCRIPTION
### Description

* Create function right after current function
* Create function with correct number of arguments
* Don't leave trailing whitespaces
* Don't create -spec

Fixes #1280
