### PR TITLE
Implement textDocument/signatureHelp

### DIFF
--- a/apps/els_core/include/els_core.hrl
+++ b/apps/els_core/include/els_core.hrl
@@ -540,17 +540,17 @@
 %%------------------------------------------------------------------------------
 -type parameter_information() :: #{
     label := binary(),
-    documentation => binary()
+    documentation => markup_content()
 }.
 -type signature_information() :: #{
     label := binary(),
-    documentation => binary(),
+    documentation => markup_content(),
     parameters => [parameter_information()]
 }.
 -type signature_help() :: #{
     signatures := [signature_information()],
-    active_signature => number(),
-    active_parameters => number()
+    activeSignature => non_neg_integer(),
+    activeParameter => non_neg_integer()
 }.
 
 %%------------------------------------------------------------------------------

--- a/apps/els_core/src/els_client.erl
+++ b/apps/els_core/src/els_client.erl
@@ -26,6 +26,7 @@
     '$_unexpectedrequest'/0,
     completion/5,
     completionitem_resolve/1,
+    signature_help/3,
     definition/3,
     did_open/4,
     did_save/1,
@@ -125,6 +126,10 @@ completion(Uri, Line, Char, TriggerKind, TriggerCharacter) ->
 -spec completionitem_resolve(completion_item()) -> ok.
 completionitem_resolve(CompletionItem) ->
     gen_server:call(?SERVER, {completionitem_resolve, CompletionItem}).
+
+-spec signature_help(uri(), non_neg_integer(), non_neg_integer()) -> ok.
+signature_help(Uri, Line, Char) ->
+    gen_server:call(?SERVER, {signature_help, {Uri, Line, Char}}).
 
 -spec definition(uri(), non_neg_integer(), non_neg_integer()) -> ok.
 definition(Uri, Line, Char) ->
@@ -431,6 +436,7 @@ do_handle_messages([Message | Messages], Pending, Notifications, Requests) ->
 -spec method_lookup(atom()) -> binary().
 method_lookup(completion) -> <<"textDocument/completion">>;
 method_lookup(completionitem_resolve) -> <<"completionItem/resolve">>;
+method_lookup(signature_help) -> <<"textDocument/signatureHelp">>;
 method_lookup(definition) -> <<"textDocument/definition">>;
 method_lookup(document_symbol) -> <<"textDocument/documentSymbol">>;
 method_lookup(references) -> <<"textDocument/references">>;
@@ -481,6 +487,14 @@ request_params({completion, {Uri, Line, Char, TriggerKind, TriggerCharacter}}) -
     };
 request_params({completionitem_resolve, CompletionItem}) ->
     CompletionItem;
+request_params({signature_help, {Uri, Line, Char}}) ->
+    #{
+        textDocument => #{uri => Uri},
+        position => #{
+            line => Line - 1,
+            character => Char - 1
+        }
+    };
 request_params({initialize, {RootUri, InitOptions}}) ->
     ContentFormat = [?MARKDOWN, ?PLAINTEXT],
     TextDocument = #{

--- a/apps/els_core/src/els_provider.erl
+++ b/apps/els_core/src/els_provider.erl
@@ -48,7 +48,8 @@
     | els_code_lens_provider
     | els_execute_command_provider
     | els_rename_provider
-    | els_text_synchronization_provider.
+    | els_text_synchronization_provider
+    | els_signature_help_provider.
 -type request() :: {atom() | binary(), map()}.
 -type state() :: #{
     in_progress := [progress_entry()],
@@ -227,7 +228,8 @@ available_providers() ->
         els_diagnostics_provider,
         els_rename_provider,
         els_call_hierarchy_provider,
-        els_text_synchronization_provider
+        els_text_synchronization_provider,
+        els_signature_help_provider
     ].
 
 %%==============================================================================

--- a/apps/els_lsp/priv/code_navigation/src/signature_help.erl
+++ b/apps/els_lsp/priv/code_navigation/src/signature_help.erl
@@ -1,0 +1,18 @@
+-module(signature_help).
+
+-export([min/2,maps_get/0,record_max/0,multiline/0]).
+
+min(A, B) ->
+    erlang:min(A, B).
+
+maps_get() ->
+    maps:get(key, #{}, false).
+
+record_max() ->
+    erlang:max({a, b, c}, {d, e, f}).
+
+multiline() ->
+    erlang:min(
+      1,
+      2
+    ).

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -115,47 +115,63 @@ handle_request({exit, #{status := Status}}, _State) ->
 -spec server_capabilities() -> server_capabilities().
 server_capabilities() ->
     {ok, Version} = application:get_key(?APP, vsn),
+    Capabilities =
+        #{
+            textDocumentSync =>
+                els_text_synchronization_provider:options(),
+            hoverProvider => true,
+            completionProvider =>
+                #{
+                    resolveProvider => true,
+                    triggerCharacters =>
+                        els_completion_provider:trigger_characters()
+                },
+            signatureHelpProvider =>
+                #{
+                    triggerCharacters =>
+                        els_signature_help_provider:trigger_characters()
+                },
+            definitionProvider =>
+                els_definition_provider:is_enabled(),
+            referencesProvider =>
+                els_references_provider:is_enabled(),
+            documentHighlightProvider =>
+                els_document_highlight_provider:is_enabled(),
+            documentSymbolProvider =>
+                els_document_symbol_provider:is_enabled(),
+            workspaceSymbolProvider =>
+                els_workspace_symbol_provider:is_enabled(),
+            codeActionProvider =>
+                els_code_action_provider:is_enabled(),
+            documentFormattingProvider =>
+                els_formatting_provider:is_enabled_document(),
+            documentRangeFormattingProvider =>
+                els_formatting_provider:is_enabled_range(),
+            foldingRangeProvider =>
+                els_folding_range_provider:is_enabled(),
+            implementationProvider =>
+                els_implementation_provider:is_enabled(),
+            executeCommandProvider =>
+                els_execute_command_provider:options(),
+            codeLensProvider =>
+                els_code_lens_provider:options(),
+            renameProvider =>
+                els_rename_provider:is_enabled(),
+            callHierarchyProvider =>
+                els_call_hierarchy_provider:is_enabled()
+        },
+    ActiveCapabilities =
+        case els_signature_help_provider:is_enabled() of
+            %% This pattern can never match because is_enabled/0 is currently
+            %% hard-coded to `false'. When enabling signature help manually,
+            %% uncomment this branch.
+            %% true ->
+            %%     Capabilities;
+            false ->
+                maps:remove(signatureHelpProvider, Capabilities)
+        end,
     #{
-        capabilities =>
-            #{
-                textDocumentSync =>
-                    els_text_synchronization_provider:options(),
-                hoverProvider => true,
-                completionProvider =>
-                    #{
-                        resolveProvider => true,
-                        triggerCharacters =>
-                            els_completion_provider:trigger_characters()
-                    },
-                definitionProvider =>
-                    els_definition_provider:is_enabled(),
-                referencesProvider =>
-                    els_references_provider:is_enabled(),
-                documentHighlightProvider =>
-                    els_document_highlight_provider:is_enabled(),
-                documentSymbolProvider =>
-                    els_document_symbol_provider:is_enabled(),
-                workspaceSymbolProvider =>
-                    els_workspace_symbol_provider:is_enabled(),
-                codeActionProvider =>
-                    els_code_action_provider:is_enabled(),
-                documentFormattingProvider =>
-                    els_formatting_provider:is_enabled_document(),
-                documentRangeFormattingProvider =>
-                    els_formatting_provider:is_enabled_range(),
-                foldingRangeProvider =>
-                    els_folding_range_provider:is_enabled(),
-                implementationProvider =>
-                    els_implementation_provider:is_enabled(),
-                executeCommandProvider =>
-                    els_execute_command_provider:options(),
-                codeLensProvider =>
-                    els_code_lens_provider:options(),
-                renameProvider =>
-                    els_rename_provider:is_enabled(),
-                callHierarchyProvider =>
-                    els_call_hierarchy_provider:is_enabled()
-            },
+        capabilities => ActiveCapabilities,
         serverInfo =>
             #{
                 name => <<"Erlang LS">>,

--- a/apps/els_lsp/src/els_methods.erl
+++ b/apps/els_lsp/src/els_methods.erl
@@ -28,6 +28,7 @@
     textdocument_codelens/2,
     textdocument_rename/2,
     textdocument_preparecallhierarchy/2,
+    textdocument_signaturehelp/2,
     callhierarchy_incomingcalls/2,
     callhierarchy_outgoingcalls/2,
     workspace_executecommand/2,
@@ -421,6 +422,17 @@ textdocument_preparecallhierarchy(Params, State) ->
     Provider = els_call_hierarchy_provider,
     {response, Response} =
         els_provider:handle_request(Provider, {prepare, Params}),
+    {response, Response, State}.
+
+%%==============================================================================
+%% textDocument/signatureHelp
+%%==============================================================================
+
+-spec textdocument_signaturehelp(params(), state()) -> result().
+textdocument_signaturehelp(Params, State) ->
+    Provider = els_signature_help_provider,
+    {response, Response} =
+        els_provider:handle_request(Provider, {signature_help, Params}),
     {response, Response, State}.
 
 %%==============================================================================

--- a/apps/els_lsp/src/els_signature_help_provider.erl
+++ b/apps/els_lsp/src/els_signature_help_provider.erl
@@ -1,0 +1,216 @@
+-module(els_signature_help_provider).
+
+-behaviour(els_provider).
+
+-include("els_lsp.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-export([
+    is_enabled/0,
+    handle_request/2,
+    trigger_characters/0
+]).
+
+-type item() :: {remote, atom(), atom()} | {local, atom()}.
+-type parameter_number() :: non_neg_integer().
+%% Parameter numbers are 0-indexed.
+
+-spec trigger_characters() -> [binary()].
+trigger_characters() ->
+    [<<"(">>, <<",">>, <<")">>].
+
+%%==============================================================================
+%% els_provider functions
+%%==============================================================================
+-spec is_enabled() -> boolean().
+is_enabled() ->
+    false.
+
+-spec handle_request(els_provider:request(), any()) -> {response, signature_help() | null}.
+handle_request({signature_help, Params}, _State) ->
+    #{
+        <<"position">> := #{
+            <<"line">> := Line,
+            <<"character">> := Character
+        },
+        <<"textDocument">> := #{<<"uri">> := Uri}
+    } = Params,
+    {ok, #{text := Text} = Document} = els_utils:lookup_document(Uri),
+    Prefix = els_text:line(Text, Line, Character),
+    Tokens = lists:reverse(els_text:tokens(Prefix)),
+    case find_signature(Tokens, Text, Line - 1) of
+        {ok, Item, ActiveParameter} ->
+            {response, signatures(Document, Item, ActiveParameter)};
+        none ->
+            {response, null}
+    end.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+-spec find_signature(
+    Tokens :: [tuple()],
+    Text :: binary(),
+    Line :: non_neg_integer()
+) ->
+    {ok, item(), parameter_number()} | none.
+find_signature(Tokens, Text, Line) ->
+    find_signature(Tokens, [0], Text, Line).
+
+-spec find_signature(
+    Tokens :: [tuple()],
+    ParameterStack :: [parameter_number()],
+    Text :: binary(),
+    Line :: non_neg_integer()
+) ->
+    {ok, item(), parameter_number()} | none.
+%% An unmatched open parenthesis is the start of a signature.
+find_signature([{'(', _} | Rest], [ActiveParameter], _Text, _Line) ->
+    case Rest of
+        %% Check for "[...] module:func("
+        [{atom, _, Func}, {':', _}, {atom, _, Module} | _Rest] ->
+            {ok, {remote, Module, Func}, ActiveParameter};
+        %% Check for "-attribute("
+        [{atom, _, _Attribute}, {'-', _} | _Rest] ->
+            none;
+        %% Check for "[...] func("
+        [{atom, _, Func} | _Rest] ->
+            {ok, {local, Func}, ActiveParameter};
+        _Tokens ->
+            none
+    end;
+%% A comma outside of any data structure (list, tuple, map, or binary) is a
+%% separator between arguments, so we increment the active parameter count.
+find_signature([{',', _} | Rest], [ActiveParameter | ParameterStack], Text, Line) ->
+    find_signature(Rest, [ActiveParameter + 1 | ParameterStack], Text, Line);
+%% Calls may contain any sort of expression but not statements, so when we
+%% see a '.', we know we've failed to find a signature.
+find_signature([{dot, _} | _Rest], _ParameterStack, _Text, _Line) ->
+    none;
+%% When closing a scope, push a new parameter counter onto the stack.
+find_signature([{ScopeClose, _} | Rest], ParameterStack, Text, Line) when
+    ScopeClose =:= ')';
+    ScopeClose =:= '}';
+    ScopeClose =:= ']';
+    ScopeClose =:= '>>'
+->
+    find_signature(Rest, [0 | ParameterStack], Text, Line);
+%% When opening a scope, pop the extra parameter counter if it exists.
+find_signature([{ScopeOpen, _} | Rest], ParameterStack, Text, Line) when
+    ScopeOpen =:= '(';
+    ScopeOpen =:= '{';
+    ScopeOpen =:= '[';
+    ScopeOpen =:= '<<'
+->
+    ParameterStack1 =
+        case ParameterStack of
+            [_] -> [0];
+            [_Head | Tail] -> Tail
+        end,
+    find_signature(Rest, ParameterStack1, Text, Line);
+%% Discard any other tokens
+find_signature([_ | Rest], ParameterStack, Text, Line) ->
+    find_signature(Rest, ParameterStack, Text, Line);
+%% If there are no lines remaining in the file, then we failed to find any
+%% signatures and are done.
+find_signature([], _ParameterStack, _Text, 0) ->
+    none;
+%% If we have exhausted the set of tokens on this line, scan backwards a line
+%% (up in the document) since expressions may be split across multiple lines.
+find_signature([], ParameterStack, Text, Line) ->
+    LineContents = els_text:line(Text, Line),
+    Tokens = lists:reverse(els_text:tokens(LineContents)),
+    find_signature(Tokens, ParameterStack, Text, Line - 1).
+
+-spec signatures(els_dt_document:item(), item(), parameter_number()) ->
+    signature_help() | null.
+signatures(Document, Item, ActiveParameter) ->
+    {Module, Function, POIs} =
+        case Item of
+            {local, F} ->
+                #{uri := Uri} = Document,
+                M = els_uri:module(Uri),
+                LocalPOIs = els_scope:local_and_included_pois(Document, function),
+                {M, F, LocalPOIs};
+            {remote, M, F} ->
+                {M, F, exported_function_pois(M)}
+        end,
+    SignaturePOIs =
+        lists:sort(
+            fun(#{id := {_, AArity}}, #{id := {_, BArity}}) -> AArity < BArity end,
+            [
+                POI
+             || #{id := {POIFunc, _Arity}} = POI <- POIs,
+                POIFunc =:= Function
+            ]
+        ),
+    ?LOG_DEBUG(
+        "Signature Help. [item=~p] [pois=~p]",
+        [Item, SignaturePOIs]
+    ),
+    case SignaturePOIs of
+        [] ->
+            null;
+        [_ | _] ->
+            %% The active signature is the signature with the smallest arity
+            %% that is at least as large as the active parameter, defaulting
+            %% to the highest arity signature. The active signature is zero
+            %% indexed.
+            ActiveSignature =
+                index_where(
+                    fun(#{id := {_, Arity}}) -> Arity > ActiveParameter end,
+                    SignaturePOIs,
+                    length(SignaturePOIs) - 1
+                ),
+            #{
+                activeParameter => ActiveParameter,
+                activeSignature => ActiveSignature,
+                signatures => [signature_item(Module, POI) || POI <- SignaturePOIs]
+            }
+    end.
+
+-spec signature_item(atom(), els_poi:poi()) -> signature_information().
+signature_item(Module, #{data := #{args := Args}, id := {Function, Arity}}) ->
+    DocEntries = els_docs:function_docs('remote', Module, Function, Arity),
+    #{
+        documentation => els_markup_content:new(DocEntries),
+        label => label(Function, Args),
+        parameters => [#{label => els_utils:to_binary(Name)} || {_Index, Name} <- Args]
+    }.
+
+-spec exported_function_pois(atom()) -> [els_poi:poi()].
+exported_function_pois(Module) ->
+    case els_utils:find_module(Module) of
+        {ok, Uri} ->
+            case els_utils:lookup_document(Uri) of
+                {ok, Document} ->
+                    Exports = [
+                        FA
+                     || #{id := FA} <- els_scope:local_and_included_pois(Document, export_entry)
+                    ],
+                    [
+                        POI
+                     || #{id := FA} = POI <- els_scope:local_and_included_pois(Document, function),
+                        lists:member(FA, Exports)
+                    ];
+                {error, _} ->
+                    []
+            end;
+        {error, _} ->
+            []
+    end.
+
+-spec label(atom(), [tuple()]) -> binary().
+label(Function, Args0) ->
+    ArgList = ["(", string:join([Name || {_Index, Name} <- Args0], ", "), ")"],
+    els_utils:to_binary([atom_to_binary(Function, utf8) | ArgList]).
+
+-spec index_where(Predicate, list(), Default) -> non_neg_integer() | Default when
+    Predicate :: fun((term()) -> boolean()),
+    Default :: term().
+index_where(Predicate, List, Default) ->
+    {IndexedList, _Acc} = lists:mapfoldl(fun(Item, Acc) -> {{Acc, Item}, Acc + 1} end, 0, List),
+    case lists:search(fun({_Index, Item}) -> Predicate(Item) end, IndexedList) of
+        {value, {Index, _Item}} -> Index;
+        false -> Default
+    end.

--- a/apps/els_lsp/test/els_signature_help_SUITE.erl
+++ b/apps/els_lsp/test/els_signature_help_SUITE.erl
@@ -1,0 +1,231 @@
+-module(els_signature_help_SUITE).
+%% CT Callbacks
+-export([
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2,
+    all/0
+]).
+
+%% Test cases
+-export([
+    remote_call/1,
+    switch_signature_between_arities/1,
+    non_trigger_character_request/1,
+    argument_expressions_may_contain_commas/1,
+    multiline_call/1
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+%% -include_lib("els_core/include/els_core.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+-spec all() -> [atom()].
+all() ->
+    els_test_utils:all(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+    els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+    els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(TestCase, Config) ->
+    els_test_utils:init_per_testcase(TestCase, Config).
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) ->
+    els_test_utils:end_per_testcase(TestCase, Config).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec remote_call(config()) -> ok.
+remote_call(Config) ->
+    %% Line 6 of this document: "    erlang:min(A, B)."
+    Uri = ?config(signature_help_uri, Config),
+    %% On the "(" of "erlang:min("
+    #{result := Result1} = els_client:signature_help(Uri, 6, 16),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 0,
+            signatures := [
+                #{
+                    label := <<"min(A, B)">>,
+                    parameters := [#{label := <<"A">>}, #{label := <<"B">>}],
+                    documentation := #{
+                        kind := <<"markdown">>
+                    }
+                }
+            ]
+        },
+        Result1
+    ),
+    %% On the "," of "erlang:min(A,"
+    #{result := Result2} = els_client:signature_help(Uri, 6, 18),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 1,
+            signatures := [#{label := <<"min(A, B)">>}]
+        },
+        Result2
+    ),
+    %% On the ")" of "erlang:min(A, B)"
+    #{result := Result3} = els_client:signature_help(Uri, 6, 21),
+    ?assertEqual(null, Result3),
+    ok.
+
+-spec switch_signature_between_arities(config()) -> ok.
+switch_signature_between_arities(Config) ->
+    %% Line 9 of this document: "    maps:get(key, #{}, false)."
+    Uri = ?config(signature_help_uri, Config),
+    %% On the "(" of "maps:get("
+    #{result := Result1} = els_client:signature_help(Uri, 9, 14),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 0,
+            signatures := [
+                #{
+                    label := <<"get(Arg1, Arg2)">>,
+                    parameters := [#{label := <<"Arg1">>}, #{label := <<"Arg2">>}],
+                    documentation := #{
+                        kind := <<"markdown">>
+                    }
+                },
+                #{
+                    label := <<"get(Key, Map, Default)">>,
+                    parameters := [
+                        #{label := <<"Key">>}, #{label := <<"Map">>}, #{label := <<"Default">>}
+                    ],
+                    documentation := #{
+                        kind := <<"markdown">>
+                    }
+                }
+            ]
+        },
+        Result1
+    ),
+    %% On the "," of "maps:get(key,"
+    #{result := Result2} = els_client:signature_help(Uri, 9, 18),
+    ?assertMatch(#{activeSignature := 0, activeParameter := 1}, Result2),
+    %% On the second "," of "maps:get(key, #{},", we switch to the higher
+    %% arity `maps:get/3' signature
+    #{result := Result3} = els_client:signature_help(Uri, 9, 23),
+    ?assertMatch(#{activeSignature := 1, activeParameter := 2}, Result3),
+    %% On the ")" of "maps:get(key, #{}, false)"
+    #{result := Result4} = els_client:signature_help(Uri, 9, 30),
+    ?assertEqual(null, Result4),
+    ok.
+
+-spec non_trigger_character_request(config()) -> ok.
+non_trigger_character_request(Config) ->
+    %% Line 9 of this document: "    maps:get(key, #{}, false)."
+    Uri = ?config(signature_help_uri, Config),
+    %% On the "e" of "maps:get(key"
+    #{result := Result} = els_client:signature_help(Uri, 9, 16),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 0,
+            signatures := [
+                #{
+                    label := <<"get(Arg1, Arg2)">>,
+                    parameters := [#{label := <<"Arg1">>}, #{label := <<"Arg2">>}],
+                    documentation := #{
+                        kind := <<"markdown">>
+                    }
+                }
+                | _
+            ]
+        },
+        Result
+    ),
+    ok.
+
+-spec argument_expressions_may_contain_commas(config()) -> ok.
+argument_expressions_may_contain_commas(Config) ->
+    %% Line 12 of this document: "    erlang:max({a, b, c}, {d, e, f})."
+    Uri = ?config(signature_help_uri, Config),
+    %% On the "," of "erlang:max({a,"
+    %% The comma belongs to the argument expression instead of separating
+    %% arguments.
+    #{result := Result1} = els_client:signature_help(Uri, 12, 19),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 0,
+            signatures := [
+                #{
+                    label := <<"max(A, B)">>,
+                    parameters := [#{label := <<"A">>}, #{label := <<"B">>}],
+                    documentation := #{
+                        kind := <<"markdown">>
+                    }
+                }
+            ]
+        },
+        Result1
+    ),
+    %% On the last "," of "erlang:max({a, b, c}, {d,"
+    #{result := Result2} = els_client:signature_help(Uri, 12, 30),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 1,
+            signatures := [#{label := <<"max(A, B)">>}]
+        },
+        Result2
+    ),
+    ok.
+
+-spec multiline_call(config()) -> ok.
+multiline_call(Config) ->
+    %% The block being tested here is lines 15-18:
+    %%
+    %%    erlang:min(
+    %%      1,
+    %%      2
+    %%    ).
+    Uri = ?config(signature_help_uri, Config),
+    %% On the "," on line 16
+    #{result := Result} = els_client:signature_help(Uri, 16, 9),
+    ?assertMatch(
+        #{
+            activeSignature := 0,
+            activeParameter := 1,
+            signatures := [
+                #{
+                    label := <<"min(A, B)">>,
+                    parameters := [#{label := <<"A">>}, #{label := <<"B">>}],
+                    documentation := #{
+                        kind := <<"markdown">>
+                    }
+                }
+            ]
+        },
+        Result
+    ),
+    ok.


### PR DESCRIPTION
### Description

Implements [signature help](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp) from the LSP spec.

For this PR it's just remote and local functions - BIFs, macros, or types aren't included yet.

The approach for finding the signature (if it exists) when a trigger is emitted is to scan backwards through the tokens that preceed the trigger and look for an unmatched opening parenthesis. Also in this recursive scanning function, we determine the active parameter number by counting the number of commas. It's not that straightforward though: you might have expressions in your calls that themselves contain commas like `maps:put(key, value, #{a => b, c => d})`. To count the active parameter number, we use a stack of counters (implemented as `list(non_neg_integer())`) of how many times we see a comma. We push a new counter when we see a closing token (`>>`, `]`, `)`, `}`) and pop when we see an opening token (`<<`, `[`, `(`, `{`), so commas within expressions are counted but discarded when we scan past the data structure (remember that the tokens are in reverse order).

This works pretty well but there are edge cases like that the signature help pane will close (language server returns `null`) if you type a comma within a string, for example: `"foo, `. I haven't encountered any false positives where the server shows signature help when it shouldn't yet.

An asciicast of the signature help working in helix: https://asciinema.org/a/495869

Fixes #1300.
