### PR TITLE
Avoid crash while reloading non-existing file

### DIFF
--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -10,6 +10,7 @@
     maybe_start/0,
     ensure_deeply_indexed/1,
     shallow_index/2,
+    shallow_index/3,
     deep_index/1,
     remove/1
 ]).


### PR DESCRIPTION
It can happen during a rebase operation that a file appears/disappears
multiple times in a very short timeframe. Specifically, since
`didChangeWatchedFiles` notifications are asynchronous, it can happen
that a file is deleted before a notification is processed by the
server. In such a case, the server should simply ignore the
notification, since a new one will arrive.

Also, there is no need to deeply index files during a rebase, so let's
convert to a shallow indexing.

We mark the source of the file as 'app', which has the only side
effect of indexing references.

