### PR TITLE
Return set, log as an error

### DIFF
--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -298,6 +298,9 @@ get_words(Text) ->
                     Words
             end,
             lists:foldl(Fun, sets:new(), Tokens);
-        {error, ErrorInfo, _ErrorLocation} ->
-            ?LOG_DEBUG("Errors while get_words ~p", [ErrorInfo])
+        {error, ErrorInfo, ErrorLocation} ->
+            ?LOG_WARNING("Errors while get_words [info=~p] [location=~p]", [
+                ErrorInfo, ErrorLocation
+            ]),
+            sets:new()
     end.


### PR DESCRIPTION
The macro was returning an `ok`, which we were storing in the DB, causing a crash while extracting words.
Also raising log level from debug to warning.