### PR TITLE
Add atom typo diagnostics

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/atom_typo.erl
+++ b/apps/els_lsp/priv/code_navigation/src/atom_typo.erl
@@ -1,0 +1,19 @@
+-module(atom_typo).
+-export([f/0]).
+
+f() ->
+  %% typos
+  ture,
+  falsee,
+  fales,
+  undifened,
+  udefined,
+  errorr,
+  %% ok
+  true,
+  false,
+  fails,
+  undefined,
+  unified,
+  error,
+  ok.

--- a/apps/els_lsp/src/els_atom_typo_diagnostics.erl
+++ b/apps/els_lsp/src/els_atom_typo_diagnostics.erl
@@ -29,7 +29,7 @@
 
 -spec is_default() -> boolean().
 is_default() ->
-    true.
+    false.
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->

--- a/apps/els_lsp/src/els_atom_typo_diagnostics.erl
+++ b/apps/els_lsp/src/els_atom_typo_diagnostics.erl
@@ -1,0 +1,71 @@
+%%==============================================================================
+%% AtomTypo diagnostics
+%% Catch common atom typos
+%%==============================================================================
+-module(els_atom_typo_diagnostics).
+
+%%==============================================================================
+%% Behaviours
+%%==============================================================================
+-behaviour(els_diagnostics).
+
+%%==============================================================================
+%% Exports
+%%==============================================================================
+-export([
+    is_default/0,
+    run/1,
+    source/0
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("els_lsp.hrl").
+
+%%==============================================================================
+%% Callback Functions
+%%==============================================================================
+
+-spec is_default() -> boolean().
+is_default() ->
+    true.
+
+-spec run(uri()) -> [els_diagnostics:diagnostic()].
+run(Uri) ->
+  case els_utils:lookup_document(Uri) of
+    {error, _Error} ->
+      [];
+    {ok, Document} ->
+      Atoms = [<<"false">>, <<"true">>, <<"undefined">>, <<"error">>],
+      POIs = els_dt_document:pois(Document, [atom]),
+      [make_diagnostic(POI, Atom) ||
+        #{id := Id} = POI <- POIs,
+        Atom <- Atoms,
+        atom_to_binary(Id, utf8) =/= Atom,
+        els_utils:jaro_distance(atom_to_binary(Id, utf8), Atom) > 0.9
+      ]
+  end.
+
+-spec source() -> binary().
+source() ->
+    <<"AtomTypo">>.
+
+%%==============================================================================
+%% Internal Functions
+%%==============================================================================
+-spec make_diagnostic(poi(), binary()) -> els_diagnostics:diagnostic().
+make_diagnostic(#{range := Range}, Atom) ->
+    Message = els_utils:to_binary(
+        io_lib:format(
+            "Atom typo? Did you mean: ~s",
+            [Atom]
+        )
+    ),
+    Severity = ?DIAGNOSTIC_WARNING,
+    els_diagnostics:make_diagnostic(
+        els_protocol:range(Range),
+        Message,
+        Severity,
+        source()
+    ).

--- a/apps/els_lsp/src/els_atom_typo_diagnostics.erl
+++ b/apps/els_lsp/src/els_atom_typo_diagnostics.erl
@@ -55,7 +55,7 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
--spec make_diagnostic(poi(), binary()) -> els_diagnostics:diagnostic().
+-spec make_diagnostic(els_poi:poi(), binary()) -> els_diagnostics:diagnostic().
 make_diagnostic(#{range := Range}, Atom) ->
     Message = els_utils:to_binary(
         io_lib:format(

--- a/apps/els_lsp/src/els_atom_typo_diagnostics.erl
+++ b/apps/els_lsp/src/els_atom_typo_diagnostics.erl
@@ -33,19 +33,20 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  case els_utils:lookup_document(Uri) of
-    {error, _Error} ->
-      [];
-    {ok, Document} ->
-      Atoms = [<<"false">>, <<"true">>, <<"undefined">>, <<"error">>],
-      POIs = els_dt_document:pois(Document, [atom]),
-      [make_diagnostic(POI, Atom) ||
-        #{id := Id} = POI <- POIs,
-        Atom <- Atoms,
-        atom_to_binary(Id, utf8) =/= Atom,
-        els_utils:jaro_distance(atom_to_binary(Id, utf8), Atom) > 0.9
-      ]
-  end.
+    case els_utils:lookup_document(Uri) of
+        {error, _Error} ->
+            [];
+        {ok, Document} ->
+            Atoms = [<<"false">>, <<"true">>, <<"undefined">>, <<"error">>],
+            POIs = els_dt_document:pois(Document, [atom]),
+            [
+                make_diagnostic(POI, Atom)
+             || #{id := Id} = POI <- POIs,
+                Atom <- Atoms,
+                atom_to_binary(Id, utf8) =/= Atom,
+                els_utils:jaro_distance(atom_to_binary(Id, utf8), Atom) > 0.9
+            ]
+    end.
 
 -spec source() -> binary().
 source() ->

--- a/apps/els_lsp/src/els_code_action_provider.erl
+++ b/apps/els_lsp/src/els_code_action_provider.erl
@@ -51,7 +51,8 @@ make_code_actions(
                 fun els_code_actions:fix_module_name/4},
             {"Unused macro: (.*)", fun els_code_actions:remove_macro/4},
             {"function (.*) undefined", fun els_code_actions:create_function/4},
-            {"Unused file: (.*)", fun els_code_actions:remove_unused/4}
+            {"Unused file: (.*)", fun els_code_actions:remove_unused/4},
+            {"Atom typo\\? Did you mean: (.*)", fun els_code_actions:fix_atom_typo/4}
         ],
         Uri,
         Range,

--- a/apps/els_lsp/src/els_code_actions.erl
+++ b/apps/els_lsp/src/els_code_actions.erl
@@ -6,7 +6,8 @@
     ignore_variable/4,
     remove_macro/4,
     remove_unused/4,
-    suggest_variable/4
+    suggest_variable/4,
+    fix_atom_typo/4
 ]).
 
 -include("els_lsp.hrl").
@@ -177,8 +178,18 @@ remove_unused(Uri, _Range0, Data, [Import]) ->
             []
     end.
 
+-spec fix_atom_typo(uri(), range(), binary(), [binary()]) -> [map()].
+fix_atom_typo(Uri, Range, _Data, [Atom]) ->
+  [make_edit_action(
+     Uri,
+     <<"Fix typo: ", Atom/binary>>,
+     ?CODE_ACTION_KIND_QUICKFIX,
+     Atom,
+     Range)
+  ].
+
 -spec ensure_range(els_poi:poi_range(), binary(), [els_poi:poi()]) ->
-    {ok, els_poi:poi_range()} | error.
+          {ok, els_poi:poi_range()} | error.
 ensure_range(#{from := {Line, _}}, SubjectId, POIs) ->
     SubjectAtom = binary_to_atom(SubjectId, utf8),
     Ranges = [

--- a/apps/els_lsp/src/els_code_actions.erl
+++ b/apps/els_lsp/src/els_code_actions.erl
@@ -191,7 +191,7 @@ fix_atom_typo(Uri, Range, _Data, [Atom]) ->
     ].
 
 -spec ensure_range(els_poi:poi_range(), binary(), [els_poi:poi()]) ->
-          {ok, els_poi:poi_range()} | error.
+    {ok, els_poi:poi_range()} | error.
 ensure_range(#{from := {Line, _}}, SubjectId, POIs) ->
     SubjectAtom = binary_to_atom(SubjectId, utf8),
     Ranges = [

--- a/apps/els_lsp/src/els_code_actions.erl
+++ b/apps/els_lsp/src/els_code_actions.erl
@@ -180,13 +180,15 @@ remove_unused(Uri, _Range0, Data, [Import]) ->
 
 -spec fix_atom_typo(uri(), range(), binary(), [binary()]) -> [map()].
 fix_atom_typo(Uri, Range, _Data, [Atom]) ->
-  [make_edit_action(
-     Uri,
-     <<"Fix typo: ", Atom/binary>>,
-     ?CODE_ACTION_KIND_QUICKFIX,
-     Atom,
-     Range)
-  ].
+    [
+        make_edit_action(
+            Uri,
+            <<"Fix typo: ", Atom/binary>>,
+            ?CODE_ACTION_KIND_QUICKFIX,
+            Atom,
+            Range
+        )
+    ].
 
 -spec ensure_range(els_poi:poi_range(), binary(), [els_poi:poi()]) ->
           {ok, els_poi:poi_range()} | error.

--- a/apps/els_lsp/src/els_diagnostics.erl
+++ b/apps/els_lsp/src/els_diagnostics.erl
@@ -65,6 +65,7 @@
 -spec available_diagnostics() -> [diagnostic_id()].
 available_diagnostics() ->
     [
+        <<"atom_typo">>,
         <<"bound_var_in_pattern">>,
         <<"compiler">>,
         <<"crossref">>,

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -92,6 +92,13 @@ init_per_testcase(TestCase, Config) when
     mock_code_reload_enabled(),
     els_test_utils:init_per_testcase(TestCase, Config);
 init_per_testcase(TestCase, Config) when
+    TestCase =:= atom_typo
+->
+    meck:new(els_atom_typo_diagnostics, [passthrough, no_link]),
+    meck:expect(els_atom_typo_diagnostics, is_default, 0, true),
+    els_mock_diagnostics:setup(),
+    els_test_utils:init_per_testcase(TestCase, Config);
+init_per_testcase(TestCase, Config) when
     TestCase =:= crossref orelse
         TestCase =:= crossref_pseudo_functions orelse
         TestCase =:= crossref_autoimport orelse
@@ -153,6 +160,13 @@ init_per_testcase(TestCase, Config) ->
     els_test_utils:init_per_testcase(TestCase, Config).
 
 -spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) when
+    TestCase =:= atom_typo
+->
+    meck:unload(els_atom_typo_diagnostics),
+    els_test_utils:end_per_testcase(TestCase, Config),
+    els_mock_diagnostics:teardown(),
+    ok;
 end_per_testcase(TestCase, Config) when
     TestCase =:= code_reload orelse
         TestCase =:= code_reload_sticky_mod

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -12,6 +12,7 @@
 
 %% Test cases
 -export([
+    atom_typo/1,
     bound_var_in_pattern/1,
     compiler/1,
     compiler_with_behaviour/1,
@@ -218,6 +219,40 @@ end_per_testcase(TestCase, Config) ->
 %%==============================================================================
 %% Testcases
 %%==============================================================================
+-spec atom_typo(config()) -> ok.
+atom_typo(_Config) ->
+    Path = src_path("atom_typo.erl"),
+    Source = <<"AtomTypo">>,
+    Errors = [],
+    Warnings = [
+        #{
+            message => <<"Atom typo? Did you mean: true">>,
+            range => {{5, 2}, {5, 6}}
+        },
+        #{
+            message => <<"Atom typo? Did you mean: false">>,
+            range => {{6, 2}, {6, 8}}
+        },
+        #{
+            message => <<"Atom typo? Did you mean: false">>,
+            range => {{7, 2}, {7, 7}}
+        },
+        #{
+            message => <<"Atom typo? Did you mean: undefined">>,
+            range => {{8, 2}, {8, 11}}
+        },
+        #{
+            message => <<"Atom typo? Did you mean: undefined">>,
+            range => {{9, 2}, {9, 10}}
+        },
+        #{
+            message => <<"Atom typo? Did you mean: error">>,
+            range => {{10, 2}, {10, 8}}
+        }
+    ],
+    Hints = [],
+    els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
 -spec bound_var_in_pattern(config()) -> ok.
 bound_var_in_pattern(_Config) ->
     Path = src_path("diagnostics_bound_var_in_pattern.erl"),


### PR DESCRIPTION
### Description
* Add diagnostics to catch misspellings of common atoms.
* Add code action to fix the typo

### Example usage
![atom_typo](https://user-images.githubusercontent.com/56249/170272444-42595cc3-41e8-461f-9592-abbf8d8c88e8.gif)

