### PR TITLE
Relax supervision max restart intensity

### DIFF
--- a/apps/els_lsp/src/els_background_job_sup.erl
+++ b/apps/els_lsp/src/els_background_job_sup.erl
@@ -37,8 +37,8 @@ start_link() ->
 init([]) ->
     SupFlags = #{
         strategy => simple_one_for_one,
-        intensity => 5,
-        period => 60
+        intensity => 10,
+        period => 10
     },
     ChildSpecs = [
         #{


### PR DESCRIPTION
Move from 5 restarts in 1 minute to 10 restarts in 10 seconds.
Background jobs are often not critical. This change should prevent
unnecessary node crashes.

