### PR TITLE
Degrade gracefully to no diagnostics if text cannot be parsed

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_bound_var_in_pattern_cannot_parse.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_bound_var_in_pattern_cannot_parse.erl
@@ -1,0 +1,6 @@
+-module(diagnostics_bound_var_in_pattern_cannot_parse).
+
+f(Var1) ->
+  Var1 = 1.
+
+g() ->'

--- a/apps/els_lsp/src/els_bound_var_in_pattern_diagnostics.erl
+++ b/apps/els_lsp/src/els_bound_var_in_pattern_diagnostics.erl
@@ -53,8 +53,13 @@ source() ->
 -spec find_vars(uri()) -> [els_poi:poi()].
 find_vars(Uri) ->
     {ok, #{text := Text}} = els_utils:lookup_document(Uri),
-    {ok, Forms} = els_parser:parse_text(Text),
-    lists:flatmap(fun find_vars_in_form/1, Forms).
+    case els_parser:parse_text(Text) of
+        {ok, Forms} ->
+            lists:flatmap(fun find_vars_in_form/1, Forms);
+        {error, Error} ->
+            ?LOG_DEBUG("Cannot parse text [text=~p] [error=~p]", [Text, Error]),
+            []
+    end.
 
 -spec find_vars_in_form(erl_syntax:forms()) -> [els_poi:poi()].
 find_vars_in_form(Form) ->

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -14,6 +14,7 @@
 -export([
     atom_typo/1,
     bound_var_in_pattern/1,
+    bound_var_in_pattern_cannot_parse/1,
     compiler/1,
     compiler_with_behaviour/1,
     compiler_with_broken_behaviour/1,
@@ -301,6 +302,15 @@ bound_var_in_pattern(_Config) ->
         %% , #{ message => <<"Bound variable in pattern: F">>
         %%    , range => {{29, 6}, {29, 9}}}
     ],
+    els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
+-spec bound_var_in_pattern_cannot_parse(config()) -> ok.
+bound_var_in_pattern_cannot_parse(_Config) ->
+    Path = src_path("diagnostics_bound_var_in_pattern_cannot_parse.erl"),
+    Source = <<"BoundVarInPattern">>,
+    Errors = [],
+    Warnings = [],
+    Hints = [],
     els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
 
 -spec compiler(config()) -> ok.


### PR DESCRIPTION
The user was already not affected by these errors, since diagnostics
are computed as a background job, but this allows us to reduce the
noise in logs.
