### PR TITLE
Only store include/include_lib POIs as string

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_includes_broken.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_unused_includes_broken.erl
@@ -1,0 +1,5 @@
+-module(diagnostics_unused_includes_broken).
+
+-include_lib(
+    "foo"-include_lib("foo")
+).

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -363,10 +363,10 @@ attribute(Tree) ->
             Args = define_args(Define),
             Data = #{value_range => ValueRange, args => Args},
             [poi(DefinePos, define, define_name(Define), Data)];
-        {include, [String]} ->
-            [poi(Pos, include, erl_syntax:string_value(String))];
-        {include_lib, [String]} ->
-            [poi(Pos, include_lib, erl_syntax:string_value(String))];
+        {include, [Node]} ->
+            include_pois(Pos, include, Node);
+        {include_lib, [Node]} ->
+            include_pois(Pos, include_lib, Node);
         {record, [Record, Fields]} ->
             case is_record_name(Record) of
                 {true, RecordName} ->
@@ -1292,3 +1292,10 @@ get_end_location(Tree) ->
     %% erl_anno:end_location(erl_syntax:get_pos(Tree)).
     Anno = erl_syntax:get_pos(Tree),
     proplists:get_value(end_location, erl_anno:to_term(Anno)).
+
+-spec include_pois(pos(), include | include_lib, tree()) -> [els_poi:poi()].
+include_pois(Pos, Type, Node) ->
+    case erl_syntax:type(Node) of
+        string -> [poi(Pos, Type, erl_syntax:string_value(Node))];
+        _ -> []
+    end.

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -41,6 +41,7 @@
     crossref_pseudo_functions/1,
     unused_includes/1,
     unused_includes_compiler_attribute/1,
+    unused_includes_broken/1,
     exclude_unused_includes/1,
     unused_macros/1,
     unused_macros_refactorerl/1,
@@ -820,6 +821,15 @@ unused_includes_compiler_attribute(_Config) ->
             data => FileName
         }
     ],
+    Hints = [],
+    els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
+-spec unused_includes_broken(config()) -> ok.
+unused_includes_broken(_Config) ->
+    Path = src_path("diagnostics_unused_includes_broken.erl"),
+    Source = <<"UnusedIncludes">>,
+    Errors = [],
+    Warnings = [],
     Hints = [],
     els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
 


### PR DESCRIPTION
In case of incorrect syntax, it can happen that the content of an
include or include_lib is a tree and not a string. Since the
erl_syntax:string_value does not guarantee a string as the output,
let's explicitly validate the returned value. This will ensure that
non-string values are not stored in the DB, causing diagnostics to
fail due to wrong type assumptions.

