### PR TITLE
Pin rebar3_lint version to be able to support OTP 22

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -31,7 +31,7 @@
 {plugins, [
     rebar3_proper,
     coveralls,
-    rebar3_lint,
+    {rebar3_lint, "1.0.2"},
     {rebar3_bsp, {git, "https://github.com/erlang-ls/rebar3_bsp.git", {ref, "master"}}}
 ]}.
 


### PR DESCRIPTION
Version `1.1.0` of `rebar3_lint` dropped support or OTP 22 (see [this PR](https://github.com/project-fifo/rebar3_lint/pull/47)).

For the time being, let's just pin the linter version. FYI @elbrujohalcon @kdmnk.
