### PR TITLE
Treat incomplete trigger kind as invoked completion

### DIFF
--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -181,13 +181,16 @@ find_completions(
     end;
 find_completions(
     Prefix,
-    ?COMPLETION_TRIGGER_KIND_INVOKED,
+    TriggerKind,
     #{
         document := Document,
         line := Line,
         column := Column
     }
-) ->
+) when
+    TriggerKind =:= ?COMPLETION_TRIGGER_KIND_INVOKED;
+    TriggerKind =:= ?COMPLETION_TRIGGER_KIND_FOR_INCOMPLETE_COMPLETIONS
+->
     case lists:reverse(els_text:tokens(Prefix)) of
         %% Check for "[...] fun atom:"
         [{':', _}, {atom, _, Module}, {'fun', _} | _] ->


### PR DESCRIPTION
### Description

Sometimes completion stops working due to the client sending trigger kind `?COMPLETION_TRIGGER_KIND_FOR_INCOMPLETE_COMPLETIONS`.

Now erlang ls will handle it the same as `?COMPLETION_TRIGGER_KIND_INVOKED`