### PR TITLE
Add support for finding callback implementation for dynamic calls

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/implementation.erl
+++ b/apps/els_lsp/priv/code_navigation/src/implementation.erl
@@ -1,3 +1,6 @@
 -module(implementation).
-
+-export([call/1]).
 -callback to_be_implemented() -> ok.
+
+call(Mod) ->
+    Mod:to_be_implemented().

--- a/apps/els_lsp/src/els_implementation_provider.erl
+++ b/apps/els_lsp/src/els_implementation_provider.erl
@@ -43,6 +43,16 @@ find_implementation(Document, Line, Character) ->
     end.
 
 -spec implementation(els_dt_document:item(), els_poi:poi()) -> [{uri(), els_poi:poi()}].
+implementation(
+    Document,
+    #{
+        kind := application,
+        id := {_M, F, A},
+        data := #{mod_is_variable := true}
+    } = POI
+) ->
+    %% Try to handle Mod:function() by assuming it is a behaviour callback.
+    implementation(Document, POI#{kind => callback, id => {F, A}});
 implementation(Document, #{kind := application, id := MFA}) ->
     #{uri := Uri} = Document,
     case callback(MFA) of

--- a/apps/els_lsp/test/els_implementation_SUITE.erl
+++ b/apps/els_lsp/test/els_implementation_SUITE.erl
@@ -15,7 +15,8 @@
 %% Test cases
 -export([
     gen_server_call/1,
-    callback/1
+    callback/1,
+    dynamic_call/1
 ]).
 
 %%==============================================================================
@@ -81,6 +82,31 @@ gen_server_call(Config) ->
 callback(Config) ->
     Uri = ?config(implementation_uri, Config),
     #{result := Result} = els_client:implementation(Uri, 3, 20),
+    Expected = [
+        #{
+            range =>
+                #{
+                    'end' => #{character => 17, line => 6},
+                    start => #{character => 0, line => 6}
+                },
+            uri => ?config(implementation_a_uri, Config)
+        },
+        #{
+            range =>
+                #{
+                    'end' => #{character => 17, line => 6},
+                    start => #{character => 0, line => 6}
+                },
+            uri => ?config(implementation_b_uri, Config)
+        }
+    ],
+    ?assertEqual(Expected, Result),
+    ok.
+
+-spec dynamic_call(config()) -> ok.
+dynamic_call(Config) ->
+    Uri = ?config(implementation_uri, Config),
+    #{result := Result} = els_client:implementation(Uri, 6, 14),
     Expected = [
         #{
             range =>


### PR DESCRIPTION
### Description

Add support for finding implementation when pointing to a dynamic call that is a behaviour callback.

