### PR TITLE
[#1205] Implement goto_definition for testcases.

### DIFF
--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -71,10 +71,20 @@ goto_definition(
             Result
     end;
 goto_definition(
+    Uri,
+    #{kind := atom, id := Id} = POI
+) ->
+    %% Two interesting cases for atoms: testcases and modules.
+    %% Testcases are functions, so we first look for a function with the same name in the local scope
+    %% If we can't find it, we hope that the atom refers to a module.
+    case find(Uri, function, {Id, 1}) of
+        {error, _Error} -> goto_definition(Uri, POI#{kind := module});
+        Else -> Else
+    end;
+goto_definition(
     _Uri,
     #{kind := Kind, id := Module}
 ) when
-    Kind =:= atom;
     Kind =:= behaviour;
     Kind =:= module
 ->

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -75,7 +75,8 @@ goto_definition(
     #{kind := atom, id := Id} = POI
 ) ->
     %% Two interesting cases for atoms: testcases and modules.
-    %% Testcases are functions, so we first look for a function with the same name in the local scope
+    %% Testcases are functions with arity 1, so we first look for a function
+    %%   with the same name and arity 1 in the local scope
     %% If we can't find it, we hope that the atom refers to a module.
     case find(Uri, function, {Id, 1}) of
         {error, _Error} -> goto_definition(Uri, POI#{kind := module});

--- a/apps/els_lsp/test/els_definition_SUITE.erl
+++ b/apps/els_lsp/test/els_definition_SUITE.erl
@@ -44,6 +44,7 @@
     record_field/1,
     record_field_included/1,
     record_type_macro_name/1,
+    testcase/1,
     type_application_remote/1,
     type_application_undefined/1,
     type_application_user/1,
@@ -160,6 +161,18 @@ behaviour(Config) ->
     ?assertEqual(?config(behaviour_a_uri, Config), DefUri),
     ?assertEqual(
         els_protocol:range(#{from => {1, 9}, to => {1, 20}}),
+        Range
+    ),
+    ok.
+
+- spec testcase(config()) -> ok.
+testcase(Config) ->
+    Uri = ?config(sample_SUITE_uri, Config),
+    Def = els_client:definition(Uri, 35, 6),
+    #{result := #{range := Range, uri := DefUri}} = Def,
+    ?assertEqual(Uri, DefUri),
+    ?assertEqual(
+        els_protocol:range(#{from => {58, 1}, to => {58, 4}}),
         Range
     ),
     ok.

--- a/apps/els_lsp/test/els_definition_SUITE.erl
+++ b/apps/els_lsp/test/els_definition_SUITE.erl
@@ -165,7 +165,7 @@ behaviour(Config) ->
     ),
     ok.
 
-- spec testcase(config()) -> ok.
+-spec testcase(config()) -> ok.
 testcase(Config) ->
     Uri = ?config(sample_SUITE_uri, Config),
     Def = els_client:definition(Uri, 35, 6),


### PR DESCRIPTION
Summary:
https://github.com/erlang-ls/erlang_ls/issues/1205 suggested supporting the goto-definition feature for testcases.
Testcases are atoms (function definitions) and currently whenever doing goto-definition on an atom we treat it as a module.
I simply modified goto_definition to first look for a function of arity 1 in the current module when it is unclear whether the user is looking for a module or a testcase.

Test Plan:
I added the "testcase" test-case in els_definition_SUITE, following the structure of all other test-cases in that file.
This new testcase corresponds to doing "goto definition" on the atom "one" which appears in "all() -> [ one ]" in sample_SUITE.erl.
It verifies that we are sent to the definition of one at the bottom of sample_SUITE.erl.
I then checked that this new test-case passed, and that I did not break any other test in that suite. In particular, there were already tests for goto-definition on module names, and they still pass.