### PR TITLE
Register capabilities dynamically, complete support for didChangedWatchedFiles

### DIFF
--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -207,7 +207,7 @@ is_dynamic_registration_enabled(Method, ClientCapabilities) ->
 -spec dynamic_registration_options(binary()) -> map().
 dynamic_registration_options(<<"didChangeWatchedFiles">>) ->
     RootPath = els_uri:path(els_config:get(root_uri)),
-    GlobPattern = filename:join([<<RootPath/binary>>, "**", "*.{e,h}rl"]),
+    GlobPattern = filename:join([RootPath, "**", "*.{e,h}rl"]),
     #{
         id => <<"workspace/didChangeWatchedFiles">>,
         method => <<"workspace/didChangeWatchedFiles">>,

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -92,6 +92,7 @@ handle_request({initialized, _Params}, _State) ->
         <<"erlang_ls">>,
         filename:basename(RootUri)
     ),
+    register_capabilities(),
     els_distribution_server:start_distribution(NodeName),
     ?LOG_INFO("Started distribution for: [~p]", [NodeName]),
     els_indexing:maybe_start(),
@@ -178,3 +179,35 @@ server_capabilities() ->
                 version => els_utils:to_binary(Version)
             }
     }.
+
+-spec register_capabilities() -> ok.
+register_capabilities() ->
+    ClientCapabilities = els_config:get(capabilities),
+    Enabled = maps:get(
+        <<"dynamicRegistration">>,
+        maps:get(
+            <<"didChangeWatchedFiles">>,
+            maps:get(<<"workspace">>, ClientCapabilities, #{}),
+            #{}
+        ),
+        #{}
+    ),
+    RootPath = els_uri:path(els_config:get(root_uri)),
+    case Enabled of
+        true ->
+            GlobPattern = filename:join([<<RootPath/binary>>, "**", "*.{e,h}rl"]),
+            Params = #{
+                registrations => [
+                    #{
+                        id => <<"workspace/didChangeWatchedFiles">>,
+                        method => <<"workspace/didChangeWatchedFiles">>,
+                        registerOptions => #{
+                            watchers => [#{globPattern => GlobPattern}]
+                        }
+                    }
+                ]
+            },
+            els_server:send_request(<<"client/registerCapability">>, Params);
+        false ->
+            ?LOG_INFO("Dynamic registration for didChangeWatchedFiles disabled")
+    end.


### PR DESCRIPTION
By being able to register capabilities dynamically, Erlang LS can
instruct the client to send `didChangeWatchedFiles`
requests whenever a file or directory is modified outside of the
client itself. Through this mechanism it is possible to prevent text
synchronization issues and crashes during events such as a rebase or a checkout.