### PR TITLE
[#1310] Add a configuration option for advertised LSP providers.

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -59,7 +59,8 @@
     | compiler_telemetry_enabled
     | refactorerl
     | wrangler
-    | edoc_custom_tags.
+    | edoc_custom_tags
+    | providers.
 
 -type path() :: file:filename().
 -type state() :: #{
@@ -81,7 +82,8 @@
     indexing_enabled => boolean(),
     compiler_telemetry_enabled => boolean(),
     wrangler => map() | 'notconfigured',
-    refactorerl => map() | 'notconfigured'
+    refactorerl => map() | 'notconfigured',
+    providers => map()
 }.
 
 %%==============================================================================
@@ -149,6 +151,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     IndexingEnabled = maps:get(<<"indexingEnabled">>, InitOptions, true),
 
     RefactorErl = maps:get("refactorerl", Config, notconfigured),
+    Providers = maps:get("providers", Config, #{}),
 
     %% Initialize and start Wrangler
     case maps:get("wrangler", Config, notconfigured) of
@@ -201,6 +204,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     ok = set(macros, Macros),
     ok = set(plt_path, DialyzerPltPath),
     ok = set(code_reload, CodeReload),
+    ok = set(providers, Providers),
     ?LOG_INFO("Config=~p", [Config]),
     ok = set(
         runtime,

--- a/apps/els_lsp/src/els_call_hierarchy_provider.erl
+++ b/apps/els_lsp/src/els_call_hierarchy_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -16,9 +15,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({prepare, Params}) ->
     {Uri, Line, Char} =

--- a/apps/els_lsp/src/els_code_action_provider.erl
+++ b/apps/els_lsp/src/els_code_action_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -12,9 +11,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({document_codeaction, Params}) ->
     #{

--- a/apps/els_lsp/src/els_code_lens_provider.erl
+++ b/apps/els_lsp/src/els_code_lens_provider.erl
@@ -2,7 +2,6 @@
 
 -behaviour(els_provider).
 -export([
-    is_enabled/0,
     options/0,
     handle_request/1
 ]).
@@ -13,9 +12,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec options() -> map().
 options() ->
     #{resolveProvider => false}.

--- a/apps/els_lsp/src/els_definition_provider.erl
+++ b/apps/els_lsp/src/els_definition_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -12,9 +11,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({definition, Params}) ->
     #{

--- a/apps/els_lsp/src/els_diagnostics_provider.erl
+++ b/apps/els_lsp/src/els_diagnostics_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     options/0,
     handle_request/1
 ]).
@@ -22,9 +21,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec options() -> map().
 options() ->
     #{}.

--- a/apps/els_lsp/src/els_document_highlight_provider.erl
+++ b/apps/els_lsp/src/els_document_highlight_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -15,9 +14,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({document_highlight, Params}) ->
     #{

--- a/apps/els_lsp/src/els_document_symbol_provider.erl
+++ b/apps/els_lsp/src/els_document_symbol_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -12,9 +11,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({document_symbol, Params}) ->
     #{<<"textDocument">> := #{<<"uri">> := Uri}} = Params,

--- a/apps/els_lsp/src/els_execute_command_provider.erl
+++ b/apps/els_lsp/src/els_execute_command_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     options/0,
     handle_request/1
 ]).
@@ -17,9 +16,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec options() -> map().
 options() ->
     Commands = [

--- a/apps/els_lsp/src/els_folding_range_provider.erl
+++ b/apps/els_lsp/src/els_folding_range_provider.erl
@@ -5,7 +5,6 @@
 -include("els_lsp.hrl").
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -17,9 +16,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(tuple()) -> {response, folding_range_result()}.
 handle_request({document_foldingrange, Params}) ->
     #{<<"textDocument">> := #{<<"uri">> := Uri}} = Params,

--- a/apps/els_lsp/src/els_formatting_provider.erl
+++ b/apps/els_lsp/src/els_formatting_provider.erl
@@ -3,11 +3,7 @@
 -behaviour(els_provider).
 
 -export([
-    handle_request/1,
-    is_enabled/0,
-    is_enabled_document/0,
-    is_enabled_range/0,
-    is_enabled_on_type/0
+    handle_request/1
 ]).
 
 %%==============================================================================
@@ -23,23 +19,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
-%% Keep the behaviour happy
--spec is_enabled() -> boolean().
-is_enabled() -> is_enabled_document().
-
--spec is_enabled_document() -> boolean().
-is_enabled_document() -> true.
-
--spec is_enabled_range() -> boolean().
-is_enabled_range() ->
-    false.
-
-%% NOTE: because erlang_ls does not send incremental document changes
-%%       via `textDocument/didChange`, this kind of formatting does not
-%%       make sense.
--spec is_enabled_on_type() -> document_ontypeformatting_options().
-is_enabled_on_type() -> false.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({document_formatting, Params}) ->
     #{
@@ -66,6 +45,9 @@ handle_request({document_rangeformatting, Params}) ->
     {ok, Document} = els_utils:lookup_document(Uri),
     {ok, TextEdit} = rangeformat_document(Uri, Document, Range, Options),
     {response, TextEdit};
+%% NOTE: because erlang_ls does not send incremental document changes
+%%       via `textDocument/didChange`, this kind of formatting does not
+%%       make sense.
 handle_request({document_ontypeformatting, Params}) ->
     #{
         <<"position">> := #{

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -2,7 +2,6 @@
 
 -behaviour(els_provider).
 -export([
-    is_enabled/0,
     default_providers/0,
     enabled_providers/0,
     handle_request/1
@@ -51,9 +50,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(
     initialize_request()
     | initialized_request()
@@ -184,34 +180,22 @@ server_capabilities() ->
                     triggerCharacters =>
                         els_signature_help_provider:trigger_characters()
                 },
-            definitionProvider =>
-                els_definition_provider:is_enabled(),
-            referencesProvider =>
-                els_references_provider:is_enabled(),
-            documentHighlightProvider =>
-                els_document_highlight_provider:is_enabled(),
-            documentSymbolProvider =>
-                els_document_symbol_provider:is_enabled(),
-            workspaceSymbolProvider =>
-                els_workspace_symbol_provider:is_enabled(),
-            codeActionProvider =>
-                els_code_action_provider:is_enabled(),
-            documentFormattingProvider =>
-                els_formatting_provider:is_enabled_document(),
-            documentRangeFormattingProvider =>
-                els_formatting_provider:is_enabled_range(),
-            foldingRangeProvider =>
-                els_folding_range_provider:is_enabled(),
-            implementationProvider =>
-                els_implementation_provider:is_enabled(),
+            definitionProvider => true,
+            referencesProvider => true,
+            documentHighlightProvider => true,
+            documentSymbolProvider => true,
+            workspaceSymbolProvider => true,
+            codeActionProvider => true,
+            documentFormattingProvider => true,
+            documentRangeFormattingProvider => false,
+            foldingRangeProvider => true,
+            implementationProvider => true,
             executeCommandProvider =>
                 els_execute_command_provider:options(),
             codeLensProvider =>
                 els_code_lens_provider:options(),
-            renameProvider =>
-                els_rename_provider:is_enabled(),
-            callHierarchyProvider =>
-                els_call_hierarchy_provider:is_enabled(),
+            renameProvider => true,
+            callHierarchyProvider => true,
             semanticTokensProvider =>
                 #{
                     legend =>
@@ -220,7 +204,7 @@ server_capabilities() ->
                             tokenModifiers => wrangler_handler:semantic_token_modifiers()
                         },
                     range => false,
-                    full => els_semantic_token_provider:is_enabled()
+                    full => wrangler_handler:is_enabled()
                 }
         },
     EnabledProviders = enabled_providers(),

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -3,6 +3,8 @@
 -behaviour(els_provider).
 -export([
     is_enabled/0,
+    default_providers/0,
+    enabled_providers/0,
     handle_request/1
 ]).
 
@@ -44,6 +46,7 @@
 -type exit_request() :: {exit, exit_params()}.
 -type exit_params() :: #{status => atom()}.
 -type exit_result() :: null.
+-type provider_id() :: string().
 
 %%==============================================================================
 %% els_provider functions
@@ -111,10 +114,61 @@ handle_request({exit, #{status := Status}}) ->
 %% API
 %%==============================================================================
 
+%% @doc Give all available providers
+-spec available_providers() -> [provider_id()].
+available_providers() ->
+    [
+        "text-document-sync",
+        "hover",
+        "completion",
+        "signature-help",
+        "definition",
+        "references",
+        "document-highlight",
+        "document-symbol",
+        "workspace-symbol",
+        "code-action",
+        "document-formatting",
+        "document-range-formatting",
+        "document-on-type-formatting",
+        "folding-range",
+        "implementation",
+        "execute-command",
+        "code-lens",
+        "rename",
+        "call-hierarchy",
+        "semantic-tokens"
+    ].
+
+%% @doc Give the list of all providers enabled by default.
+-spec default_providers() -> [provider_id()].
+default_providers() ->
+    available_providers() --
+        [
+            "document-range-formatting",
+            %% NOTE: because erlang_ls does not send incremental document changes
+            %%       via `textDocument/didChange', this kind of formatting does not
+            %%       make sense.
+            "document-on-type-formatting",
+            %% Signature help is experimental.
+            "signature-help"
+        ].
+
+%% @doc Give the list of all providers enabled by the current configuration.
+-spec enabled_providers() -> [provider_id()].
+enabled_providers() ->
+    Config = els_config:get(providers),
+    Default = default_providers(),
+    Enabled = maps:get("enabled", Config, []),
+    Disabled = maps:get("disabled", Config, []),
+    lists:usort((Default ++ valid(Enabled)) -- valid(Disabled)).
+
+%% @doc Give the LSP server capabilities map for all capabilities enabled by
+%% the current configuration.
 -spec server_capabilities() -> server_capabilities().
 server_capabilities() ->
     {ok, Version} = application:get_key(?APP, vsn),
-    Capabilities =
+    AvailableCapabilities =
         #{
             textDocumentSync =>
                 els_text_synchronization_provider:options(),
@@ -169,18 +223,16 @@ server_capabilities() ->
                     full => els_semantic_token_provider:is_enabled()
                 }
         },
-    ActiveCapabilities =
-        case els_signature_help_provider:is_enabled() of
-            %% This pattern can never match because is_enabled/0 is currently
-            %% hard-coded to `false'. When enabling signature help manually,
-            %% uncomment this branch.
-            %% true ->
-            %%     Capabilities;
-            false ->
-                maps:remove(signatureHelpProvider, Capabilities)
-        end,
+    EnabledProviders = enabled_providers(),
+    ConfiguredCapabilities =
+        maps:filter(
+            fun(Provider, _Config) ->
+                lists:member(provider_id(Provider), EnabledProviders)
+            end,
+            AvailableCapabilities
+        ),
     #{
-        capabilities => ActiveCapabilities,
+        capabilities => ConfiguredCapabilities,
         serverInfo =>
             #{
                 name => <<"Erlang LS">>,
@@ -223,3 +275,50 @@ dynamic_registration_options(<<"didChangeWatchedFiles">>) ->
             watchers => [#{globPattern => GlobPattern}]
         }
     }.
+
+-spec valid([any()]) -> [provider_id()].
+valid(ProviderIds) ->
+    {Valid, Invalid} = lists:partition(fun is_valid_provider_id/1, ProviderIds),
+    case Invalid of
+        [] ->
+            ok;
+        _ ->
+            Fmt = "Discarding invalid providers in config file: ~p",
+            Args = [Invalid],
+            Msg = lists:flatten(io_lib:format(Fmt, Args)),
+            ?LOG_WARNING(Msg),
+            els_server:send_notification(
+                <<"window/showMessage">>,
+                #{
+                    type => ?MESSAGE_TYPE_WARNING,
+                    message => els_utils:to_binary(Msg)
+                }
+            )
+    end,
+    Valid.
+
+-spec is_valid_provider_id(any()) -> boolean().
+is_valid_provider_id(ProviderId) ->
+    lists:member(ProviderId, available_providers()).
+
+-spec provider_id(atom()) -> provider_id().
+provider_id(textDocumentSync) -> "text-document-sync";
+provider_id(completionProvider) -> "completion";
+provider_id(hoverProvider) -> "hover";
+provider_id(signatureHelpProvider) -> "signature-help";
+provider_id(definitionProvider) -> "definition";
+provider_id(referencesProvider) -> "references";
+provider_id(documentHighlightProvider) -> "document-highlight";
+provider_id(documentSymbolProvider) -> "document-symbol";
+provider_id(workspaceSymbolProvider) -> "workspace-symbol";
+provider_id(codeActionProvider) -> "code-action";
+provider_id(documentFormattingProvider) -> "document-formatting";
+provider_id(documentRangeFormattingProvider) -> "document-range-formatting";
+provider_id(documentOnTypeFormattingProvider) -> "document-on-type-formatting";
+provider_id(foldingRangeProvider) -> "folding-range";
+provider_id(implementationProvider) -> "implementation";
+provider_id(executeCommandProvider) -> "execute-command";
+provider_id(codeLensProvider) -> "code-lens";
+provider_id(renameProvider) -> "rename";
+provider_id(callHierarchyProvider) -> "call-hierarchy";
+provider_id(semanticTokensProvider) -> "semantic-tokens".

--- a/apps/els_lsp/src/els_hover_provider.erl
+++ b/apps/els_lsp/src/els_hover_provider.erl
@@ -6,7 +6,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -20,10 +19,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() ->
-    true.
-
 -spec handle_request(any()) -> {async, uri(), pid()}.
 handle_request({hover, Params}) ->
     #{

--- a/apps/els_lsp/src/els_implementation_provider.erl
+++ b/apps/els_lsp/src/els_implementation_provider.erl
@@ -5,16 +5,12 @@
 -include("els_lsp.hrl").
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(tuple()) -> {response, [location()]}.
 handle_request({implementation, Params}) ->
     #{

--- a/apps/els_lsp/src/els_references_provider.erl
+++ b/apps/els_lsp/src/els_references_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -26,9 +25,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, [location()] | null}.
 handle_request({references, Params}) ->
     #{

--- a/apps/els_lsp/src/els_rename_provider.erl
+++ b/apps/els_lsp/src/els_rename_provider.erl
@@ -3,8 +3,7 @@
 -behaviour(els_provider).
 
 -export([
-    handle_request/1,
-    is_enabled/0
+    handle_request/1
 ]).
 
 %%==============================================================================
@@ -24,9 +23,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({rename, Params}) ->
     #{

--- a/apps/els_lsp/src/els_semantic_token_provider.erl
+++ b/apps/els_lsp/src/els_semantic_token_provider.erl
@@ -3,16 +3,11 @@
 -behaviour(els_provider).
 
 -include("els_lsp.hrl").
--export([handle_request/1, is_enabled/0]).
+-export([handle_request/1]).
 
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
-
--spec is_enabled() -> boolean().
-is_enabled() ->
-    %% Currently this is used by Wrangler only.
-    wrangler_handler:is_enabled().
 
 -spec handle_request(any()) -> {response, any()}.
 handle_request({semantic_tokens, Params}) ->

--- a/apps/els_lsp/src/els_signature_help_provider.erl
+++ b/apps/els_lsp/src/els_signature_help_provider.erl
@@ -6,7 +6,6 @@
 -include_lib("kernel/include/logger.hrl").
 
 -export([
-    is_enabled/0,
     handle_request/1,
     trigger_characters/0
 ]).
@@ -22,10 +21,6 @@ trigger_characters() ->
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() ->
-    false.
-
 -spec handle_request(els_provider:provider_request()) ->
     {response, signature_help() | null}.
 handle_request({signature_help, Params}) ->

--- a/apps/els_lsp/src/els_workspace_symbol_provider.erl
+++ b/apps/els_lsp/src/els_workspace_symbol_provider.erl
@@ -3,7 +3,6 @@
 -behaviour(els_provider).
 
 -export([
-    is_enabled/0,
     handle_request/1
 ]).
 
@@ -14,9 +13,6 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec is_enabled() -> boolean().
-is_enabled() -> true.
-
 -spec handle_request(any()) -> {response, any()}.
 handle_request({symbol, Params}) ->
     %% TODO: Version 3.15 of the protocol introduces a much nicer way of

--- a/apps/els_lsp/test/els_initialization_SUITE.erl
+++ b/apps/els_lsp/test/els_initialization_SUITE.erl
@@ -22,7 +22,10 @@
     initialize_diagnostics_invalid/1,
     initialize_lenses_default/1,
     initialize_lenses_custom/1,
-    initialize_lenses_invalid/1
+    initialize_lenses_invalid/1,
+    initialize_providers_default/1,
+    initialize_providers_custom/1,
+    initialize_providers_invalid/1
 ]).
 
 %%==============================================================================
@@ -209,4 +212,46 @@ initialize_lenses_invalid(Config) ->
         <<"suggest-spec">>
     ],
     ?assertEqual(Expected, Result),
+    ok.
+
+-spec initialize_providers_default(config()) -> ok.
+initialize_providers_default(Config) ->
+    RootUri = els_test_utils:root_uri(),
+    DataDir = ?config(data_dir, Config),
+    ConfigPath = filename:join(DataDir, "providers_default.config"),
+    InitOpts = #{<<"erlang">> => #{<<"config_path">> => ConfigPath}},
+    els_client:initialize(RootUri, InitOpts),
+    Result = els_general_provider:enabled_providers(),
+    Expected = lists:usort(els_general_provider:default_providers()),
+    ?assertEqual(Expected, Result),
+    #{capabilities := Capabilities} = els_general_provider:server_capabilities(),
+    ?assertEqual(true, maps:is_key(hoverProvider, Capabilities)),
+    ok.
+
+-spec initialize_providers_custom(config()) -> ok.
+initialize_providers_custom(Config) ->
+    RootUri = els_test_utils:root_uri(),
+    DataDir = ?config(data_dir, Config),
+    ConfigPath = filename:join(DataDir, "providers_custom.config"),
+    InitOpts = #{<<"erlang">> => #{<<"config_path">> => ConfigPath}},
+    els_client:initialize(RootUri, InitOpts),
+    EnabledProviders = els_general_provider:enabled_providers(),
+    ?assertEqual(false, lists:member("hover", EnabledProviders)),
+    ?assertEqual(true, lists:member("document-on-type-formatting", EnabledProviders)),
+    #{capabilities := Capabilities} = els_general_provider:server_capabilities(),
+    ?assertEqual(false, maps:is_key(hoverProvider, Capabilities)),
+    ok.
+
+-spec initialize_providers_invalid(config()) -> ok.
+initialize_providers_invalid(Config) ->
+    RootUri = els_test_utils:root_uri(),
+    DataDir = ?config(data_dir, Config),
+    ConfigPath = filename:join(DataDir, "providers_invalid.config"),
+    InitOpts = #{<<"erlang">> => #{<<"config_path">> => ConfigPath}},
+    els_client:initialize(RootUri, InitOpts),
+    Result = els_general_provider:enabled_providers(),
+    Expected = lists:usort(els_general_provider:default_providers()),
+    ?assertEqual(Expected, Result),
+    #{capabilities := Capabilities} = els_general_provider:server_capabilities(),
+    ?assertEqual(true, maps:is_key(hoverProvider, Capabilities)),
     ok.

--- a/apps/els_lsp/test/els_initialization_SUITE_data/providers_custom.config
+++ b/apps/els_lsp/test/els_initialization_SUITE_data/providers_custom.config
@@ -1,0 +1,5 @@
+providers:
+    enabled:
+        - document-on-type-formatting
+    disabled:
+        - hover

--- a/apps/els_lsp/test/els_initialization_SUITE_data/providers_invalid.config
+++ b/apps/els_lsp/test/els_initialization_SUITE_data/providers_invalid.config
@@ -1,0 +1,5 @@
+providers:
+  enabled:
+    - hover
+  disabled:
+    - ssignaturee-hhelpp # Typos intentional


### PR DESCRIPTION
### Description

Adds a configuration option `providers` with `enabled` and `disabled` lists. These can be used to configure which providers the language server should advertise to the client in the ServerCapabilities message. For example, to enable signature help:

```yaml
# erlang_ls.config
providers:
  enabled:
    - signature-help
```

This could also be useful to bring in #980 as disabled-by-default.

The implementation is mostly inspired by the `lenses` configuration option which takes the same shape.

Fixes #1310.
