### PR TITLE
Do not send the 'body' field for DAP Initialized Event.

### DIFF
--- a/apps/els_dap/src/els_dap_protocol.erl
+++ b/apps/els_dap/src/els_dap_protocol.erl
@@ -30,8 +30,16 @@
 %%==============================================================================
 %% Messaging API
 %%==============================================================================
--spec event(number(), binary(), any()) -> binary().
-%% TODO: Body is optional
+
+-spec event(number(), binary(), map()) -> binary().
+event(Seq, <<"initialized">> = EventType, _Body) ->
+    %% The initialized event has no body.
+    Message = #{
+        type => <<"event">>,
+        seq => Seq,
+        event => EventType
+    },
+    content(jsx:encode(Message));
 event(Seq, EventType, Body) ->
     Message = #{
         type => <<"event">>,


### PR DESCRIPTION
### Description

The body field is required on most DAP Events and optional on Terminated but
is actually not included in Initialized at all. Clients parsing the Events
strictly will think an Initialized Event with a body is malformed, so this
change drops the field entirely for Initialized.

https://microsoft.github.io/debug-adapter-protocol/specification#Events_Initialized
