### PR TITLE
DAP: add `expensive` field to scopes type.

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -351,7 +351,8 @@ handle_request(
                         #{
                             <<"name">> => <<"Locals">>,
                             <<"presentationHint">> => <<"locals">>,
-                            <<"variablesReference">> => Ref
+                            <<"variablesReference">> => Ref,
+                            <<"expensive">> => false
                         }
                     ]
                 },


### PR DESCRIPTION
### Description

There's a required `expensive` field on the Scope Type used
to hint to the client whether the variables in the given scope are
expensive to retrieve.

https://microsoft.github.io/debug-adapter-protocol/specification#Types_Scope