### PR TITLE
Fix garbled utf8 characters

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics.erl
@@ -3,6 +3,7 @@
 -include("diagnostics.hrl").
 -include("broken_diagnostics.hrl").
 
+%% utf-8: （・ｗ・）
 -spec main(defined_type()) -> undefined_type().
 main(X) ->
   X.

--- a/apps/els_lsp/priv/code_navigation/src/diagnostics.new.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics.new.erl
@@ -1,8 +1,10 @@
 -module(diagnostics).
 %% Changed diagnostics.erl, to test diff generation
 
+%% Added utf-8: （・ω・）
 -include("diagnostics.hrl").
 -include("broken_diagnostics.hrl").
 
+%% Updated utf-8: （・ω・）
 -spec main(defined_type()) -> undefined_type().
 main(X) -> X + 1.

--- a/apps/els_lsp/src/els_text_edit.erl
+++ b/apps/els_lsp/src/els_text_edit.erl
@@ -50,14 +50,14 @@ make_text_edits([{del, Del}, {ins, Ins} | T], Line, Acc) ->
     Pos2 = #{line => Line + Len, character => 0},
     Edit = #{
         range => #{start => Pos1, 'end' => Pos2},
-        newText => els_utils:to_binary(lists:concat(Ins))
+        newText => list_to_binary(lists:concat(Ins))
     },
     make_text_edits(T, Line + Len, [Edit | Acc]);
 make_text_edits([{ins, Data} | T], Line, Acc) ->
     Pos = #{line => Line, character => 0},
     Edit = #{
         range => #{start => Pos, 'end' => Pos},
-        newText => els_utils:to_binary(lists:concat(Data))
+        newText => list_to_binary(lists:concat(Data))
     },
     make_text_edits(T, Line, [Edit | Acc]);
 make_text_edits([{del, Data} | T], Line, Acc) ->

--- a/apps/els_lsp/test/els_text_edit_SUITE.erl
+++ b/apps/els_lsp/test/els_text_edit_SUITE.erl
@@ -62,7 +62,7 @@ text_edit_diff(Config) ->
     DiagnosticsPath = els_uri:path(DiagnosticsUri),
     DiagnosticsDiffPath = ?config('diagnostics.new_path', Config),
     Result = els_text_edit:diff_files(DiagnosticsPath, DiagnosticsDiffPath),
-    [Edit1, Edit2] = Result,
+    [Edit1, Edit2, Edit3, Edit4] = Result,
     ?assertEqual(
         #{
             newText =>
@@ -77,13 +77,37 @@ text_edit_diff(Config) ->
     ),
     ?assertEqual(
         #{
-            newText => <<"main(X) -> X + 1.\n">>,
+            newText =>
+                <<"%% Added utf-8: （・ω・）\n"/utf8>>,
             range =>
                 #{
-                    'end' => #{character => 0, line => 8},
-                    start => #{character => 0, line => 6}
+                    'end' => #{character => 0, line => 2},
+                    start => #{character => 0, line => 2}
                 }
         },
         Edit2
+    ),
+    ?assertEqual(
+        #{
+            newText =>
+                <<"%% Updated utf-8: （・ω・）\n"/utf8>>,
+            range =>
+                #{
+                    'end' => #{character => 0, line => 6},
+                    start => #{character => 0, line => 5}
+                }
+        },
+        Edit3
+    ),
+    ?assertEqual(
+        #{
+            newText => <<"main(X) -> X + 1.\n">>,
+            range =>
+                #{
+                    'end' => #{character => 0, line => 9},
+                    start => #{character => 0, line => 7}
+                }
+        },
+        Edit4
     ),
     ok.


### PR DESCRIPTION
### Description

Fixes garbled UTF-8 characters after formatting.
tdiff:diff_files/2 returns the diff in raw string, so simple list_to_binary/1 is required when converting it into binary.

Currently,

```erlang
    %% （・ω・）
```

gets formatted into

```erlang
%% ï¼<88>ã<83>»Ï<89>ã<83>»ï¼<89>
```