### PR TITLE
Remove eqwalizer as dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,10 +23,7 @@
     {ephemeral, "2.0.4"},
     {tdiff, "0.1.2"},
     {uuid, "2.0.1", {pkg, uuid_erl}},
-    {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {ref, "6e89b4e"}}},
-    {eqwalizer_support,
-        {git_subdir, "https://github.com/whatsapp/eqwalizer.git", {branch, "main"},
-            "eqwalizer_support"}}
+    {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {ref, "6e89b4e"}}}
 ]}.
 
 {shell, [{apps, [els_lsp]}]}.
@@ -39,10 +36,7 @@
 ]}.
 
 {project_plugins, [
-    erlfmt,
-    {eqwalizer_rebar3,
-        {git_subdir, "https://github.com/whatsapp/eqwalizer.git", {branch, "main"},
-            "eqwalizer_rebar3"}}
+    erlfmt
 ]}.
 
 {minimum_otp_vsn, "22.0"}.


### PR DESCRIPTION
Temporarily remove eqwalizer as a project dependency, since the
git_subdir method breaks our internal upgrade scripts.
This does not affect eqwalizer diagnostics, which are still available.

