### PR TITLE
Send end progress when request is cancelled.

### DIFF
--- a/apps/els_lsp/test/els_progress_SUITE.erl
+++ b/apps/els_lsp/test/els_progress_SUITE.erl
@@ -66,7 +66,10 @@ init_per_testcase(failing_job = TestCase, Config) ->
     setup_mocks(Task),
     [{task, Task} | els_test_utils:init_per_testcase(TestCase, Config)];
 init_per_testcase(stop_job = TestCase, Config) ->
-    Task = fun(_, _) -> sample_job:task_called(), timer:sleep(timer:seconds(100)) end,
+    Task = fun(_, _) ->
+        sample_job:task_called(),
+        timer:sleep(timer:seconds(100))
+    end,
     setup_mocks(Task),
     %% Bit of a hack, because meck only count history after mocked function returns it seems,
     %% and the above function will not return.


### PR DESCRIPTION
### Description
If task is long running, the background job gen_server will not process messages meanwhile. So when stopping background job, it seems supervisor will timeout and kill the process instead of graceful shutdown. So terminate function is not called.
This PR changes to run the task in a subprocess.

Also send an error response for cancelled tasks. As I understand it, even cancelled requests must send a response.

Fixes https://github.com/erlang-ls/erlang_ls/issues/1365 .
