### PR TITLE
[1371] Add Custom Hostname and Domain Options

### DIFF
--- a/apps/els_core/src/els_distribution_server.erl
+++ b/apps/els_core/src/els_distribution_server.erl
@@ -18,7 +18,6 @@
     rpc_call/3,
     rpc_call/4,
     node_name/2,
-    node_name/3,
     normalize_node_name/1
 ]).
 
@@ -223,15 +222,7 @@ node_name(Prefix, Name0) ->
     Name = normalize_node_name(Name0),
     Int = erlang:phash2(erlang:timestamp()),
     Id = lists:flatten(io_lib:format("~s_~s_~p", [Prefix, Name, Int])),
-    {ok, HostName} = inet:gethostname(),
-    node_name(Id, HostName, els_config_runtime:get_name_type()).
-
--spec node_name(string(), string(), 'longnames' | 'shortnames') -> atom().
-node_name(Id, HostName, shortnames) ->
-    list_to_atom(Id ++ "@" ++ HostName);
-node_name(Id, HostName, longnames) ->
-    Domain = proplists:get_value(domain, inet:get_rc(), ""),
-    list_to_atom(Id ++ "@" ++ HostName ++ "." ++ Domain).
+    els_utils:compose_node_name(Id, els_config_runtime:get_name_type()).
 
 -spec normalize_node_name(string() | binary()) -> string().
 normalize_node_name(Name) ->

--- a/apps/els_core/src/els_utils.erl
+++ b/apps/els_core/src/els_utils.erl
@@ -453,15 +453,18 @@ compose_node_name(Name, Type) ->
             true ->
                 Name;
             _ ->
-                {ok, HostName} = inet:gethostname(),
+                HostName = els_config_runtime:get_hostname(),
                 Name ++ [$@ | HostName]
         end,
     case Type of
         shortnames ->
             list_to_atom(NodeName);
         longnames ->
-            Domain = proplists:get_value(domain, inet:get_rc(), ""),
-            list_to_atom(NodeName ++ "." ++ Domain)
+            Domain = els_config_runtime:get_domain(),
+            case Domain of
+                "" -> list_to_atom(NodeName);
+                _ -> list_to_atom(NodeName ++ "." ++ Domain)
+            end
     end.
 
 %% @doc Given an MFA or a FA, return a printable version of the


### PR DESCRIPTION
# #1371  Add Custom Hostname and Domain Options

When using `longnames` in projects that don't adhere to the host-provided hostname and domain it is useful to be able to override those via the `erlang_ls.config` file.  The code in this commit provides these options as well as cleans up some related duplicated code.

This code also fixes a small bug that would leave a trailing dot `.` if a domain is not defined.

Tests have been updated to reflect these changes and new tests have been created to test the new options.

A sample config file with the new options looks like this:

```yaml
apps_dirs:
    - "src/*"
include_dirs:
    - "src"
    - "src/*/include"
code_reload:
    node: "node1@127.0.0.1"
runtime:
    use_long_names: true
    hostname: "127"
    domain: "0.0.1"
```

The above is an exaggerated example, a simple, more direct one that accomplishes the same would be:

```yaml
apps_dirs:
    - "src/*"
include_dirs:
    - "src"
    - "src/*/include"
code_reload:
    node: "node1@127.0.0.1"
runtime:
    use_long_names: true
    hostname: "127.0.0.1"
    # no need to also specify domain, but may be useful to override as an empty string if needed
    domain: ""
```

Fixes #1371 
