### PR TITLE
[dap] support non-verified breakpoints 

### DIFF
--- a/apps/els_dap/src/els_dap_breakpoints.erl
+++ b/apps/els_dap/src/els_dap_breakpoints.erl
@@ -139,7 +139,12 @@ do_line_breakpoints(Node, Module, LineBreakPoints, Breaks, Set) ->
 -spec do_function_breaks(node(), module(), [function_break()], breakpoints(), boolean()) ->
     breakpoints().
 do_function_breaks(Node, Module, FBreaks, Breaks, Set) ->
-    [[els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks] || Set],
+    case Set of
+        true ->
+            [els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks];
+        false ->
+            ok
+    end,
     case Breaks of
         #{Module := ModBreaks} ->
             Breaks#{Module => ModBreaks#{function => FBreaks}};

--- a/apps/els_dap/src/els_dap_breakpoints.erl
+++ b/apps/els_dap/src/els_dap_breakpoints.erl
@@ -3,8 +3,8 @@
     build_source_breakpoints/1,
     get_function_breaks/2,
     get_line_breaks/2,
-    do_line_breakpoints/4,
-    do_function_breaks/4,
+    do_line_breakpoints/5,
+    do_function_breaks/5,
     type/3
 ]).
 
@@ -108,21 +108,27 @@ get_function_breaks(Module, Breaks) ->
 get_line_breaks(Module, Breaks) ->
     case Breaks of
         #{Module := #{line := Lines}} -> Lines;
-        _ -> []
+        _ -> #{}
     end.
 
 -spec do_line_breakpoints(
     node(),
     module(),
     #{line() => line_breaks()},
-    breakpoints()
+    breakpoints(),
+    boolean()
 ) ->
     breakpoints().
-do_line_breakpoints(Node, Module, LineBreakPoints, Breaks) ->
-    maps:map(
-        fun(Line, _) -> els_dap_rpc:break(Node, Module, Line) end,
-        LineBreakPoints
-    ),
+do_line_breakpoints(Node, Module, LineBreakPoints, Breaks, Set) ->
+    case Set of
+        true ->
+            maps:map(
+                fun(Line, _) -> els_dap_rpc:break(Node, Module, Line) end,
+                LineBreakPoints
+            );
+        false ->
+            ok
+    end,
     case Breaks of
         #{Module := ModBreaks} ->
             Breaks#{Module => ModBreaks#{line => LineBreakPoints}};
@@ -130,10 +136,10 @@ do_line_breakpoints(Node, Module, LineBreakPoints, Breaks) ->
             Breaks#{Module => #{line => LineBreakPoints, function => []}}
     end.
 
--spec do_function_breaks(node(), module(), [function_break()], breakpoints()) ->
+-spec do_function_breaks(node(), module(), [function_break()], breakpoints(), boolean()) ->
     breakpoints().
-do_function_breaks(Node, Module, FBreaks, Breaks) ->
-    [els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks],
+do_function_breaks(Node, Module, FBreaks, Breaks, Set) ->
+    [[els_dap_rpc:break_in(Node, Module, Func, Arity) || {Func, Arity} <- FBreaks] || Set],
     case Breaks of
         #{Module := ModBreaks} ->
             Breaks#{Module => ModBreaks#{function => FBreaks}};

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -192,7 +192,7 @@ handle_request(
     ensure_connected(ProjectNode, Timeout),
     {Module, LineBreaks} = els_dap_breakpoints:build_source_breakpoints(Params),
 
-    {IsModuleAvailable, Message} = maybe_interprete_and_clear_module(ProjectNode, Module),
+    {IsModuleAvailable, Message} = maybe_interpret_and_clear_module(ProjectNode, Module),
 
     Breakpoints1 =
         els_dap_breakpoints:do_line_breakpoints(
@@ -256,7 +256,7 @@ handle_request(
         maps:fold(
             fun(Module, FunctionBreaks, {AccBP, AccVerified}) ->
                 {IsModuleAvailable, Message} =
-                    maybe_interprete_and_clear_module(ProjectNode, Module),
+                    maybe_interpret_and_clear_module(ProjectNode, Module),
                 {
                     els_dap_breakpoints:do_function_breaks(
                         ProjectNode,
@@ -1092,8 +1092,8 @@ distribution_error(Error) ->
         )
     ).
 
--spec maybe_interprete_and_clear_module(node(), module()) -> {boolean(), binary()}.
-maybe_interprete_and_clear_module(ProjectNode, Module) ->
+-spec maybe_interpret_and_clear_module(node(), module()) -> {boolean(), binary()}.
+maybe_interpret_and_clear_module(ProjectNode, Module) ->
     case els_dap_rpc:interpretable(ProjectNode, Module) of
         true ->
             {module, Module} = els_dap_rpc:i(ProjectNode, Module),

--- a/apps/els_dap/src/els_dap_rpc.erl
+++ b/apps/els_dap/src/els_dap_rpc.erl
@@ -15,6 +15,7 @@
     get_meta/2,
     halt/1,
     i/2,
+    interpretable/2,
     load_binary/4,
     meta/4,
     meta_eval/3,
@@ -105,6 +106,12 @@ halt(Node) ->
 -spec i(node(), module()) -> any().
 i(Node, Module) ->
     rpc:call(Node, int, i, [Module]).
+
+-spec interpretable(node(), module() | string()) ->
+    true
+    | {error, no_src | no_beam | no_debug_info | badarg | {app, kernel | stdlib | gs | debugger}}.
+interpretable(Node, AbsModule) ->
+    rpc:call(Node, int, interpretable, [AbsModule]).
 
 -spec load_binary(node(), module(), string(), binary()) -> any().
 load_binary(Node, Module, File, Bin) ->

--- a/apps/els_dap/test/els_dap_general_provider_SUITE.erl
+++ b/apps/els_dap/test/els_dap_general_provider_SUITE.erl
@@ -478,6 +478,16 @@ breakpoints(Config) ->
         )
     ),
     ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
+
+    els_dap_provider:handle_request(
+        Provider,
+        request_set_breakpoints(
+            path_to_test_module(DataDir, i_dont_exist),
+            [42]
+        )
+    ),
+    ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
+
     els_dap_provider:handle_request(
         Provider,
         request_set_function_breakpoints([<<"els_dap_test_module:entry/1">>])
@@ -508,7 +518,16 @@ breakpoints(Config) ->
         Provider,
         request_set_function_breakpoints([])
     ),
-    ?assertMatch([{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)),
+    ?assertMatch(
+        [{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)
+    ),
+    els_dap_provider:handle_request(
+        Provider,
+        request_set_function_breakpoints([<<"i_dont:exist/42">>])
+    ),
+    ?assertMatch(
+        [{{els_dap_test_module, 9}, _}], els_dap_rpc:all_breaks(Node)
+    ),
     ok.
 
 -spec project_node_exit(config()) -> ok.


### PR DESCRIPTION
### Description
support non-verified breakpoints in case the module isn't available in the debugged node

Before this would crash, now create a non-verified breakpoint, with some description

Fixes #1373 

