### PR TITLE
Find references asynchronously

### DIFF
--- a/apps/els_lsp/src/els_definition_provider.erl
+++ b/apps/els_lsp/src/els_definition_provider.erl
@@ -11,7 +11,7 @@
 %%==============================================================================
 %% els_provider functions
 %%==============================================================================
--spec handle_request(any()) -> {response, any()}.
+-spec handle_request(any()) -> {response, any()} | {async, uri(), pid()}.
 handle_request({definition, Params}) ->
     #{
         <<"position">> := #{

--- a/apps/els_lsp/src/els_methods.erl
+++ b/apps/els_lsp/src/els_methods.erl
@@ -306,9 +306,12 @@ completionitem_resolve(Params, State) ->
 -spec textdocument_definition(params(), els_server:state()) -> result().
 textdocument_definition(Params, State) ->
     Provider = els_definition_provider,
-    {response, Response} =
-        els_provider:handle_request(Provider, {definition, Params}),
-    {response, Response, State}.
+    case els_provider:handle_request(Provider, {definition, Params}) of
+        {response, Response} ->
+            {response, Response, State};
+        {async, Uri, Job} ->
+            {async, Uri, Job, State}
+    end.
 
 %%==============================================================================
 %% textDocument/references
@@ -317,9 +320,8 @@ textdocument_definition(Params, State) ->
 -spec textdocument_references(params(), els_server:state()) -> result().
 textdocument_references(Params, State) ->
     Provider = els_references_provider,
-    {response, Response} =
-        els_provider:handle_request(Provider, {references, Params}),
-    {response, Response, State}.
+    {async, Uri, Job} = els_provider:handle_request(Provider, {references, Params}),
+    {async, Uri, Job, State}.
 
 %%==============================================================================
 %% textDocument/documentHightlight


### PR DESCRIPTION
### Description

Currently Erlang LS finds references synchronously. For a big code basis, if the user looks for references for a function which is commonly named, this could result in a huge number of _candidates_ and therefore in a massive indexing process.
Since the request is handled in a synchronous way, the `els_server` process gets unresponsive for seconds (minutes) without the ability to cancel the request.

This PR moves to the built-in asynchronous model, not to block the main server.

As a follow up, we should:

* Implement cancellation for workdone progress jobs. This will allow clients such as VS Code to render a "Cancel" button that users can use to cancel long jobs manually.
* In the case of references, we should switch to a client-initiated workdone progress job. This will likely enable the client to auto-cancel long requests whose results are no longer necessary.