### PR TITLE
[#1360] Support completion of record fields inside #record{}

### DIFF
--- a/apps/els_core/src/els_text.erl
+++ b/apps/els_core/src/els_text.erl
@@ -12,6 +12,7 @@
     tokens/1,
     apply_edits/2
 ]).
+-export([strip_comments/1]).
 
 -export_type([edit/0]).
 
@@ -131,6 +132,17 @@ ensure_string(Text) when is_binary(Text) ->
     els_utils:to_list(Text);
 ensure_string(Text) ->
     Text.
+
+-spec strip_comments(binary()) -> binary().
+strip_comments(Text) ->
+    lines_to_bin(
+        lists:map(
+            fun(Line) ->
+                hd(string:split(Line, "%"))
+            end,
+            bin_to_lines(Text)
+        )
+    ).
 
 %%==============================================================================
 %% Internal functions

--- a/apps/els_core/src/els_utils.erl
+++ b/apps/els_core/src/els_utils.erl
@@ -22,6 +22,7 @@
     base64_encode_term/1,
     base64_decode_term/1,
     levenshtein_distance/2,
+    camel_case/1,
     jaro_distance/2,
     is_windows/0,
     system_tmp_dir/0
@@ -487,6 +488,13 @@ base64_encode_term(Term) ->
 base64_decode_term(Base64) ->
     binary_to_term(base64:decode(Base64)).
 
+-spec camel_case(binary() | string()) -> binary().
+camel_case(Str0) ->
+    %% Remove ''
+    Str = string:trim(Str0, both, "'"),
+    Words = [string:titlecase(Word) || Word <- string:lexemes(Str, "_")],
+    iolist_to_binary(Words).
+
 -spec levenshtein_distance(binary(), binary()) -> integer().
 levenshtein_distance(S, T) ->
     {Distance, _} = levenshtein_distance(to_list(S), to_list(T), #{}),
@@ -716,5 +724,13 @@ jaro_distance_test_() ->
             0.6666666666666666
         )
     ].
+
+camel_case_test() ->
+    ?assertEqual(<<"">>, camel_case(<<"">>)),
+    ?assertEqual(<<"F">>, camel_case(<<"f">>)),
+    ?assertEqual(<<"Foo">>, camel_case(<<"foo">>)),
+    ?assertEqual(<<"FooBar">>, camel_case(<<"foo_bar">>)),
+    ?assertEqual(<<"FooBarBaz">>, camel_case(<<"foo_bar_baz">>)),
+    ?assertEqual(<<"FooBarBaz">>, camel_case(<<"'foo_bar_baz'">>)).
 
 -endif.

--- a/apps/els_lsp/priv/code_navigation/src/completion_records.erl
+++ b/apps/els_lsp/priv/code_navigation/src/completion_records.erl
@@ -1,0 +1,10 @@
+-module(completion_records).
+
+-record(record_a, {field_a, field_b, 'Field C'}).
+-record(record_b, {field_x, field_y}).
+
+function_a(#record_a{field_a = a, field_b = b}) ->
+    #record_b{field_x = #record_a{},
+              %% #record_a{
+              field_y = y},
+    {}.

--- a/apps/els_lsp/src/els_scope.erl
+++ b/apps/els_lsp/src/els_scope.erl
@@ -4,7 +4,8 @@
 -export([
     local_and_included_pois/2,
     local_and_includer_pois/2,
-    variable_scope_range/2
+    variable_scope_range/2,
+    pois_before/2
 ]).
 
 -include("els_lsp.hrl").
@@ -154,9 +155,9 @@ variable_scope_range(VarRange, Document) ->
     end.
 
 -spec pois_before([els_poi:poi()], els_poi:poi_range()) -> [els_poi:poi()].
-pois_before(POIs, VarRange) ->
+pois_before(POIs, Range) ->
     %% Reverse since we are typically interested in the last POI
-    lists:reverse([POI || POI <- POIs, els_range:compare(range(POI), VarRange)]).
+    lists:reverse([POI || POI <- POIs, els_range:compare(range(POI), Range)]).
 
 -spec pois_after([els_poi:poi()], els_poi:poi_range()) -> [els_poi:poi()].
 pois_after(POIs, VarRange) ->


### PR DESCRIPTION
### Description

Support completion of record fields inside #record{}

* Automatic triggering when cursor is at #record{| and #record{... , |
* Invoked completion on record field inside record #record{field|

![record_fields](https://user-images.githubusercontent.com/56249/191338902-e56ecd2e-6e29-4b46-a71d-78070712d995.gif)

Fixes #1360 .

