### PR TITLE
[#1290] Fix error when parsing record containing a comment

### DIFF
--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -851,7 +851,9 @@ record_field_name(FieldNode, Record, Kind) ->
             record_field ->
                 erl_syntax:record_field_name(FieldNode);
             record_type_field ->
-                erl_syntax:record_type_field_name(FieldNode)
+                erl_syntax:record_type_field_name(FieldNode);
+            comment ->
+                undefined
         end,
     case is_atom_node(NameNode) of
         {true, NameAtom} ->
@@ -968,7 +970,9 @@ macro_name(Tree) ->
 macro_name(Name, none) -> node_name(Name);
 macro_name(Name, Args) -> {node_name(Name), length(Args)}.
 
--spec is_atom_node(tree()) -> {true, atom()} | false.
+-spec is_atom_node(tree() | undefined) -> {true, atom()} | false.
+is_atom_node(undefined) ->
+    false;
 is_atom_node(Tree) ->
     case erl_syntax:type(Tree) of
         atom ->

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -32,7 +32,8 @@
     record_def_recursive/1,
     var_in_application/1,
     unicode_clause_pattern/1,
-    latin1_source_code/1
+    latin1_source_code/1,
+    record_comment/1
 ]).
 
 %%==============================================================================
@@ -449,6 +450,16 @@ latin1_source_code(_Config) ->
     ?assertMatch(
         [#{data := <<"(\"È\") "/utf8>>}],
         parse_find_pois(Text, function_clause, {f, 1, 1})
+    ),
+    ok.
+
+%% Issue #1290 Parsing error
+-spec record_comment(config()) -> ok.
+record_comment(_Config) ->
+    Text = <<"#my_record{\n%% TODO\n}.">>,
+    ?assertMatch(
+        [#{id := my_record}],
+        parse_find_pois(Text, record_expr)
     ),
     ok.
 


### PR DESCRIPTION
### Description

Fix error when parsing record containing a comment.

Fixes #1290 .
