### PR TITLE
Show function docs for function_clauses and specs

### DIFF
--- a/apps/els_lsp/src/els_docs.erl
+++ b/apps/els_lsp/src/els_docs.erl
@@ -53,8 +53,12 @@ docs(_Uri, #{kind := Kind, id := {M, F, A}}) when
 docs(Uri, #{kind := Kind, id := {F, A}}) when
     Kind =:= application;
     Kind =:= implicit_fun;
-    Kind =:= export_entry
+    Kind =:= export_entry;
+    Kind =:= spec
 ->
+    M = els_uri:module(Uri),
+    function_docs('local', M, F, A);
+docs(Uri, #{kind := function_clause, id := {F, A, _Index}}) ->
     M = els_uri:module(Uri),
     function_docs('local', M, F, A);
 docs(Uri, #{kind := macro, id := Name} = POI) ->


### PR DESCRIPTION
`els_docs:docs/2` was not previously implemented for `function_clause` and `spec` POIs, so hover requests would return `null` when hovering over function and spec definitions. This change returns the function definition docs for both cases.

The new behavior is in line with other language servers (ElixirLS, rust-analyzer) and can be useful - for example to see how the documentation looks for a function you're just written.
