### PR TITLE
Ignore auto-formatting commit from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply erlfmt to the entire codebase (#1297)
+c19fb7239ef6766aa7e583d1c010ac38588a3de3


### PR DESCRIPTION
### Description

Git allows ignore revisions from blame results with

    git blame --ignore-revs-file .git-blame-ignore-revs

GitHub also allows ignoring revisions from blame results: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

This is usually used for large auto-formatting commits since the formatting changes are a bit noisy and can make it tricky to poke around the blame.

What do you think?