### PR TITLE
[#1046,#1064] Follow symlinks in `els_utils:resolve_paths/2`

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -134,7 +134,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     Lenses = maps:get("lenses", Config, #{}),
     Diagnostics = maps:get("diagnostics", Config, #{}),
     ExcludePathsSpecs = [[OtpPath, "lib", P ++ "*"] || P <- OtpAppsExclude],
-    ExcludePaths = els_utils:resolve_paths(ExcludePathsSpecs, RootPath, true),
+    ExcludePaths = els_utils:resolve_paths(ExcludePathsSpecs, true),
     ?LOG_INFO("Excluded OTP Applications: ~p", [OtpAppsExclude]),
     CodeReload = maps:get("code_reload", Config, disabled),
     Runtime = maps:get("runtime", Config, #{}),
@@ -375,7 +375,7 @@ report_missing_config() ->
 -spec include_paths(path(), string(), boolean()) -> [string()].
 include_paths(RootPath, IncludeDirs, Recursive) ->
     Paths = [
-        els_utils:resolve_paths([[RootPath, Dir]], RootPath, Recursive)
+        els_utils:resolve_paths([[RootPath, Dir]], Recursive)
      || Dir <- IncludeDirs
     ],
     lists:append(Paths).
@@ -389,7 +389,6 @@ project_paths(RootPath, Dirs, Recursive) ->
                 [RootPath, Dir, "test"],
                 [RootPath, Dir, "include"]
             ],
-            RootPath,
             Recursive
         )
      || Dir <- Dirs
@@ -411,7 +410,6 @@ otp_paths(OtpPath, Recursive) ->
             [OtpPath, "lib", "*", "src"],
             [OtpPath, "lib", "*", "include"]
         ],
-        OtpPath,
         Recursive
     ).
 


### PR DESCRIPTION
### Description

erlang-ls/erlang_ls#346 discarded any paths containing symlinks since they broke assumptions about there being a single URI for each module in calls to `els_utils:find_module/1`.

erlang-ls/erlang_ls#648 added prioritization for cases when there are multiple URIs in `els_utils:find_module/1`, so discarding paths with symlinks is now no longer necessary.

Following symlinks is necessary when using rebar3 checkout dependencies (erlang-ls/erlang_ls#1046) or when using Bazel (erlang-ls/erlang_ls#1064) since Bazel places dependencies and compiled files under its cache directory and symlinks the relevant directory in the cache to the workspace directory.

This change removes the behavior of `els_utils:resolve_paths/2` that discards paths containing symlinks.

I tested this in a rebar3 project with checkout dependencies and in a Bazel project and it works well. I haven't noticed any regressions, so I think the changes in #648 fixed the issue in #339.

Fixes #1046.
Fixes #1064.