### PR TITLE
Add some clearer logging

### DIFF
--- a/apps/els_lsp/src/els_code_lens_suggest_spec.erl
+++ b/apps/els_lsp/src/els_code_lens_suggest_spec.erl
@@ -30,6 +30,9 @@ init(#{uri := Uri} = _Document) ->
         Info ->
             Info
     catch
+        throw:{dialyzer_error, "Could not read PLT file " ++ _ = Message} ->
+            ?LOG_WARNING("~s are you missing configuration?", [Message]),
+            'no_info';
         C:E:S ->
             Fmt =
                 "Cannot extract typer info.~n"

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -853,13 +853,13 @@ handle_rpc_result({ok, Module}, _) ->
         }
     );
 handle_rpc_result(Err, Module) ->
-    ?LOG_INFO(
-        "[code_reload] code_reload using c:c/1 crashed with: ~p",
-        [Err]
+    ?LOG_ERROR(
+        "[code_reload] rpc c:c(~s) crashed with: ~p",
+        [Module, Err]
     ),
     Msg = io_lib:format(
-        "code_reload swap crashed for: ~s with: ~w",
-        [Module, Err]
+        "code_reload failed for: ~s (check logs for details)",
+        [Module]
     ),
     els_server:send_notification(
         <<"window/showMessage">>,

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -81,7 +81,13 @@ source() ->
 -spec on_complete(uri(), [els_diagnostics:diagnostic()]) -> ok.
 on_complete(Uri, Diagnostics) ->
     ?MODULE:telemetry(Uri, Diagnostics),
-    maybe_compile_and_load(Uri, Diagnostics).
+    case filename:extension(Uri) of
+        <<".erl">> ->
+            maybe_compile_and_load(Uri, Diagnostics);
+        _Ext ->
+            ?LOG_DEBUG("Skipping compile and load due to extension [uri=~p]", [Uri]),
+            ok
+    end.
 
 %%==============================================================================
 %% Internal Functions


### PR DESCRIPTION
### Description

I was originally looking at cookie issues with code reloading and thought some of the error logging made it harder for me to figure out what was wrong.

This PR should make debugging your local Erlang LS setup easier.

* Move reload error details from notifications to the error log (makes the notifications smaller)
* Make code_reload only act on `.erl` files (avoids code reload notification spam from e.g. `.hrl` or `.config` files)
* Catch PLT file read errors from `els_typer` when initializing the `'suggest-spec'` command and suggest how to fix that