### PR TITLE
Make test suite work in OTP 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [22, 23, 24]
+        otp-version: [22, 23, 24, 25]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [22, 23, 24, 25]
+        otp-version: [23, 24, 25]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}
@@ -89,7 +89,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install Erlang
-      run: choco install -y erlang --version 22.3
+      run: choco install -y erlang --version 23.3
     - name: Install rebar3
       run: choco install -y rebar3 --version 3.13.1
     - name: Compile

--- a/apps/els_lsp/src/els_docs.erl
+++ b/apps/els_lsp/src/els_docs.erl
@@ -103,8 +103,7 @@ docs(_M, _POI) ->
 -spec function_docs(application_type(), atom(), atom(), non_neg_integer()) ->
     [els_markup_content:doc_entry()].
 function_docs(Type, M, F, A) ->
-    %% this enables mocking eep48_docs/4 in tests
-    case ?MODULE:eep48_docs(function, M, F, A) of
+    case eep48_docs(function, M, F, A) of
         {ok, Docs} ->
             [{text, Docs}];
         {error, not_available} ->

--- a/apps/els_lsp/src/els_docs.erl
+++ b/apps/els_lsp/src/els_docs.erl
@@ -103,7 +103,8 @@ docs(_M, _POI) ->
 -spec function_docs(application_type(), atom(), atom(), non_neg_integer()) ->
     [els_markup_content:doc_entry()].
 function_docs(Type, M, F, A) ->
-    case eep48_docs(function, M, F, A) of
+    %% this enables mocking eep48_docs/4 in tests
+    case ?MODULE:eep48_docs(function, M, F, A) of
         {ok, Docs} ->
             [{text, Docs}];
         {error, not_available} ->

--- a/apps/els_lsp/src/els_docs.erl
+++ b/apps/els_lsp/src/els_docs.erl
@@ -103,7 +103,8 @@ docs(_M, _POI) ->
 -spec function_docs(application_type(), atom(), atom(), non_neg_integer()) ->
     [els_markup_content:doc_entry()].
 function_docs(Type, M, F, A) ->
-    case eep48_docs(function, M, F, A) of
+    %% call via ?MODULE to enable mocking in tests
+    case ?MODULE:eep48_docs(function, M, F, A) of
         {ok, Docs} ->
             [{text, Docs}];
         {error, not_available} ->
@@ -126,7 +127,8 @@ function_docs(Type, M, F, A) ->
 -spec type_docs(application_type(), atom(), atom(), non_neg_integer()) ->
     [els_markup_content:doc_entry()].
 type_docs(_Type, M, F, A) ->
-    case eep48_docs(type, M, F, A) of
+    %% call via ?MODULE to enable mocking in tests
+    case ?MODULE:eep48_docs(type, M, F, A) of
         {ok, Docs} ->
             [{text, Docs}];
         {error, not_available} ->

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -1919,12 +1919,8 @@ resolve_type_application_remote_otp(Config) ->
         Result
     ),
     #{documentation := #{value := ActualValue}} = Result,
-    case {has_eep48_edoc(), has_eep48(file)} of
-        {true, false} ->
-            %% If this should fail the test we should document requirements for
-            %% the development environment so that OTP has the EEP-48 docs.
-            {skip, "This OTP build does not have EEP-48 docs for the 'file' module"};
-        {true, true} ->
+    case has_eep48(file) of
+        true ->
             ExpectValue = <<
                 "```erlang\n-type name_all() ::\n     string() |"
                 " atom() | deep_list() | (RawFilename :: binary()).\n"
@@ -1939,7 +1935,7 @@ resolve_type_application_remote_otp(Config) ->
                 "\\(not even at the end\\)\\.\n"
             >>,
             ?assertEqual(ExpectValue, ActualValue);
-        {false, _} ->
+        false ->
             ExpectValue = <<
                 "```erlang\n-type name_all()  :: "
                 "string() | atom() | deep_list() | "

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -1971,7 +1971,7 @@ has_eep48(Module) ->
         {ok, {docs_v1, _, erlang, _, _, _, Docs}} ->
             lists:any(
                 fun
-                    ({_, _, _, #{}, _}) -> true;
+                    ({_, _, _, Doc, _}) when is_map(Doc) -> true;
                     ({_, _, _, _, _}) -> false
                 end,
                 Docs

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -1675,45 +1675,44 @@ resolve_application_remote_otp(Config) ->
         <<"write/2">>
     ),
     #{result := Result} = els_client:completionitem_resolve(Selected),
-    ?assertMatch(
-        #{
-            data := #{module := <<"file">>, function := <<"write">>, arity := 2},
-            documentation := #{kind := <<"markdown">>, value := _}
-        },
-        Result
-    ),
-    #{documentation := #{value := ActualValue}} = Result,
-    case has_eep48(file) of
-        true ->
-            ExpectValue = <<
-                "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, "
-                "Reason}\nwhen\n  IoDevice :: io_device() | atom(),\n  Bytes ::"
-                " iodata(),\n  Reason :: posix() | badarg | terminated.\n```\n\n"
-                "---\n\nWrites `Bytes` to the file referenced by `IoDevice`\\. "
-                "This function is the only way to write to a file opened in `raw`"
-                " mode \\(although it works for normally opened files too\\)\\. "
-                "Returns `ok` if successful, and `{error, Reason}` otherwise\\."
-                "\n\nIf the file is opened with `encoding` set to something else "
-                "than `latin1`, each byte written can result in many bytes being "
-                "written to the file, as the byte range 0\\.\\.255 can represent "
-                "anything between one and four bytes depending on value and UTF "
-                "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
-                "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
-                "  No space is left on the device\\.\n"
-            >>,
-            ?assertEqual(ExpectValue, ActualValue);
-        false ->
-            ExpectValue = <<
-                "## file:write/2\n\n---\n\n```erlang\n\n  write(File, "
-                "Bytes) when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
-                "descriptor{module = Module} = Handle, Bytes) \n\n  write(_, _) "
-                "\n\n```\n\n```erlang\n-spec write(IoDevice, Bytes) -> ok | "
-                "{error, Reason} when\n      IoDevice :: io_device() | atom(),"
-                "\n      Bytes :: iodata(),\n      Reason :: posix() | "
-                "badarg | terminated.\n```"
-            >>,
-            ?assertEqual(ExpectValue, ActualValue)
-    end.
+    Value =
+        case has_eep48(file) of
+            true ->
+                <<
+                    "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, "
+                    "Reason}\nwhen\n  IoDevice :: io_device() | atom(),\n  Bytes ::"
+                    " iodata(),\n  Reason :: posix() | badarg | terminated.\n```\n\n"
+                    "---\n\nWrites `Bytes` to the file referenced by `IoDevice`\\. "
+                    "This function is the only way to write to a file opened in `raw`"
+                    " mode \\(although it works for normally opened files too\\)\\. "
+                    "Returns `ok` if successful, and `{error, Reason}` otherwise\\."
+                    "\n\nIf the file is opened with `encoding` set to something else "
+                    "than `latin1`, each byte written can result in many bytes being "
+                    "written to the file, as the byte range 0\\.\\.255 can represent "
+                    "anything between one and four bytes depending on value and UTF "
+                    "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
+                    "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
+                    "  No space is left on the device\\.\n"
+                >>;
+            false ->
+                <<
+                    "## file:write/2\n\n---\n\n```erlang\n\n  write(File, "
+                    "Bytes) when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
+                    "descriptor{module = Module} = Handle, Bytes) \n\n  write(_, _) "
+                    "\n\n```\n\n```erlang\n-spec write(IoDevice, Bytes) -> ok | "
+                    "{error, Reason} when\n      IoDevice :: io_device() | atom(),"
+                    "\n      Bytes :: iodata(),\n      Reason :: posix() | "
+                    "badarg | terminated.\n```"
+                >>
+        end,
+    Expected = Selected#{
+        documentation =>
+            #{
+                kind => <<"markdown">>,
+                value => Value
+            }
+    },
+    ?assertEqual(Expected, Result).
 
 call_markdown(F, Doc) ->
     call_markdown(<<"completion_resolve">>, F, Doc).
@@ -1914,35 +1913,37 @@ resolve_type_application_remote_otp(Config) ->
         <<"name_all/0">>
     ),
     #{result := Result} = els_client:completionitem_resolve(Selected),
-    ?assertMatch(
-        #{documentation := #{kind := <<"markdown">>, value := _}},
-        Result
-    ),
-    #{documentation := #{value := ActualValue}} = Result,
-    case has_eep48(file) of
-        true ->
-            ExpectValue = <<
-                "```erlang\n-type name_all() ::\n     string() |"
-                " atom() | deep_list() | (RawFilename :: binary()).\n"
-                "```\n\n---\n\nIf VM is in Unicode filename mode, "
-                "characters are allowed to be \\> 255\\. `RawFilename`"
-                " is a filename not subject to Unicode translation, "
-                "meaning that it can contain characters not conforming"
-                " to the Unicode encoding expected from the file system"
-                " \\(that is, non\\-UTF\\-8 characters although the VM is"
-                " started in Unicode filename mode\\)\\. Null characters "
-                "\\(integer value zero\\) are *not* allowed in filenames "
-                "\\(not even at the end\\)\\.\n"
-            >>,
-            ?assertEqual(ExpectValue, ActualValue);
-        false ->
-            ExpectValue = <<
-                "```erlang\n-type name_all()  :: "
-                "string() | atom() | deep_list() | "
-                "(RawFilename :: binary()).\n```"
-            >>,
-            ?assertEqual(ExpectValue, ActualValue)
-    end.
+    Value =
+        case has_eep48(file) of
+            true ->
+                <<
+                    "```erlang\n-type name_all() ::\n     string() |"
+                    " atom() | deep_list() | (RawFilename :: binary()).\n"
+                    "```\n\n---\n\nIf VM is in Unicode filename mode, "
+                    "characters are allowed to be \\> 255\\. `RawFilename`"
+                    " is a filename not subject to Unicode translation, "
+                    "meaning that it can contain characters not conforming"
+                    " to the Unicode encoding expected from the file system"
+                    " \\(that is, non\\-UTF\\-8 characters although the VM is"
+                    " started in Unicode filename mode\\)\\. Null characters "
+                    "\\(integer value zero\\) are *not* allowed in filenames "
+                    "\\(not even at the end\\)\\.\n"
+                >>;
+            false ->
+                <<
+                    "```erlang\n-type name_all()  :: "
+                    "string() | atom() | deep_list() | "
+                    "(RawFilename :: binary()).\n```"
+                >>
+        end,
+    Expected = Selected#{
+        documentation =>
+            #{
+                kind => <<"markdown">>,
+                value => Value
+            }
+    },
+    ?assertEqual(Expected, Result).
 
 %% Issue #1387
 completion_request_fails(Config) ->

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -1683,12 +1683,8 @@ resolve_application_remote_otp(Config) ->
         Result
     ),
     #{documentation := #{value := ActualValue}} = Result,
-    case {has_eep48_edoc(), has_eep48(file)} of
-        {true, false} ->
-            %% If this should fail the test we should document requirements for
-            %% the development environment so that OTP has the EEP-48 docs.
-            {skip, "This OTP build does not have EEP-48 docs for the 'file' module"};
-        {true, true} ->
+    case has_eep48(file) of
+        true ->
             ExpectValue = <<
                 "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, "
                 "Reason}\nwhen\n  IoDevice :: io_device() | atom(),\n  Bytes ::"
@@ -1706,7 +1702,7 @@ resolve_application_remote_otp(Config) ->
                 "  No space is left on the device\\.\n"
             >>,
             ?assertEqual(ExpectValue, ActualValue);
-        {false, _} ->
+        false ->
             ExpectValue = <<
                 "## file:write/2\n\n---\n\n```erlang\n\n  write(File, "
                 "Bytes) when is_pid(File) orelse is_atom(File)\n\n  write(#file_"

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -528,10 +528,7 @@ nonexisting_type(Config) ->
     Value =
         case has_eep48_edoc() of
             true ->
-                <<
-                    "## j/1\n\n---\n\n```erlang\n\n  j(_) \n\n```\n\n"
-                    "```erlang\n-spec j(doesnt:exist()) -> ok.\n```"
-                >>;
+                <<"```erlang\nj(_ :: doesnt:exist()) -> ok.\n```\n\n---\n\n\n">>;
             false ->
                 <<
                     "## j/1\n\n---\n\n```erlang\n\n  j(_) \n\n```\n\n"

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -543,10 +543,20 @@ nonexisting_type(Config) ->
     #{result := Result} = els_client:hover(Uri, 22, 15),
     %% The spec for `j' is shown instead of the type docs.
     Value =
-        case has_eep48_edoc() of
-            true ->
-                <<"```erlang\nj(_ :: doesnt:exist()) -> ok.\n```\n\n---\n\n\n">>;
-            false ->
+        case list_to_integer(erlang:system_info(otp_release)) of
+            %% WIP: I think this might not be the way to go,
+            %% just putting it here for the PR.
+            25 ->
+                <<
+                    "```erlang\nj(_ :: doesnt:exist()) -> ok.\n```\n\n"
+                    "---\n\n\n"
+                >>;
+            24 ->
+                <<
+                    "## j/1\n\n---\n\n```erlang\n\n  j(_) \n\n```\n\n"
+                    "```erlang\n-spec j(doesnt:exist()) -> ok.\n```"
+                >>;
+            _ ->
                 <<
                     "## j/1\n\n---\n\n```erlang\n\n  j(_) \n\n```\n\n"
                     "```erlang\n-spec j(doesnt:exist()) -> ok.\n```"

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -203,12 +203,8 @@ remote_call_otp(Config) ->
     Contents = maps:get(contents, Result),
     ?assertMatch(#{kind := <<"markdown">>, value := _}, Contents),
     ActualValue = maps:get(value, Contents),
-    case {has_eep48_edoc(), has_eep48(file)} of
-        {true, false} ->
-            %% If this should fail the test we should document requirements for
-            %% the development environment so that OTP has the EEP-48 docs.
-            {skip, "This OTP build does not have EEP-48 docs for the 'file' module"};
-        {true, true} ->
+    case has_eep48(file) of
+        true ->
             ExpectValue = <<
                 "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, Reason}\n"
                 "when\n  IoDevice :: io_device() | atom(),\n  Bytes :: iodata(),"
@@ -226,7 +222,7 @@ remote_call_otp(Config) ->
                 "  No space is left on the device\\.\n"
             >>,
             ?assertEqual(ExpectValue, ActualValue);
-        {false, _} ->
+        false ->
             ExpectValue = <<
                 "## file:write/2\n\n---\n\n```erlang\n\n  write(File, Bytes) "
                 "when is_pid(File) orelse is_atom(File)\n\n  write(#file_"

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -79,7 +79,10 @@ init_per_testcase(TestCase, Config) ->
 -spec end_per_testcase(atom(), config()) -> ok.
 end_per_testcase(TestCase, Config) ->
     lists:foreach(
-        fun (els_docs_meck) -> meck:unload(els_docs); (_) -> ok end,
+        fun
+            (els_docs_meck) -> meck:unload(els_docs);
+            (_) -> ok
+        end,
         erlang:registered()
     ),
     els_test_utils:end_per_testcase(TestCase, Config).

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -600,7 +600,7 @@ has_eep48(Module) ->
         {ok, {docs_v1, _, erlang, _, _, _, Docs}} ->
             lists:any(
                 fun
-                    ({_, _, _, #{}, _}) -> true;
+                    ({_, _, _, Doc, _}) when is_map(Doc) -> true;
                     ({_, _, _, _, _}) -> false
                 end,
                 Docs

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -546,6 +546,8 @@ nonexisting_type(Config) ->
                     "```erlang\nj(_ :: doesnt:exist()) -> ok.\n```\n\n"
                     "---\n\n\n"
                 >>;
+            % els_eep48_docs:render returns {error, function_missing} for
+            % OTP versions under 25
             _ ->
                 <<
                     "## j/1\n\n---\n\n```erlang\n\n  j(_) \n\n```\n\n"

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -541,17 +541,10 @@ nonexisting_type(Config) ->
     %% The spec for `j' is shown instead of the type docs.
     Value =
         case list_to_integer(erlang:system_info(otp_release)) of
-            %% WIP: I think this might not be the way to go,
-            %% just putting it here for the PR.
             25 ->
                 <<
                     "```erlang\nj(_ :: doesnt:exist()) -> ok.\n```\n\n"
                     "---\n\n\n"
-                >>;
-            24 ->
-                <<
-                    "## j/1\n\n---\n\n```erlang\n\n  j(_) \n\n```\n\n"
-                    "```erlang\n-spec j(doesnt:exist()) -> ok.\n```"
                 >>;
             _ ->
                 <<

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -201,39 +201,42 @@ remote_call_otp(Config) ->
     #{result := Result} = els_client:hover(Uri, 26, 12),
     ?assert(maps:is_key(contents, Result)),
     Contents = maps:get(contents, Result),
-    ?assertMatch(#{kind := <<"markdown">>, value := _}, Contents),
-    ActualValue = maps:get(value, Contents),
-    case has_eep48(file) of
-        true ->
-            ExpectValue = <<
-                "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, Reason}\n"
-                "when\n  IoDevice :: io_device() | atom(),\n  Bytes :: iodata(),"
-                "\n  Reason :: posix() | badarg | terminated.\n```\n\n---\n\n"
-                "Writes `Bytes` to the file referenced by `IoDevice`\\. This "
-                "function is the only way to write to a file opened in `raw` "
-                "mode \\(although it works for normally opened files too\\)\\. "
-                "Returns `ok` if successful, and `{error, Reason}` otherwise\\."
-                "\n\nIf the file is opened with `encoding` set to something else "
-                "than `latin1`, each byte written can result in many bytes being "
-                "written to the file, as the byte range 0\\.\\.255 can represent "
-                "anything between one and four bytes depending on value and UTF "
-                "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
-                "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
-                "  No space is left on the device\\.\n"
-            >>,
-            ?assertEqual(ExpectValue, ActualValue);
-        false ->
-            ExpectValue = <<
-                "## file:write/2\n\n---\n\n```erlang\n\n  write(File, Bytes) "
-                "when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
-                "descriptor{module = Module} = Handle, Bytes) \n\n  "
-                "write(_, _) \n\n```\n\n```erlang\n-spec write(IoDevice, Bytes)"
-                " -> ok | {error, Reason} when\n      IoDevice :: io_device() |"
-                " atom(),\n      Bytes :: iodata(),\n      Reason :: posix() | "
-                "badarg | terminated.\n```"
-            >>,
-            ?assertEqual(ExpectValue, ActualValue)
-    end.
+    Value =
+        case has_eep48(file) of
+            true ->
+                <<
+                    "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, Reason}\n"
+                    "when\n  IoDevice :: io_device() | atom(),\n  Bytes :: iodata(),"
+                    "\n  Reason :: posix() | badarg | terminated.\n```\n\n---\n\n"
+                    "Writes `Bytes` to the file referenced by `IoDevice`\\. This "
+                    "function is the only way to write to a file opened in `raw` "
+                    "mode \\(although it works for normally opened files too\\)\\. "
+                    "Returns `ok` if successful, and `{error, Reason}` otherwise\\."
+                    "\n\nIf the file is opened with `encoding` set to something else "
+                    "than `latin1`, each byte written can result in many bytes being "
+                    "written to the file, as the byte range 0\\.\\.255 can represent "
+                    "anything between one and four bytes depending on value and UTF "
+                    "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
+                    "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
+                    "  No space is left on the device\\.\n"
+                >>;
+            false ->
+                <<
+                    "## file:write/2\n\n---\n\n```erlang\n\n  write(File, Bytes) "
+                    "when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
+                    "descriptor{module = Module} = Handle, Bytes) \n\n  "
+                    "write(_, _) \n\n```\n\n```erlang\n-spec write(IoDevice, Bytes)"
+                    " -> ok | {error, Reason} when\n      IoDevice :: io_device() |"
+                    " atom(),\n      Bytes :: iodata(),\n      Reason :: posix() | "
+                    "badarg | terminated.\n```"
+                >>
+        end,
+    Expected = #{
+        kind => <<"markdown">>,
+        value => Value
+    },
+    ?assertEqual(Expected, Contents),
+    ok.
 
 local_fun_expression(Config) ->
     %% this test is for the fallback render when no doc chunks are available

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -201,42 +201,43 @@ remote_call_otp(Config) ->
     #{result := Result} = els_client:hover(Uri, 26, 12),
     ?assert(maps:is_key(contents, Result)),
     Contents = maps:get(contents, Result),
-    Value =
-        case has_eep48(file) of
-            true ->
-                <<
-                    "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, Reason}\n"
-                    "when\n  IoDevice :: io_device() | atom(),\n  Bytes :: iodata(),"
-                    "\n  Reason :: posix() | badarg | terminated.\n```\n\n---\n\n"
-                    "Writes `Bytes` to the file referenced by `IoDevice`\\. This "
-                    "function is the only way to write to a file opened in `raw` "
-                    "mode \\(although it works for normally opened files too\\)\\. "
-                    "Returns `ok` if successful, and `{error, Reason}` otherwise\\."
-                    "\n\nIf the file is opened with `encoding` set to something else "
-                    "than `latin1`, each byte written can result in many bytes being "
-                    "written to the file, as the byte range 0\\.\\.255 can represent "
-                    "anything between one and four bytes depending on value and UTF "
-                    "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
-                    "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
-                    "  No space is left on the device\\.\n"
-                >>;
-            false ->
-                <<
-                    "## file:write/2\n\n---\n\n```erlang\n\n  write(File, Bytes) "
-                    "when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
-                    "descriptor{module = Module} = Handle, Bytes) \n\n  "
-                    "write(_, _) \n\n```\n\n```erlang\n-spec write(IoDevice, Bytes)"
-                    " -> ok | {error, Reason} when\n      IoDevice :: io_device() |"
-                    " atom(),\n      Bytes :: iodata(),\n      Reason :: posix() | "
-                    "badarg | terminated.\n```"
-                >>
-        end,
-    Expected = #{
-        kind => <<"markdown">>,
-        value => Value
-    },
-    ?assertEqual(Expected, Contents),
-    ok.
+    ?assertMatch(#{kind := <<"markdown">>, value := _}, Contents),
+    ActualValue = maps:get(value, Contents),
+    case {has_eep48_edoc(), has_eep48(file)} of
+        {true, false} ->
+            %% If this should fail the test we should document requirements for
+            %% the development environment so that OTP has the EEP-48 docs.
+            {skip, "This OTP build does not have EEP-48 docs for the 'file' module"};
+        {true, true} ->
+            ExpectValue = <<
+                "```erlang\nwrite(IoDevice, Bytes) -> ok | {error, Reason}\n"
+                "when\n  IoDevice :: io_device() | atom(),\n  Bytes :: iodata(),"
+                "\n  Reason :: posix() | badarg | terminated.\n```\n\n---\n\n"
+                "Writes `Bytes` to the file referenced by `IoDevice`\\. This "
+                "function is the only way to write to a file opened in `raw` "
+                "mode \\(although it works for normally opened files too\\)\\. "
+                "Returns `ok` if successful, and `{error, Reason}` otherwise\\."
+                "\n\nIf the file is opened with `encoding` set to something else "
+                "than `latin1`, each byte written can result in many bytes being "
+                "written to the file, as the byte range 0\\.\\.255 can represent "
+                "anything between one and four bytes depending on value and UTF "
+                "encoding type\\.\n\nTypical error reasons:\n\n* **`ebadf`**  \n"
+                "  The file is not opened for writing\\.\n\n* **`enospc`**  \n"
+                "  No space is left on the device\\.\n"
+            >>,
+            ?assertEqual(ExpectValue, ActualValue);
+        {false, _} ->
+            ExpectValue = <<
+                "## file:write/2\n\n---\n\n```erlang\n\n  write(File, Bytes) "
+                "when is_pid(File) orelse is_atom(File)\n\n  write(#file_"
+                "descriptor{module = Module} = Handle, Bytes) \n\n  "
+                "write(_, _) \n\n```\n\n```erlang\n-spec write(IoDevice, Bytes)"
+                " -> ok | {error, Reason} when\n      IoDevice :: io_device() |"
+                " atom(),\n      Bytes :: iodata(),\n      Reason :: posix() | "
+                "badarg | terminated.\n```"
+            >>,
+            ?assertEqual(ExpectValue, ActualValue)
+    end.
 
 local_fun_expression(Config) ->
     %% this test is for the fallback when EEP-48 is not available
@@ -599,8 +600,17 @@ mock_eep48_render_fail() ->
 
 has_eep48_edoc() ->
     list_to_integer(erlang:system_info(otp_release)) >= 24.
+
 has_eep48(Module) ->
     case catch code:get_doc(Module) of
-        {ok, _} -> true;
-        _ -> false
+        {ok, {docs_v1, _, erlang, _, _, _, Docs}} ->
+            lists:any(
+                fun
+                    ({_, _, _, #{}, _}) -> true;
+                    ({_, _, _, _, _}) -> false
+                end,
+                Docs
+            );
+        _ ->
+            false
     end.

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -80,7 +80,7 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(TestCase, Config) ->
     lists:foreach(
         fun
-            (els_eep48_docs_meck) -> meck:unload(els_eep48_docs);
+            (els_docs_meck) -> meck:unload(els_docs);
             (_) -> ok
         end,
         erlang:registered()
@@ -91,8 +91,8 @@ end_per_testcase(TestCase, Config) ->
 %% Testcases
 %%==============================================================================
 local_call_no_args(Config) ->
-    %% this test is for the fallback when EEP-48 is not available
-    mock_eep48_render_fail(),
+    %% this test is for the fallback render when no doc chunks are available
+    mock_doc_chunks_unavailable(),
     Uri = ?config(hover_docs_caller_uri, Config),
     #{result := Result} = els_client:hover(Uri, 10, 7),
     ?assert(maps:is_key(contents, Result)),
@@ -106,8 +106,8 @@ local_call_no_args(Config) ->
     ok.
 
 local_call_with_args(Config) ->
-    %% this test is for the fallback when EEP-48 is not available
-    mock_eep48_render_fail(),
+    %% this test is for the fallback render when no doc chunks are available
+    mock_doc_chunks_unavailable(),
     Uri = ?config(hover_docs_caller_uri, Config),
     #{result := Result} = els_client:hover(Uri, 13, 7),
     ?assert(maps:is_key(contents, Result)),
@@ -131,8 +131,8 @@ local_call_with_args(Config) ->
     ok.
 
 remote_call_multiple_clauses(Config) ->
-    %% this test is for the fallback when EEP-48 is not available
-    mock_eep48_render_fail(),
+    %% this test is for the fallback render when no doc chunks are available
+    mock_doc_chunks_unavailable(),
     Uri = ?config(hover_docs_caller_uri, Config),
     #{result := Result} = els_client:hover(Uri, 16, 15),
     ?assert(maps:is_key(contents, Result)),
@@ -236,8 +236,8 @@ remote_call_otp(Config) ->
     end.
 
 local_fun_expression(Config) ->
-    %% this test is for the fallback when EEP-48 is not available
-    mock_eep48_render_fail(),
+    %% this test is for the fallback render when no doc chunks are available
+    mock_doc_chunks_unavailable(),
     Uri = ?config(hover_docs_caller_uri, Config),
     #{result := Result} = els_client:hover(Uri, 19, 5),
     ?assert(maps:is_key(contents, Result)),
@@ -261,8 +261,8 @@ local_fun_expression(Config) ->
     ok.
 
 remote_fun_expression(Config) ->
-    %% this test is for the fallback when EEP-48 is not available
-    mock_eep48_render_fail(),
+    %% this test is for the fallback render when no doc chunks are available
+    mock_doc_chunks_unavailable(),
     Uri = ?config(hover_docs_caller_uri, Config),
     #{result := Result} = els_client:hover(Uri, 20, 10),
     ?assert(maps:is_key(contents, Result)),
@@ -585,14 +585,11 @@ nonexisting_module(Config) ->
 %% Helpers
 %%==============================================================================
 
-mock_eep48_render_fail() ->
-    %% els_docs calls the render functions twice
-    Fail4 = fun(_, _, _, _) -> {error, {mocked, ?MODULE, ?LINE}} end,
-    Fail3 = fun(_, _, _) -> {error, {mocked, ?MODULE, ?LINE}} end,
-    meck:expect(els_eep48_docs, render, Fail4),
-    meck:expect(els_eep48_docs, render, Fail3),
-    meck:expect(els_eep48_docs, render_type, Fail4),
-    meck:expect(els_eep48_docs, render_type, Fail3).
+mock_doc_chunks_unavailable() ->
+    meck:expect(
+        els_docs, eep48_docs,
+        fun(_, _, _, _) -> {error, not_available} end
+    ).
 
 has_eep48_edoc() ->
     list_to_integer(erlang:system_info(otp_release)) >= 24.

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -587,7 +587,8 @@ nonexisting_module(Config) ->
 
 mock_doc_chunks_unavailable() ->
     meck:expect(
-        els_docs, eep48_docs,
+        els_docs,
+        eep48_docs,
         fun(_, _, _, _) -> {error, not_available} end
     ).
 

--- a/apps/els_lsp/test/els_hover_SUITE.erl
+++ b/apps/els_lsp/test/els_hover_SUITE.erl
@@ -590,7 +590,7 @@ mock_doc_chunks_unavailable() ->
         eep48_docs,
         fun(_, _, _, _) -> {error, not_available} end
     ),
-    fun () ->
+    fun() ->
         ok = meck:unload(els_docs)
     end.
 

--- a/apps/els_lsp/test/prop_statem.erl
+++ b/apps/els_lsp/test/prop_statem.erl
@@ -316,7 +316,7 @@ exit_post(S, _Args, Res) ->
             true -> 0;
             false -> 1
         end,
-    els_test_utils:wait_for(halt_called, 1000),
+    els_test_utils:wait_for(halt_called, 64000),
     ?assert(meck:called(els_utils, halt, [ExpectedExitCode])),
     ?assertMatch(ok, Res),
     true.

--- a/apps/els_lsp/test/prop_statem.erl
+++ b/apps/els_lsp/test/prop_statem.erl
@@ -376,6 +376,9 @@ setup() ->
     application:ensure_all_started(els_lsp),
     ConfigFile = filename:join([els_utils:system_tmp_dir(), "erlang_ls.config"]),
     file:write_file(ConfigFile, <<"">>),
+    %% An empty config file makes the config loader log warnings,
+    %% we don't need to see them when running the tests.
+    logger:set_module_level(els_config, error),
     ok.
 
 %%==============================================================================

--- a/apps/els_lsp/test/prop_statem.erl
+++ b/apps/els_lsp/test/prop_statem.erl
@@ -316,7 +316,7 @@ exit_post(S, _Args, Res) ->
             true -> 0;
             false -> 1
         end,
-    els_test_utils:wait_for(halt_called, 64000),
+    els_test_utils:wait_for(halt_called, 6400),
     ?assert(meck:called(els_utils, halt, [ExpectedExitCode])),
     ?assertMatch(ok, Res),
     true.


### PR DESCRIPTION
Problem
======

The hover and completion provider test suites have some test cases for showing docs.

Some tests are testing the Erlang LS internal fallback docs provided if EEP-48 docs can not be extracted. These test cases don't work with newer OTP versions (because their expected values depend on the EEP-48 docs not being available).

Some of the tests are testing edoc extraction itself, and have conditional expectations depending on if EEP-48 docs are available or not. These tests assume that OTP >= 24 will always have EEP-48 docs for `file:write` if `code:get_docs(file)` is not empty, but this is not the case (see e.g. https://github.com/erlang-ls/erlang_ls/pull/1402#discussion_r1020932452). The test suites and the code in els_docs are not in agreement about when the docs are available.

Proposed Solution
==============

* Mock the els_docs eep48 calls to say eep48 is unavailable for the tests that test that fallback
* Skip the OTP module specific tests if OTP was not built with doc chunks (as far as I can tell, those test cases don't test any Erlang LS code that other test cases don't cover)

If the doc chunks are expected to be there in OTP for anyone running the test suite, perhaps we can document how to resolve that (as it is now, I don't know how to make the test suite pass locally).

Bonus Content
===========

* Add OTP 25 to CI.
* Drop OTP 22 from CI.