### PR TITLE
[#1337] Make goto variable definition respect list comprehension scopes

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/variable_list_comp.erl
+++ b/apps/els_lsp/priv/code_navigation/src/variable_list_comp.erl
@@ -1,0 +1,20 @@
+-module(variable_list_comp).
+
+one() ->
+    Var = 1,
+    [ Var || Var <- [1, 2, 3] ],
+    Var.
+
+two() ->
+    [ Var || Var <- [1, 2, 3] ],
+    [ Var || Var <- [4, 5, 6] ].
+
+three() ->
+    Var = 1,
+    [ Var || _ <- [1, 2, 3] ],
+    Var.
+
+four() ->
+    [ {Var, Var2} || Var <- [4, 5, 6],
+                     Var2 <- [ Var || Var <- [1, 2, 3] ]
+    ].

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -213,6 +213,8 @@ do_points_of_interest(Tree) ->
                 record_index_expr(Tree);
             record_expr ->
                 record_expr(Tree);
+            list_comp ->
+                list_comp(Tree);
             variable ->
                 variable(Tree);
             atom ->
@@ -720,6 +722,21 @@ implicit_fun(Tree) ->
 macro(Tree) ->
     Anno = macro_location(Tree),
     [poi(Anno, macro, macro_name(Tree))].
+
+-spec list_comp(tree()) -> [els_poi:poi()].
+list_comp(Tree) ->
+    Pos = erl_syntax:get_pos(Tree),
+    Body = erl_syntax:list_comp_body(Tree),
+    PatRanges = [
+        els_range:range(
+            erl_syntax:get_pos(
+                erl_syntax:generator_pattern(Gen)
+            )
+        )
+     || Gen <- Body,
+        erl_syntax:type(Gen) =:= generator
+    ],
+    [poi(Pos, list_comp, undefined, #{pattern_ranges => PatRanges})].
 
 -spec map_record_def_fields(Fun, tree(), atom()) -> [Result] when
     Fun :: fun((tree(), atom()) -> Result).


### PR DESCRIPTION
### Description

Make goto variable definition respect list comprehension scopes.

Fixes #1337 .
