### PR TITLE
Disable suggest-spec lens by default

### DIFF
--- a/apps/els_lsp/src/els_code_lens_suggest_spec.erl
+++ b/apps/els_lsp/src/els_code_lens_suggest_spec.erl
@@ -61,7 +61,7 @@ command(Document, #{range := #{from := {Line, _}}} = POI, Info) ->
 
 -spec is_default() -> boolean().
 is_default() ->
-    true.
+    false.
 
 -spec pois(els_dt_document:item()) -> [els_poi:poi()].
 pois(Document) ->

--- a/apps/els_lsp/test/els_code_lens_SUITE.erl
+++ b/apps/els_lsp/test/els_code_lens_SUITE.erl
@@ -53,9 +53,6 @@ end_per_suite(Config) ->
 init_per_testcase(server_info, Config) ->
     meck:new(els_code_lens_server_info, [passthrough, no_link]),
     meck:expect(els_code_lens_server_info, is_default, 0, true),
-    %% Let's disable the suggest_spec lens to avoid noise
-    meck:new(els_code_lens_suggest_spec, [passthrough, no_link]),
-    meck:expect(els_code_lens_suggest_spec, is_default, 0, false),
     els_test_utils:init_per_testcase(server_info, Config);
 init_per_testcase(ct_run_test, Config) ->
     meck:new(els_code_lens_ct_run_test, [passthrough, no_link]),
@@ -68,7 +65,6 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(server_info, Config) ->
     els_test_utils:end_per_testcase(server_info, Config),
     meck:unload(els_code_lens_server_info),
-    meck:unload(els_code_lens_suggest_spec),
     ok;
 end_per_testcase(ct_run_test, Config) ->
     els_test_utils:end_per_testcase(ct_run_test, Config),
@@ -91,12 +87,11 @@ default_lenses(Config) ->
     ],
     ?assertEqual(
         [
-            <<"function-references">>,
-            <<"suggest-spec">>
+            <<"function-references">>
         ],
         lists:usort(Commands)
     ),
-    ?assertEqual(50, length(Commands)),
+    ?assertEqual(27, length(Commands)),
     ok.
 
 -spec server_info(config()) -> ok.

--- a/apps/els_lsp/test/els_initialization_SUITE.erl
+++ b/apps/els_lsp/test/els_initialization_SUITE.erl
@@ -191,8 +191,7 @@ initialize_lenses_custom(Config) ->
     els_client:initialize(RootUri, InitOpts),
     Expected = [
         <<"function-references">>,
-        <<"server-info">>,
-        <<"suggest-spec">>
+        <<"server-info">>
     ],
     Result = els_code_lens:enabled_lenses(),
     ?assertEqual(Expected, Result),
@@ -209,8 +208,7 @@ initialize_lenses_invalid(Config) ->
     Expected = [
         <<"ct-run-test">>,
         <<"function-references">>,
-        <<"show-behaviour-usages">>,
-        <<"suggest-spec">>
+        <<"show-behaviour-usages">>
     ],
     ?assertEqual(Expected, Result),
     ok.


### PR DESCRIPTION
### Description

This lens often requires some manual configuration to work and it can be quite CPU intensive.
Disabling it by default to avoid noise for many users (eg when navigating to the OTP repository itself).

