### PR TITLE
[#1401] Present configuration read errors for the user

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -359,10 +359,12 @@ consult_config(Path) ->
     Options = [{map_node_format, map}],
     try yamerl:decode_file(Path, Options) of
         [] ->
-            ?LOG_WARNING("Using empty configuration from: ~p", [Path]),
+            ?LOG_WARNING("Using empty configuration from ~s", [Path]),
             {ok, #{}};
-        [Config] ->
-            {ok, Config}
+        [Config] when is_map(Config) ->
+            {ok, Config};
+        _ ->
+            {error, {syntax_error, Path}}
     catch
         Class:Error ->
             {error, {Class, Error}}

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -84,8 +84,9 @@ handle_request({<<"initialize">>, _Params}, State) ->
     RootUri = els_uri:uri(els_utils:to_binary(RootPath)),
     InitOptions = #{},
     Capabilities = capabilities(),
-    %% another fix, see https://github.com/erlang-ls/erlang_ls/issues/1060
-    ok = els_config:initialize(RootUri, Capabilities, InitOptions),
+    %% we can't use LSP notifications here, see
+    %% https://github.com/erlang-ls/erlang_ls/issues/1060
+    ok = els_config:initialize(RootUri, Capabilities, InitOptions, log),
     {Capabilities, State};
 handle_request({<<"launch">>, #{<<"cwd">> := Cwd} = Params}, State) ->
     case start_distribution(Params) of

--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -84,6 +84,7 @@ handle_request({<<"initialize">>, _Params}, State) ->
     RootUri = els_uri:uri(els_utils:to_binary(RootPath)),
     InitOptions = #{},
     Capabilities = capabilities(),
+    %% another fix, see https://github.com/erlang-ls/erlang_ls/issues/1060
     ok = els_config:initialize(RootUri, Capabilities, InitOptions),
     {Capabilities, State};
 handle_request({<<"launch">>, #{<<"cwd">> := Cwd} = Params}, State) ->

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -81,7 +81,7 @@ handle_request({initialize, Params}) ->
             _ ->
                 #{}
         end,
-    ok = els_config:initialize(RootUri, Capabilities, InitOptions, true),
+    ok = els_config:initialize(RootUri, Capabilities, InitOptions, use_els_server),
     {response, server_capabilities()};
 handle_request({initialized, _Params}) ->
     RootUri = els_config:get(root_uri),

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -81,7 +81,7 @@ handle_request({initialize, Params}) ->
             _ ->
                 #{}
         end,
-    ok = els_config:initialize(RootUri, Capabilities, InitOptions, use_els_server),
+    ok = els_config:initialize(RootUri, Capabilities, InitOptions, lsp_notification),
     {response, server_capabilities()};
 handle_request({initialized, _Params}) ->
     RootUri = els_config:get(root_uri),


### PR DESCRIPTION
Description
========

If the the configuration file(s) found cannot be parsed, show a notice for the user instead of silently moving on to the next config alternative.

Fixes  #1401 
