### PR TITLE
Add completion for function clause

### DIFF
--- a/apps/els_core/include/els_core.hrl
+++ b/apps/els_core/include/els_core.hrl
@@ -335,6 +335,7 @@
     kind => completion_item_kind(),
     insertText => binary(),
     insertTextFormat => insert_text_format(),
+    insertTextMode => insert_text_mode(),
     data => map()
 }.
 

--- a/apps/els_core/include/els_core.hrl
+++ b/apps/els_core/include/els_core.hrl
@@ -141,6 +141,16 @@
     | ?INSERT_TEXT_FORMAT_SNIPPET.
 
 %%------------------------------------------------------------------------------
+%% Insert Text Mode
+%%------------------------------------------------------------------------------
+
+-define(INSERT_TEXT_MODE_AS_IS, 1).
+-define(INSERT_TEXT_MODE_ADJUST_INDENTATION, 2).
+-type insert_text_mode() ::
+    ?INSERT_TEXT_MODE_AS_IS
+    | ?INSERT_TEXT_MODE_ADJUST_INDENTATION.
+
+%%------------------------------------------------------------------------------
 %% Text Edit
 %%------------------------------------------------------------------------------
 -type text_edit() :: #{

--- a/apps/els_lsp/priv/code_navigation/src/completion_functionclause.erl
+++ b/apps/els_lsp/priv/code_navigation/src/completion_functionclause.erl
@@ -1,0 +1,11 @@
+-module(completion_functionclause).
+
+test_a(ArgA, ArgB) when
+    (ArgA == 123);
+    (ArgB == 321) ->
+  test_a.
+
+test_b(ArgA, ArgB, ArgC) ->
+    test_b;
+test_b(ArgA, ArgB, ArgC) ->
+    ArgA + ArgB + ArgC;

--- a/apps/els_lsp/priv/code_navigation/src/completion_functionclause_2.erl
+++ b/apps/els_lsp/priv/code_navigation/src/completion_functionclause_2.erl
@@ -1,0 +1,6 @@
+-module(completion_functionclause_2).
+
+test_c(Arg1, Arg2) ->
+    Test = xyzzy,
+    case Arg1 of
+        test -> 1;

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -654,7 +654,7 @@ function(Tree) ->
         ClausesPOIs
     ]).
 
--spec range_from_body_trees([tree()]) -> [els_poi:poi()].
+-spec range_from_body_trees([tree()]) -> els_poi:poi_range().
 range_from_body_trees(BodyTrees) ->
     FirstExpr = hd(BodyTrees),
     LastExpr = lists:last(BodyTrees),

--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -622,6 +622,12 @@ function(Tree) ->
      || {I, Clause} <- IndexedClauses,
         erl_syntax:type(Clause) =:= clause
     ],
+
+    FunctionBodyRanges = [
+        range_from_body_trees(erl_syntax:clause_body(Clause))
+     || Clause <- Clauses
+    ],
+
     {StartLine, StartColumn} = get_start_location(Tree),
     {EndLine, EndColumn} = get_end_location(Tree),
     FoldingRange = exceeds_one_line(StartLine, EndLine),
@@ -639,13 +645,27 @@ function(Tree) ->
                 from => {StartLine, StartColumn},
                 to => {EndLine, EndColumn}
             },
-            folding_range => FoldingRange
+            folding_range => FoldingRange,
+            clause_body_ranges => FunctionBodyRanges
         }
     ),
     lists:append([
         [FunctionPOI],
         ClausesPOIs
     ]).
+
+-spec range_from_body_trees([tree()]) -> [els_poi:poi()].
+range_from_body_trees(BodyTrees) ->
+    FirstExpr = hd(BodyTrees),
+    LastExpr = lists:last(BodyTrees),
+
+    {StartLine, StartColumn} = _Start = get_start_location(FirstExpr),
+    {EndLine, EndColumn} = _End = get_end_location(LastExpr),
+
+    #{
+        from => {StartLine, StartColumn},
+        to => {EndLine, EndColumn}
+    }.
 
 -spec analyze_function(tree(), [tree()]) ->
     {atom(), arity(), [{integer(), string()}]}.

--- a/apps/els_lsp/test/els_call_hierarchy_SUITE.erl
+++ b/apps/els_lsp/test/els_call_hierarchy_SUITE.erl
@@ -80,7 +80,10 @@ incoming_calls(Config) ->
                             folding_range => #{
                                 from => {7, ?END_OF_LINE},
                                 to => {16, ?END_OF_LINE}
-                            }
+                            },
+                            clause_body_ranges => [
+                                #{from => {8, 3}, to => {8, 5}}, #{from => {10, 3}, to => {16, 18}}
+                            ]
                         },
                     id => {function_a, 1},
                     kind => function,
@@ -133,7 +136,12 @@ incoming_calls(Config) ->
                                                     #{
                                                         from => {7, ?END_OF_LINE},
                                                         to => {13, ?END_OF_LINE}
-                                                    }
+                                                    },
+                                                clause_body_ranges =>
+                                                    [
+                                                        #{from => {8, 3}, to => {8, 5}},
+                                                        #{from => {10, 3}, to => {13, 18}}
+                                                    ]
                                             },
                                         id => {function_a, 1},
                                         kind => function,
@@ -185,7 +193,12 @@ incoming_calls(Config) ->
                                                     #{
                                                         from => {7, ?END_OF_LINE},
                                                         to => {16, ?END_OF_LINE}
-                                                    }
+                                                    },
+                                                clause_body_ranges =>
+                                                    [
+                                                        #{from => {8, 3}, to => {8, 5}},
+                                                        #{from => {10, 3}, to => {16, 18}}
+                                                    ]
                                             },
                                         id => {function_a, 1},
                                         kind => function,
@@ -254,7 +267,11 @@ outgoing_calls(Config) ->
                         folding_range => #{
                             from => {7, ?END_OF_LINE},
                             to => {16, ?END_OF_LINE}
-                        }
+                        },
+                        clause_body_ranges => [
+                            #{from => {8, 3}, to => {8, 5}},
+                            #{from => {10, 3}, to => {16, 18}}
+                        ]
                     },
                     id => {function_a, 1},
                     kind => function,
@@ -301,7 +318,11 @@ outgoing_calls(Config) ->
                                 folding_range => #{
                                     from => {7, ?END_OF_LINE},
                                     to => {16, ?END_OF_LINE}
-                                }
+                                },
+                                clause_body_ranges => [
+                                    #{from => {8, 3}, to => {8, 5}},
+                                    #{from => {10, 3}, to => {16, 18}}
+                                ]
                             },
                         id => {function_a, 1},
                         kind => function,
@@ -325,7 +346,10 @@ outgoing_calls(Config) ->
                                 folding_range => #{
                                     from => {18, ?END_OF_LINE},
                                     to => {19, ?END_OF_LINE}
-                                }
+                                },
+                                clause_body_ranges => [
+                                    #{from => {19, 3}, to => {19, 5}}
+                                ]
                             },
                         id => {function_b, 0},
                         kind => function,
@@ -349,7 +373,11 @@ outgoing_calls(Config) ->
                                 folding_range => #{
                                     from => {7, ?END_OF_LINE},
                                     to => {13, ?END_OF_LINE}
-                                }
+                                },
+                                clause_body_ranges => [
+                                    #{from => {8, 3}, to => {8, 5}},
+                                    #{from => {10, 3}, to => {13, 18}}
+                                ]
                             },
                         id => {function_a, 1},
                         kind => function,
@@ -373,7 +401,10 @@ outgoing_calls(Config) ->
                                 folding_range => #{
                                     from => {18, ?END_OF_LINE},
                                     to => {19, ?END_OF_LINE}
-                                }
+                                },
+                                clause_body_ranges => [
+                                    #{from => {19, 3}, to => {19, 5}}
+                                ]
                             },
                         id => {function_b, 0},
                         kind => function,

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -51,6 +51,7 @@
     resolve_type_application_remote_external/1,
     resolve_opaque_application_remote_external/1,
     resolve_type_application_remote_otp/1,
+    function_clause/1,
     completion_request_fails/1
 ]).
 
@@ -1944,6 +1945,40 @@ resolve_type_application_remote_otp(Config) ->
             }
     },
     ?assertEqual(Expected, Result).
+
+-spec function_clause(config()) -> ok.
+function_clause(Config) ->
+    Uri = ?config(completion_functionclause_uri, Config),
+    Uri2 = ?config(completion_functionclause_2_uri, Config),
+    TriggerKindChar = ?COMPLETION_TRIGGER_KIND_CHARACTER,
+    Expected1 =
+        [
+            #{
+                kind => ?COMPLETION_ITEM_KIND_SNIPPET,
+                label => <<"Add function clause">>,
+                insertText => <<"\ntest_b(${1:Arg1}, ${2:Arg2}, ${3:Arg3}) ->\n    ${4:Body}">>,
+                insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET,
+                insertTextMode => ?INSERT_TEXT_MODE_AS_IS
+            }
+        ],
+
+    #{result := Completion1} =
+        els_client:completion(Uri, 11, 24, TriggerKindChar, <<";">>),
+
+    #{result := Completion2} =
+        els_client:completion(Uri, 9, 12, TriggerKindChar, <<";">>),
+
+    #{result := Completion3} =
+        els_client:completion(Uri, 4, 18, TriggerKindChar, <<";">>),
+
+    #{result := Completion4} =
+        els_client:completion(Uri2, 6, 19, TriggerKindChar, <<";">>),
+
+    ?assertEqual(Expected1, Completion1),
+    ?assertEqual(Expected1, Completion2),
+    ?assertEqual([], Completion3),
+    ?assertEqual([], Completion4),
+    ok.
 
 %% Issue #1387
 completion_request_fails(Config) ->


### PR DESCRIPTION
### Description

With this change you will get an autocompletion for a new function clause after you type the semicolon ";" in a function clause body.

So when you type
```
test_fun(Test1, Test2) ->
    test;
```

The editor will popup the option to autocomplete function clause, and ErlangLS will insert the following, where you can tab between the fields:

```
test_fun(Arg1, Arg2) ->
   Body
```

The autocompletion should not be offered in function guard sequences or in case/receive/etc clauses. Maybe it would be nice to have something like this for other kind of clauses as well, but since incomplete statements seems not to be parsed currently, it is hard to tell them apart.

Something similar was mentioned in https://github.com/erlang-ls/erlang_ls/issues/655.
