### PR TITLE
Do not crash in case of empty data

### DIFF
--- a/apps/els_lsp/src/els_code_actions.erl
+++ b/apps/els_lsp/src/els_code_actions.erl
@@ -162,6 +162,8 @@ remove_macro(Uri, Range, _Data, [Macro]) ->
     end.
 
 -spec remove_unused(uri(), range(), binary(), [binary()]) -> [map()].
+remove_unused(_Uri, _Range0, <<>>, [_Import]) ->
+    [];
 remove_unused(Uri, _Range0, Data, [Import]) ->
     {ok, Document} = els_utils:lookup_document(Uri),
     case els_range:inclusion_range(Data, Document) of


### PR DESCRIPTION
### Description

In some corner cases, it can happen that the incoming request does not contain a `data` field, which defaults to `<<>>`.
That causes a server crash, since a Uri is expected.
