### PR TITLE
Add docs memoization

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -167,6 +167,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     RefactorErl = maps:get("refactorerl", Config, notconfigured),
     Providers = maps:get("providers", Config, #{}),
     EdocParseEnabled = maps:get("edoc_parse_enabled", Config, true),
+    DocsMemo = maps:get("docs_memo", Config, false),
 
     %% Initialize and start Wrangler
     case maps:get("wrangler", Config, notconfigured) of
@@ -220,6 +221,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     ok = set(plt_path, DialyzerPltPath),
     ok = set(code_reload, CodeReload),
     ok = set(providers, Providers),
+    ok = set(docs_memo, DocsMemo),
     ?LOG_INFO("Config=~p", [Config]),
     ok = set(
         runtime,

--- a/apps/els_lsp/priv/code_navigation/src/docs_memo.erl
+++ b/apps/els_lsp/priv/code_navigation/src/docs_memo.erl
@@ -1,0 +1,6 @@
+-module(docs_memo).
+
+-type type() -> any().
+
+-spec function() -> ok.
+function() -> ok.

--- a/apps/els_lsp/src/els_db.erl
+++ b/apps/els_lsp/src/els_db.erl
@@ -31,7 +31,8 @@ tables() ->
         els_dt_document,
         els_dt_document_index,
         els_dt_references,
-        els_dt_signatures
+        els_dt_signatures,
+        els_docs_memo
     ].
 
 -spec delete(atom(), any()) -> ok.

--- a/apps/els_lsp/src/els_docs_memo.erl
+++ b/apps/els_lsp/src/els_docs_memo.erl
@@ -1,0 +1,106 @@
+%%==============================================================================
+%% The 'docs' table
+%%==============================================================================
+
+-module(els_docs_memo).
+
+%%==============================================================================
+%% Behaviour els_db_table
+%%==============================================================================
+
+-behaviour(els_db_table).
+-export([
+    name/0,
+    opts/0
+]).
+
+%%==============================================================================
+%% API
+%%==============================================================================
+
+-export([
+    insert/1,
+    lookup/1,
+    delete_by_uri/1
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("els_lsp.hrl").
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+%%==============================================================================
+%% Item Definition
+%%==============================================================================
+
+-record(els_docs_memo, {
+    mfact :: mfact() | '_' | {atom(), '_', '_', call_type() | '_', function | type | '_'},
+    entries :: [els_markup_content:doc_entry()] | '_'
+}).
+-type call_type() :: 'local' | 'remote'.
+-type mfact() :: {module(), atom(), arity(), call_type(), function | type}.
+-type els_docs_memo() :: #els_docs_memo{}.
+-type item() :: #{
+    mfact := mfact(),
+    entries := [els_markup_content:doc_entry()]
+}.
+-export_type([item/0]).
+
+%%==============================================================================
+%% Callbacks for the els_db_table Behaviour
+%%==============================================================================
+
+-spec name() -> atom().
+name() -> ?MODULE.
+
+-spec opts() -> proplists:proplist().
+opts() ->
+    [ordered_set].
+
+%%==============================================================================
+%% API
+%%==============================================================================
+
+-spec from_item(item()) -> els_docs_memo().
+from_item(#{
+    mfact := MFACT,
+    entries := Entries
+}) ->
+    #els_docs_memo{
+        mfact = MFACT,
+        entries = Entries
+    }.
+
+-spec to_item(els_docs_memo()) -> item().
+to_item(#els_docs_memo{
+    mfact = MFACT,
+    entries = Entries
+}) ->
+    #{
+        mfact => MFACT,
+        entries => Entries
+    }.
+
+-spec insert(item()) -> ok | {error, any()}.
+insert(Map) when is_map(Map) ->
+    Record = from_item(Map),
+    els_db:write(name(), Record).
+
+-spec lookup(mfact()) -> {ok, [item()]}.
+lookup({M, _F, _A, _C, _T} = MFACT) ->
+    {ok, _Uris} = els_utils:find_modules(M),
+    {ok, Items} = els_db:lookup(name(), MFACT),
+    {ok, [to_item(Item) || Item <- Items]}.
+
+-spec delete_by_uri(uri()) -> ok.
+delete_by_uri(Uri) ->
+    case filename:extension(Uri) of
+        <<".erl">> ->
+            Module = els_uri:module(Uri),
+            Pattern = #els_docs_memo{mfact = {Module, '_', '_', '_', '_'}, _ = '_'},
+            ok = els_db:match_delete(name(), Pattern);
+        _ ->
+            ok
+    end.

--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -59,7 +59,9 @@ did_open(Params) ->
     ok.
 
 -spec did_save(map()) -> ok.
-did_save(_Params) ->
+did_save(Params) ->
+    #{<<"textDocument">> := #{<<"uri">> := Uri}} = Params,
+    els_docs_memo:delete_by_uri(Uri),
     ok.
 
 -spec did_change_watched_files(map()) -> ok.
@@ -93,8 +95,10 @@ handle_file_change(Uri, Type) when
     Type =:= ?FILE_CHANGE_TYPE_CREATED;
     Type =:= ?FILE_CHANGE_TYPE_CHANGED
 ->
+    els_docs_memo:delete_by_uri(Uri),
     reload_from_disk(Uri);
 handle_file_change(Uri, Type) when Type =:= ?FILE_CHANGE_TYPE_DELETED ->
+    els_docs_memo:delete_by_uri(Uri),
     els_indexing:remove(Uri).
 
 -spec reload_from_disk(uri()) -> ok.

--- a/apps/els_lsp/test/els_docs_SUITE.erl
+++ b/apps/els_lsp/test/els_docs_SUITE.erl
@@ -1,0 +1,126 @@
+-module(els_docs_SUITE).
+
+-include("els_lsp.hrl").
+
+%% CT Callbacks
+-export([
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2,
+    all/0
+]).
+
+%% Test cases
+-export([
+    memo_docs_true/1,
+    memo_docs_false/1,
+    invalidate/1
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec all() -> [atom()].
+all() ->
+    els_test_utils:all(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+    els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+    els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(TestCase, Config) ->
+    els_test_utils:init_per_testcase(TestCase, Config).
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) ->
+    els_test_utils:end_per_testcase(TestCase, Config).
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec memo_docs_true(config()) -> ok.
+memo_docs_true(Config) ->
+    RootUri = els_test_utils:root_uri(),
+    DataDir = ?config(data_dir, Config),
+    ConfigPath = filename:join(DataDir, "docs_memo_true.config"),
+    InitOpts = #{<<"erlang">> => #{<<"config_path">> => ConfigPath}},
+    els_client:initialize(RootUri, InitOpts),
+
+    %% Function
+    MFACT1 = {M1 = docs_memo, F1 = function, A1 = 0, 'local', function},
+    Expected1 = els_docs:function_docs('local', M1, F1, A1),
+    {ok, [#{entries := Result1}]} = els_docs_memo:lookup(MFACT1),
+    ?assertEqual(Expected1, Result1),
+
+    %% Type
+    MFACT2 = {M2 = docs_memo, F2 = type, A2 = 0, 'local', type},
+    Expected2 = els_docs:type_docs('local', M2, F2, A2),
+    {ok, [#{entries := Result2}]} = els_docs_memo:lookup(MFACT2),
+    ?assertEqual(Expected2, Result2),
+
+    ok.
+
+-spec memo_docs_false(config()) -> ok.
+memo_docs_false(Config) ->
+    RootUri = els_test_utils:root_uri(),
+    DataDir = ?config(data_dir, Config),
+    ConfigPath = filename:join(DataDir, "docs_memo_false.config"),
+    InitOpts = #{<<"erlang">> => #{<<"config_path">> => ConfigPath}},
+    els_client:initialize(RootUri, InitOpts),
+
+    %% Function
+    MFACT1 = {M1 = docs_memo, F1 = function, A1 = 0, 'local', function},
+    els_docs:function_docs('local', M1, F1, A1),
+    {ok, []} = els_docs_memo:lookup(MFACT1),
+
+    %% Type
+    MFACT2 = {M2 = docs_memo, F2 = type, A2 = 0, 'local', type},
+    els_docs:type_docs('local', M2, F2, A2),
+    {ok, []} = els_docs_memo:lookup(MFACT2),
+
+    ok.
+
+-spec invalidate(config()) -> ok.
+invalidate(Config) ->
+    Uri = ?config(docs_memo_uri, Config),
+    RootUri = els_test_utils:root_uri(),
+    DataDir = ?config(data_dir, Config),
+    ConfigPath = filename:join(DataDir, "docs_memo_true.config"),
+    InitOpts = #{<<"erlang">> => #{<<"config_path">> => ConfigPath}},
+    els_client:initialize(RootUri, InitOpts),
+    meck:new(els_text_synchronization, [passthrough]),
+
+    MFACT = {M = docs_memo, F = function, A = 0, 'local', function},
+
+    %% Did save
+    els_docs:function_docs('local', M, F, A),
+    {ok, [_]} = els_docs_memo:lookup(MFACT),
+    ok = els_client:did_save(Uri),
+    els_test_utils:wait_until_mock_called(els_text_synchronization, did_save),
+    {ok, []} = els_docs_memo:lookup(MFACT),
+
+    %% Did change watched files
+    els_docs:function_docs('local', M, F, A),
+    {ok, [_]} = els_docs_memo:lookup(MFACT),
+    ok = els_client:did_change_watched_files([{Uri, ?FILE_CHANGE_TYPE_CHANGED}]),
+    els_test_utils:wait_until_mock_called(els_text_synchronization, did_change_watched_files),
+    {ok, []} = els_docs_memo:lookup(MFACT),
+
+    ok.

--- a/apps/els_lsp/test/els_docs_SUITE_data/docs_memo_false.config
+++ b/apps/els_lsp/test/els_docs_SUITE_data/docs_memo_false.config
@@ -1,0 +1,1 @@
+docs_memo: false

--- a/apps/els_lsp/test/els_docs_SUITE_data/docs_memo_true.config
+++ b/apps/els_lsp/test/els_docs_SUITE_data/docs_memo_true.config
@@ -1,0 +1,1 @@
+docs_memo: true

--- a/apps/els_lsp/test/els_hover_SUITE_data/docs_memo_true.config
+++ b/apps/els_lsp/test/els_hover_SUITE_data/docs_memo_true.config
@@ -1,0 +1,1 @@
+docs_memo: true


### PR DESCRIPTION
Closes #1208, and a little more. Since the memoization is done in `els_docs`, the change should also help `els_signature_help_provider` and `els_completion_provider`. Should tests be written here for the integration with the 2?

Also, there is a slight difference between this PR and #1208 in that there is a small amount of time when the memoization can be cancelled. I wasn't able to think of a solution without changing `els_background_job`.