### PR TITLE
[DAP] Prioritize information from module_info when available

### DIFF
--- a/apps/els_dap/src/els_dap_general_provider.erl
+++ b/apps/els_dap/src/els_dap_general_provider.erl
@@ -743,7 +743,7 @@ break_line(Pid, Node) ->
 
 -spec source(atom(), atom()) -> binary().
 source(Module, Node) ->
-    Source0 = els_dap_rpc:file(Node, Module),
+    {ok, Source0} = els_dap_rpc:file(Node, Module),
     Source1 = filename:absname(Source0),
     els_dap_rpc:clear(Node),
     unicode:characters_to_binary(Source1).


### PR DESCRIPTION
### Description

Certain build systems (most notoriously [Buck2)](https://buck2.build/) store build artifacts (including a copy of the source files) in custom folders (e.g. `buck-out` in Buck2). This can lead to an incorrect path to be returned by the debugger to the client whenever a breakpoint triggers. In turn, this result in the editor opening a buffer from the build system custom folder rather than the original source file and confusion among the users.

This PR changes the logic how the location of source files is identified. The current logic is:

1. Ask the interpreter first (can return an incorrect path)
2. If not found, ask the code server
4. Only as a last resort, try reading the `compile` info from `module_info`.

The `module_info` is supposed to contain the most accurate information, but - in the case of non hermetic builds - it can contain a path to a non-existing file (e.g. if the code was built on a machine and ported to a different one). That's the main reason the current logic looks like the above (see [this PR](https://github.com/erlang-ls/erlang_ls/pull/1084) for context).

Instead:

1. Check whether the `compile` info from `module_info` points to a regular file
2. If it does, use it (eventually converting it to an absolute path)
3. If it does not, ask the interpreter
4. If not found, ask the code server

The logic has been refactored into separate functions to ease reading. Debug logs have also been added to simplify eventual troubleshooting.