### PR TITLE
Idea: hrl don't have to warning unuse

### DIFF
--- a/apps/els_lsp/src/els_unused_includes_diagnostics.erl
+++ b/apps/els_lsp/src/els_unused_includes_diagnostics.erl
@@ -32,7 +32,12 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-    case els_utils:lookup_document(Uri) of
+    %% hrl don't have to warning unuse
+    case filename:extension(binary_to_list(Uri)) =/= ".hrl" 
+        andalso els_utils:lookup_document(Uri)
+    of
+        false ->
+            [];
         {error, _Error} ->
             [];
         {ok, Document} ->


### PR DESCRIPTION
normally, include another `.hrl` in an `.hrl` file, don't have to warning unuse in this situation.
a.hrl
```
-include("aa.hrl").
-include("aaa.hrl").
```
a.erl
```
-include("a.hrl").
```