### PR TITLE
Add -hidden flag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,7 +41,7 @@
 
 {minimum_otp_vsn, "22.0"}.
 
-{escript_emu_args, "%%! -connect_all false\n"}.
+{escript_emu_args, "%%! -connect_all false -hidden\n"}.
 {escript_incl_extra, [{"els_lsp/priv/snippets/*", "_build/default/lib/"}]}.
 {escript_main_app, els_lsp}.
 {escript_name, erlang_ls}.


### PR DESCRIPTION
We saw situations where erlang_ls interfered with the application being developed through `global`. We had a locking issue that only occurred when the editor with erlang_ls was running. Adding `-hidden` resolves the problem for us.