### PR TITLE
[DAP] Ensure breakpoints are purged on setBreakpoints

### DIFF
--- a/apps/els_dap/src/els_dap_rpc.erl
+++ b/apps/els_dap/src/els_dap_rpc.erl
@@ -10,6 +10,7 @@
     break_in/4,
     clear/1,
     continue/2,
+    delete_break/3,
     eval/3,
     file/3,
     get_meta/2,
@@ -65,6 +66,10 @@ clear(Node) ->
 -spec continue(node(), pid()) -> any().
 continue(Node, Pid) ->
     rpc:call(Node, int, continue, [Pid]).
+
+-spec delete_break(node(), module(), non_neg_integer()) -> any().
+delete_break(Node, Module, Line) ->
+    rpc:call(Node, int, delete_break, [Module, Line]).
 
 -spec eval(node(), string(), [any()]) -> any().
 eval(Node, Input, Bindings) ->

--- a/elvis.config
+++ b/elvis.config
@@ -18,6 +18,7 @@
                             els_client,
                             els_completion_SUITE,
                             els_dap_general_provider_SUITE,
+                            els_dap_rpc,
                             els_definition_SUITE,
                             els_diagnostics_SUITE,
                             els_document_highlight_SUITE,


### PR DESCRIPTION
### Description

This is a workaround for [a bug in the OTP interpreter](https://github.com/erlang/otp/issues/7336), which causes breakpoints to stay active, even after they are removed by the user via the UI, for existing processes.

This makes removing breakpoints a very confusing experience, especially in presence of recursive functions, where the only option left to the user is to interrupt and restart the debugging session.

In this PR:

* Created a test-case which highlights the issue (the test would time out before the fix)
* Ensure the breakpoints are purged on a new `setBreakpoints` call
* Add helper function to wait for processes to resume regular operation