### PR TITLE
Handle extended head mismatch error

### DIFF
--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -611,7 +611,7 @@ make_code(qlc, {error, _Module, _Reason}) ->
 make_code(qlc, _E) ->
     <<"Q1699">>;
 %% stdlib-3.15.2/src/erl_parse.yrl
-make_code(erl_parse, "head mismatch") ->
+make_code(erl_parse, "head mismatch" ++ _) ->
     <<"P1700">>;
 make_code(erl_parse, "bad type variable") ->
     <<"P1701">>;


### PR DESCRIPTION
This pull request adds support for parsing extended "head mismatch" errors as introduced in https://github.com/erlang/otp/pull/7383.