### PR TITLE
Update Gradualizer to 0.3.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
     {ephemeral, "2.0.4"},
     {tdiff, "0.1.2"},
     {uuid, "2.0.1", {pkg, uuid_erl}},
-    {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {ref, "6e89b4e"}}}
+    {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {tag, "0.3.0"}}}
 ]}.
 
 {shell, [{apps, [els_lsp]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,7 @@
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},2},
  {<<"gradualizer">>,
   {git,"https://github.com/josefs/Gradualizer.git",
-       {ref,"6e89b4e1cd489637a848cc5ca55058c8a241bf7d"}},
+       {ref,"3021d29d82741399d131e3be38d2a8db79d146d4"}},
   0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"3.0.0">>},0},
  {<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.2.1">>},1},


### PR DESCRIPTION
This version of Gradualizer brings approx. 30 PRs. The highlights are:

- Improve map exhaustiveness checking [#524](https://github.com/josefs/gradualizer/pull/524) by @xxdavid
- Fix all remaining self-check errors [#521](https://github.com/josefs/gradualizer/pull/521) by @erszcz
- Fix intersection-typed function calls with union-typed arguments [#514](https://github.com/josefs/gradualizer/pull/514) by @erszcz
- Experimental constraint solver [#450](https://github.com/josefs/gradualizer/pull/450) by @erszcz