### PR TITLE
Lowercase drive letter in URIs for Windows

### DIFF
--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -45,9 +45,16 @@ path(Uri, IsWindows) ->
     case {IsWindows, Host} of
         {true, <<>>} ->
             % Windows drive letter, have to strip the initial slash
-            re:replace(
+            Path1 = re:replace(
                 Path, "^/([a-zA-Z]:)(.*)", "\\1\\2", [{return, binary}]
-            );
+            ),
+            % Also need to lowercase it
+            case Path1 of
+                <<Drive0, ":", Rest/binary>> ->
+                    Drive = string:to_lower(Drive0),
+                    <<Drive, ":", Rest/binary>>;
+                _ -> Path1
+            end;
         {true, _} ->
             <<"//", Host/binary, Path/binary>>;
         {false, <<>>} ->

--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -99,7 +99,8 @@ percent_decode(Str) ->
 lowercase_drive_letter(<<Drive0, ":", Rest/binary>>) ->
     Drive = string:to_lower(Drive0),
     <<Drive, ":", Rest/binary>>;
-lowercase_drive_letter(Path) -> Path.
+lowercase_drive_letter(Path) ->
+    Path.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -48,13 +48,7 @@ path(Uri, IsWindows) ->
             Path1 = re:replace(
                 Path, "^/([a-zA-Z]:)(.*)", "\\1\\2", [{return, binary}]
             ),
-            % Also need to lowercase it
-            case Path1 of
-                <<Drive0, ":", Rest/binary>> ->
-                    Drive = string:to_lower(Drive0),
-                    <<Drive, ":", Rest/binary>>;
-                _ -> Path1
-            end;
+            lowercase_drive_letter(Path1);
         {true, _} ->
             <<"//", Host/binary, Path/binary>>;
         {false, <<>>} ->
@@ -100,6 +94,15 @@ percent_decode(Str) ->
 percent_decode(Str) ->
     http_uri:decode(Str).
 -endif.
+
+
+-spec lowercase_drive_letter(binary()) -> binary().
+lowercase_drive_letter(<<Drive0, ":", Rest/binary>>) ->
+    Drive = string:to_lower(Drive0),
+    <<Drive, ":", Rest/binary>>;
+
+lowercase_drive_letter(Path) -> Path.
+
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -95,14 +95,11 @@ percent_decode(Str) ->
     http_uri:decode(Str).
 -endif.
 
-
 -spec lowercase_drive_letter(binary()) -> binary().
 lowercase_drive_letter(<<Drive0, ":", Rest/binary>>) ->
     Drive = string:to_lower(Drive0),
     <<Drive, ":", Rest/binary>>;
-
 lowercase_drive_letter(Path) -> Path.
-
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
### Description

If a LSP client on Windows sends a capital drive letter in a URI, then the compiler diagnostics end up sending the wrong position/range. 

This is because of [this line.](https://github.com/erlang-ls/erlang_ls/blob/e91c9519996e0ff701edc19f308524906a3df131/apps/els_lsp/src/els_compiler_diagnostics.erl#L195) It checks that the path from the compiler matches the URI path. The path from the compiler has a lowercase drive letter, so they don't match and the diagnostics are treated as if they are coming from an include.

I've fixed this in els_uri:path, but there might be a better place to do it, I'm not sure.
