### PR TITLE
els_typer: Handle OTP26 changes to dialyzer functions

### DIFF
--- a/apps/els_lsp/src/els_typer.erl
+++ b/apps/els_lsp/src/els_typer.erl
@@ -34,6 +34,14 @@
 
 -include("els_lsp.hrl").
 
+-if(?OTP_RELEASE >= 26).
+-define(DEFAULT_PLT_FILE, dialyzer_iplt:get_default_iplt_filename()).
+-define(PLT_FROM_FILE(PltFile), dialyzer_iplt:from_file(PltFile)).
+-else.
+-define(DEFAULT_PLT_FILE, dialyzer_plt:get_default_plt()).
+-define(PLT_FROM_FILE(PltFile), dialyzer_plt:from_file(PltFile)).
+-endif.
+
 -type files() :: [file:filename()].
 -type callgraph() :: dialyzer_callgraph:callgraph().
 -type codeserver() :: dialyzer_codeserver:codeserver().
@@ -427,11 +435,11 @@ get_dialyzer_plt() ->
     PltFile =
         case els_config:get(plt_path) of
             undefined ->
-                dialyzer_plt:get_default_plt();
+                ?DEFAULT_PLT_FILE;
             PltPath ->
                 PltPath
         end,
-    dialyzer_plt:from_file(PltFile).
+    ?PLT_FROM_FILE(PltFile).
 
 %% Exported Types
 


### PR DESCRIPTION
### Description

OTP26 added the `dialyzer_iplt` module and took over some of the PLT functions from `dialyzer_plt`. I added some conditional compilation to use the dialyzer_iplt functions on 26+ and dialyzer_plt on 25-. `dialyzer_iplt` comes from the big refactor for incremental mode: https://www.erlang.org/blog/otp-26-highlights/#incremental-mode-for-dialyzer

Fixes #1443.
