### PR TITLE
[LSP] Fix initialize on OTP 23.0/23.1

### DIFF
--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -5,6 +5,10 @@
 %%==============================================================================
 -module(els_uri).
 
+-if(?OTP_RELEASE =:= 23).
+-compile([{nowarn_deprecated_function, [{http_uri, decode, 1}]}]).
+-endif.
+
 %%==============================================================================
 %% Exports
 %%==============================================================================
@@ -84,10 +88,20 @@ uri(Path) ->
 uri_join(List) ->
     lists:join(<<"/">>, List).
 
--if(?OTP_RELEASE >= 23).
+-if(?OTP_RELEASE > 23).
 -spec percent_decode(binary()) -> binary().
 percent_decode(Str) ->
     uri_string:percent_decode(Str).
+-elif(?OTP_RELEASE =:= 23).
+-spec percent_decode(binary()) -> binary().
+percent_decode(Str) ->
+    %% The `percent_decode/1' function is unavailable until OTP 23.2
+    case erlang:function_exported(uri_string, percent_decode, 1) of
+        'true' ->
+            uri_string:percent_decode(Str);
+        'false' ->
+            http_uri:decode(Str)
+    end.
 -else.
 -spec percent_decode(binary()) -> binary().
 percent_decode(Str) ->

--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -98,10 +98,15 @@ percent_decode(Str) ->
     %% The `percent_decode/1' function is unavailable until OTP 23.2
     case erlang:function_exported(uri_string, percent_decode, 1) of
         'true' ->
-            uri_string:percent_decode(Str);
+            percent_decode2(Str);
         'false' ->
             http_uri:decode(Str)
     end.
+
+-dialyzer([{nowarn_function, percent_decode2/1}]).
+-spec percent_decode2(binary()) -> binary().
+percent_decode2(Str) ->
+    uri_string:percent_decode(Str).
 -else.
 -spec percent_decode(binary()) -> binary().
 percent_decode(Str) ->

--- a/rebar.config
+++ b/rebar.config
@@ -89,7 +89,9 @@
 %% Set xref ignores for functions introduced in OTP 23 & function of wrangler
 {xref_ignores, [
     {code, get_doc, 1},
+    {http_uri, decode, 1},
     {shell_docs, render, 4},
+    {uri_string, percent_decode, 1},
     wrangler_handler,
     api_wrangler,
     wls_code_lens,


### PR DESCRIPTION
### Description

`els_uri:path/2` was calling `uri_string:percent_decode/1`, which is unavailable until OTP 23.2
(https://www.erlang.org/doc/man/uri_string#percent_decode-1)