### PR TITLE
added nonempty_binary and nonempty_bitstring

### DIFF
--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -996,6 +996,8 @@ bifs(type_definition, ItemFormat) ->
         {'nil', 0},
         {'no_return', 0},
         {'node', 0},
+        {'nonempty_binary', 0},
+        {'nonempty_bitstring', 0},
         {'nonempty_improper_list', 2},
         {'nonempty_list', 1},
         {'non_neg_integer', 0},


### PR DESCRIPTION
### Description

Added types were introduced in OTP24, but since macro FEATURE_AVAILABLE (introduced in OTP25) is available, I think those types should be too.
