### PR TITLE
Added config item 'erls_dirs' to add code not in 'src' to the scope

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -130,6 +130,7 @@ initialize(RootUri, Capabilities, InitOptions, ErrorReporting) ->
 
 -spec do_initialize(uri(), map(), map(), {undefined | path(), map()}) -> ok.
 do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
+    put(erls_dirs, maps:get("erls_dirs", Config, [])),
     RootPath = els_utils:to_list(els_uri:path(RootUri)),
     OtpPath = maps:get("otp_path", Config, code:root_dir()),
     ?LOG_INFO("OTP Path: ~p", [OtpPath]),
@@ -444,6 +445,7 @@ project_paths(RootPath, Dirs, Recursive) ->
                 [RootPath, Dir, "src"],
                 [RootPath, Dir, "test"],
                 [RootPath, Dir, "include"]
+                | [[RootPath, Dir, Src] || Src <- erlang:get(erls_dirs)]
             ],
             Recursive
         )

--- a/erlang_ls.config.sample
+++ b/erlang_ls.config.sample
@@ -3,6 +3,12 @@ apps_dirs:
 deps_dirs:
   - "_build/default/lib/*"
   - "_build/test/lib/*"
+
+%% If your code exists in directories other than "src", add them through this configuration
+erls_dirs:
+  - "common"
+  - "game"
+
 include_dirs:
   - "apps"
   - "apps/*/include"


### PR DESCRIPTION
I am currently maintaining a project whose 'erl' files is not in the 'src' directory.
In order for the plugin to work properly on my project, a new configuration item was added so that directories other than 'src' could be included in the source code search.
