### PR TITLE
Replace ':' with '%3A' in 'Uri = els_uri:uri(Fullname)'

### DIFF
--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -68,7 +68,7 @@ uri(Path) ->
                 {H, uri_join(T)};
             {true, _} ->
                 % Strip the trailing slash from the first component
-                H1 = string:slice(Head, 0, 2),
+                H1 = <<(string:slice(Head, 0, 1))/binary, "%3A">>,
                 {<<>>, uri_join([H1 | Tail])}
         end,
 


### PR DESCRIPTION
My client vscode makes a request like '<<"textDocument/definition">>', which carries a params of uri like '<<"file:///d%3A/SvnFiles/yf5_dragalia/server/game/player/player_prop.erl">>',But when the plugin executes 'shallow_index/4', the 'Uri' calculated by 'Uri = els_uri:uri(Fullname)' is '<<"file:///d:/SvnFiles/yf5_dragalia/server/game/player/player_prop.erl">>'.
They don't match, causing the plugin to work abnormally, and my submission is designed to fix that.