### PR TITLE
'index_dir' cover the source code in the subdirectory

### DIFF
--- a/apps/els_core/src/els_utils.erl
+++ b/apps/els_core/src/els_utils.erl
@@ -287,7 +287,7 @@ do_fold_files(F, Filter, Dir, [File | Rest], Acc0) ->
     Acc =
         case filelib:is_regular(Path) of
             true -> do_fold_file(F, Filter, Path, Acc0);
-            false -> Acc0
+            false -> do_fold_dir(F, Filter, Path, Acc0)
         end,
     do_fold_files(F, Filter, Dir, Rest, Acc).
 


### PR DESCRIPTION
The plugin starts with 'index_dir/4' and 'shallow_index/4' for every file retrieved, but its search level is shallow and there is no way to cover the source code in the subdirectory. This commit aims to solve this problem.