### PR TITLE
Makes 'find_references/2' faster

### DIFF
--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -286,6 +286,8 @@ get_words(Text) ->
             Fun = fun
                 ({atom, _Location, Atom}, Words) ->
                     sets:add_element(Atom, Words);
+                ({var, _Location, Var}, Words) ->
+                    sets:add_element(Var, Words);
                 ({string, _Location, String}, Words) ->
                     case filename:extension(String) of
                         ".hrl" ->

--- a/apps/els_lsp/src/els_dt_references.erl
+++ b/apps/els_lsp/src/els_dt_references.erl
@@ -180,6 +180,11 @@ kind_to_category(Kind) when
     Kind =:= record
 ->
     record;
+kind_to_category(Kind) when
+    Kind =:= record_def_field;
+    Kind =:= record_field
+->
+    record_field;
 kind_to_category(Kind) when Kind =:= include ->
     include;
 kind_to_category(Kind) when Kind =:= include_lib ->

--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -156,6 +156,7 @@ index_references(Id, Uri, POIs, Version) ->
 
 -spec index_reference(atom(), uri(), els_poi:poi(), version()) -> ok.
 index_reference(M, Uri, #{kind := Kind, id := {F, A}} = POI, Version) when
+    Kind =/= macro,
     Kind =/= record_field
 ->
     index_reference(M, Uri, POI#{id => {M, F, A}}, Version);

--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -155,7 +155,9 @@ index_references(Id, Uri, POIs, Version) ->
     ok.
 
 -spec index_reference(atom(), uri(), els_poi:poi(), version()) -> ok.
-index_reference(M, Uri, #{kind := function, id := {F, A}} = POI, Version) ->
+index_reference(M, Uri, #{kind := Kind, id := {F, A}} = POI, Version) when
+    Kind =/= record_field
+->
     index_reference(M, Uri, POI#{id => {M, F, A}}, Version);
 index_reference(_M, Uri, #{kind := Kind, id := Id, range := Range}, Version) ->
     els_dt_references:versioned_insert(Kind, #{

--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -137,6 +137,11 @@ index_references(Id, Uri, POIs, Version) ->
         %% Include
         include,
         include_lib,
+        %% Macro
+        macro,
+        %% Record
+        record_expr,
+        record_field,
         %% Behaviour
         behaviour,
         %% Type
@@ -150,7 +155,7 @@ index_references(Id, Uri, POIs, Version) ->
     ok.
 
 -spec index_reference(atom(), uri(), els_poi:poi(), version()) -> ok.
-index_reference(M, Uri, #{id := {F, A}} = POI, Version) ->
+index_reference(M, Uri, #{kind := function, id := {F, A}} = POI, Version) ->
     index_reference(M, Uri, POI#{id => {M, F, A}}, Version);
 index_reference(_M, Uri, #{kind := Kind, id := Id, range := Range}, Version) ->
     els_dt_references:versioned_insert(Kind, #{

--- a/apps/els_lsp/src/els_references_provider.erl
+++ b/apps/els_lsp/src/els_references_provider.erl
@@ -101,14 +101,12 @@ find_references(Uri, #{
     {F, A, _Index} = Id,
     Key = {els_uri:module(Uri), F, A},
     find_references_for_id(Kind, Key);
-find_references(Uri, Poi = #{kind := Kind}) when
+find_references(_Uri, #{kind := Kind, id := Key}) when
     Kind =:= record;
     Kind =:= record_def_field;
     Kind =:= define
 ->
-    uri_pois_to_locations(
-        find_scoped_references_for_def(Uri, Poi)
-    );
+    find_references_for_id(Kind, Key);
 find_references(Uri, Poi = #{kind := Kind, id := Id}) when
     Kind =:= type_definition
 ->

--- a/apps/els_lsp/src/els_text_search.erl
+++ b/apps/els_lsp/src/els_text_search.erl
@@ -34,6 +34,10 @@ extract_pattern({macro, {Name, _Arity}}) ->
     Name;
 extract_pattern({macro, Name}) ->
     Name;
+extract_pattern({record, Record}) ->
+    Record;
+extract_pattern({record_field, {Record, _Field}}) ->
+    Record;
 extract_pattern({include, Id}) ->
     include_id(Id);
 extract_pattern({include_lib, Id}) ->


### PR DESCRIPTION
Fixed the way Kind equals `record`/`record_def_field`/`define` works in `find_references/2`, this `uri_pois_to_locations(find_scoped_references_for_def(Uri, Poi));` is really too slow, now they can use `find_references_for_id(Kind, Key);` like a function.