### PR TITLE
Add edoc_parse_enabled to config

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -165,6 +165,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
 
     RefactorErl = maps:get("refactorerl", Config, notconfigured),
     Providers = maps:get("providers", Config, #{}),
+    EdocParseEnabled = maps:get("edoc_parse_enabled", Config, true),
 
     %% Initialize and start Wrangler
     case maps:get("wrangler", Config, notconfigured) of
@@ -236,6 +237,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     ok = set(elvis_config_path, ElvisConfigPath),
     ok = set(compiler_telemetry_enabled, CompilerTelemetryEnabled),
     ok = set(edoc_custom_tags, EDocCustomTags),
+    ok = set(edoc_parse_enabled, EdocParseEnabled),
     ok = set(incremental_sync, IncrementalSync),
     ok = set(
         indexing,

--- a/apps/els_core/src/els_dodger.erl
+++ b/apps/els_core/src/els_dodger.erl
@@ -567,7 +567,7 @@ quickscan_form([{'-', _L}, {'if', La} | _Ts]) ->
     kill_form(La);
 quickscan_form([{'-', _L}, {atom, La, elif} | _Ts]) ->
     kill_form(La);
-quickscan_form([{'-', _L}, {atom, La, else} | _Ts]) ->
+quickscan_form([{'-', _L}, {atom, La, 'else'} | _Ts]) ->
     kill_form(La);
 quickscan_form([{'-', _L}, {atom, La, endif} | _Ts]) ->
     kill_form(La);
@@ -791,13 +791,13 @@ scan_form([{'-', _L}, {atom, La, elif} | Ts], Opt) ->
         {atom, La, 'elif'}
         | scan_macros(Ts, Opt)
     ];
-scan_form([{'-', _L}, {atom, La, else} | Ts], Opt) ->
+scan_form([{'-', _L}, {atom, La, 'else'} | Ts], Opt) ->
     [
         {atom, La, ?pp_form},
         {'(', La},
         {')', La},
         {'->', La},
-        {atom, La, else}
+        {atom, La, 'else'}
         | scan_macros(Ts, Opt)
     ];
 scan_form([{'-', _L}, {atom, La, endif} | Ts], Opt) ->


### PR DESCRIPTION
### Description

Adds config option to disable edoc parsing.

Found that parsing some files took very long time to edoc parse which made completion break.

Simple solution, add an option to disable the edoc parsing if one runs into such issues.

For future consideration: Add a timeout for edoc parsing so it can be interrupted if it takes too long.