### PR TITLE
Allows custom setting the formatter

### DIFF
--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -60,7 +60,8 @@
     | refactorerl
     | wrangler
     | edoc_custom_tags
-    | providers.
+    | providers
+    | formatting.
 
 -type path() :: file:filename().
 -type state() :: #{
@@ -83,7 +84,8 @@
     compiler_telemetry_enabled => boolean(),
     wrangler => map() | 'notconfigured',
     refactorerl => map() | 'notconfigured',
-    providers => map()
+    providers => map(),
+    formatting => map()
 }.
 
 -type error_reporting() :: lsp_notification | log.
@@ -167,6 +169,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     RefactorErl = maps:get("refactorerl", Config, notconfigured),
     Providers = maps:get("providers", Config, #{}),
     EdocParseEnabled = maps:get("edoc_parse_enabled", Config, true),
+    Formatting = maps:get("formatting", Config, #{}),
 
     %% Initialize and start Wrangler
     case maps:get("wrangler", Config, notconfigured) of
@@ -269,6 +272,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     ok = set(indexing_enabled, IndexingEnabled),
 
     ok = set(refactorerl, RefactorErl),
+    ok = set(formatting, Formatting),
     ok.
 
 -spec start_link() -> {ok, pid()}.

--- a/apps/els_lsp/src/els_formatting_provider.erl
+++ b/apps/els_lsp/src/els_formatting_provider.erl
@@ -99,7 +99,9 @@ format_document_local(
         sub_indent => SubIndent,
         output_dir => Dir
     },
-    Formatter = rebar3_formatter:new(default_formatter, Opts, unused),
+    Config = els_config:get(formatting),
+    FormatterName = get_formatter_name(Config),
+    Formatter = rebar3_formatter:new(FormatterName, Opts, unused),
     rebar3_formatter:format_file(RelativePath, Formatter),
     ok.
 
@@ -119,3 +121,19 @@ rangeformat_document(_Uri, _Document, _Range, _Options) ->
     {ok, [text_edit()]}.
 ontypeformat_document(_Uri, _Document, _Line, _Col, _Char, _Options) ->
     {ok, []}.
+
+-spec get_formatter_name(map() | undefined) ->
+    sr_formatter | erlfmt_formatter | otp_formatter | default_formatter.
+get_formatter_name(undefined) ->
+    default_formatter;
+get_formatter_name(Config) ->
+    case maps:get("formatter", Config, undefined) of
+        "sr" ->
+            sr_formatter;
+        "erlfmt" ->
+            erlfmt_formatter;
+        "otp" ->
+            otp_formatter;
+        _ ->
+            default_formatter
+    end.


### PR DESCRIPTION
### Description

The low-level formatting plugin erlang_ls relies on supports some formatters, maybe it would be good to expose them into the configuration.

This PR added a new configuration section with an option to specify the formatter

Fixes # .
