### PR TITLE
Fix invalid crossref warning for Mod:module_info()

### DIFF
--- a/apps/els_lsp/priv/code_navigation/src/diagnostics_xref_pseudo.erl
+++ b/apps/els_lsp/priv/code_navigation/src/diagnostics_xref_pseudo.erl
@@ -33,4 +33,6 @@ main() ->
 
   % At lease one failure so we know the diagnostic is running
   unknown_module:nonexistent(),
+  Mod:module_info(),
+  Mod:module_info(module),
   ok.

--- a/apps/els_lsp/src/els_crossref_diagnostics.erl
+++ b/apps/els_lsp/src/els_crossref_diagnostics.erl
@@ -95,6 +95,14 @@ has_definition(
 has_definition(
     #{
         kind := application,
+        data := #{mod_is_variable := true}
+    },
+    _
+) ->
+    true;
+has_definition(
+    #{
+        kind := application,
         id := {Module, module_info, Arity}
     },
     _
@@ -112,14 +120,6 @@ has_definition(
     #{
         kind := application,
         id := {behaviour_info, 1}
-    },
-    _
-) ->
-    true;
-has_definition(
-    #{
-        kind := application,
-        data := #{mod_is_variable := true}
     },
     _
 ) ->


### PR DESCRIPTION
### Description

Fixes #1471.
