### PR TITLE
`all` target - building as dap not required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ PREFIX ?= '/usr/local'
 all:
 	@ echo "Building escript..."
 	@ rebar3 escriptize
-	@ rebar3 as dap escriptize
 
 .PHONY: install
 install: all


### PR DESCRIPTION
### Description

I think that it's not necessary anymore to have this build step.
