### PR TITLE
Don't emit parser error when ?MODULE is used in a header file

### DIFF
--- a/apps/els_lsp/priv/code_navigation/include/builtin_macros.hrl
+++ b/apps/els_lsp/priv/code_navigation/include/builtin_macros.hrl
@@ -1,0 +1,12 @@
+-export([f/0]).
+
+-spec f() -> any().
+f() ->
+    ?MODULE,
+    ?MODULE_STRING,
+    ?FILE,
+    ?LINE,
+    ?MACHINE,
+    ?FUNCTION_NAME,
+    ?FUNCTION_ARITY,
+    ?OTP_RELEASE.

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -99,6 +99,14 @@ compile(Uri) ->
                 diagnostics(Path, ES, ?DIAGNOSTIC_ERROR)
     end.
 
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE =< 23).
+%% Invalid spec in eep:open/1 will cause dialyzer to emit a warning
+%% in OTP 23 and earlier.
+-dialyzer([{nowarn_function, parse/1}]).
+-endif.
+-endif.
+
 -spec parse(uri()) -> [els_diagnostics:diagnostic()].
 parse(Uri) ->
     FileName = els_utils:to_list(els_uri:path(Uri)),

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -111,7 +111,11 @@ parse(Uri) ->
         end,
     {ok, Epp} = epp:open([
         {name, FileName},
-        {includes, els_config:get(include_paths)}
+        {includes, els_config:get(include_paths)},
+        {macros, [
+            {'MODULE', dummy_module, redefine},
+            {'MODULE_STRING', "dummy_module", redefine}
+        ]}
     ]),
     Res = [
         epp_diagnostic(Document, Anno, Module, Desc)

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -32,6 +32,7 @@
     use_long_names_no_domain/1,
     use_long_names_custom_hostname/1,
     epp_with_nonexistent_macro/1,
+    epp_with_builtin_macro/1,
     elvis/1,
     escript/1,
     escript_warnings/1,
@@ -690,11 +691,6 @@ epp_with_nonexistent_macro(_Config) ->
             range => {{2, 0}, {3, 0}}
         },
         #{
-            code => <<"E1507">>,
-            message => <<"undefined macro 'MODULE'">>,
-            range => {{4, 0}, {5, 0}}
-        },
-        #{
             code => <<"E1522">>,
             message => <<
                 "-error(\"including nonexistent_macro.hrl "
@@ -703,6 +699,16 @@ epp_with_nonexistent_macro(_Config) ->
             range => {{6, 0}, {7, 0}}
         }
     ],
+    Warnings = [],
+    Hints = [],
+    els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
+-spec epp_with_builtin_macro(config()) -> ok.
+epp_with_builtin_macro(_Config) ->
+    %% This should NOT trigger a diagnostic
+    Path = include_path("builtin_macros.hrl"),
+    Source = <<"Compiler">>,
+    Errors = [],
     Warnings = [],
     Hints = [],
     els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).


### PR DESCRIPTION
### Description

Don't emit parser error when ?MODULE is used in a header file.

Fixes #1498.
