### PR TITLE
Add support for inlay hints

### DIFF
--- a/apps/els_core/include/els_core.hrl
+++ b/apps/els_core/include/els_core.hrl
@@ -603,6 +603,35 @@
 }.
 
 %%------------------------------------------------------------------------------
+%% Inlay hint
+%%------------------------------------------------------------------------------
+-define(INLAY_HINT_KIND_TYPE, 1).
+-define(INLAY_HINT_KIND_PARAMETER, 2).
+
+-type inlay_hint_kind() ::
+    ?INLAY_HINT_KIND_TYPE
+    | ?INLAY_HINT_KIND_PARAMETER.
+
+-type inlay_hint_label_part() ::
+    #{
+        value := binary(),
+        tooltip => binary() | markup_content(),
+        location => location(),
+        command => els_command:command()
+    }.
+
+-type inlay_hint() :: #{
+    position := position(),
+    label := binary() | [inlay_hint_label_part()],
+    kind => inlay_hint_kind(),
+    textEdits => [text_edit()],
+    tooltip => binary() | markup_content(),
+    paddingLeft => boolean(),
+    paddingRight => boolean(),
+    data => map()
+}.
+
+%%------------------------------------------------------------------------------
 %% Workspace
 %%------------------------------------------------------------------------------
 

--- a/apps/els_core/src/els_client.erl
+++ b/apps/els_core/src/els_client.erl
@@ -57,7 +57,8 @@
     preparecallhierarchy/3,
     callhierarchy_incomingcalls/1,
     callhierarchy_outgoingcalls/1,
-    get_notifications/0
+    get_notifications/0,
+    inlay_hint/2
 ]).
 
 -export([handle_responses/1]).
@@ -276,6 +277,10 @@ get_notifications() ->
 handle_responses(Responses) ->
     gen_server:cast(?SERVER, {handle_responses, Responses}).
 
+-spec inlay_hint(uri(), range()) -> ok.
+inlay_hint(Uri, Range) ->
+    gen_server:call(?SERVER, {inlay_hint, {Uri, Range}}).
+
 %%==============================================================================
 %% gen_server Callback Functions
 %%==============================================================================
@@ -462,6 +467,7 @@ method_lookup(implementation) -> <<"textDocument/implementation">>;
 method_lookup(folding_range) -> <<"textDocument/foldingRange">>;
 method_lookup(semantic_tokens) -> <<"textDocument/semanticTokens/full">>;
 method_lookup(preparecallhierarchy) -> <<"textDocument/prepareCallHierarchy">>;
+method_lookup(inlay_hint) -> <<"textDocument/inlayHint">>;
 method_lookup(callhierarchy_incomingcalls) -> <<"callHierarchy/incomingCalls">>;
 method_lookup(callhierarchy_outgoingcalls) -> <<"callHierarchy/outgoingCalls">>;
 method_lookup(workspace_symbol) -> <<"workspace/symbol">>;
@@ -476,6 +482,11 @@ request_params({document_symbol, {Uri}}) ->
     #{textDocument => TextDocument};
 request_params({workspace_symbol, {Query}}) ->
     #{query => Query};
+request_params({inlay_hint, {Uri, Range}}) ->
+    #{
+        textDocument => #{uri => Uri},
+        range => Range
+    };
 request_params({workspace_executecommand, {Command, Args}}) ->
     #{
         command => Command,

--- a/apps/els_core/src/els_config.erl
+++ b/apps/els_core/src/els_config.erl
@@ -172,6 +172,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     RefactorErl = maps:get("refactorerl", Config, notconfigured),
     Providers = maps:get("providers", Config, #{}),
     EdocParseEnabled = maps:get("edoc_parse_enabled", Config, true),
+    InlayHintsEnabled = maps:get("inlay_hints_enabled", Config, false),
     Formatting = maps:get("formatting", Config, #{}),
     DocsMemo = maps:get("docs_memo", Config, false),
 
@@ -248,6 +249,7 @@ do_initialize(RootUri, Capabilities, InitOptions, {ConfigPath, Config}) ->
     ok = set(edoc_custom_tags, EDocCustomTags),
     ok = set(edoc_parse_enabled, EdocParseEnabled),
     ok = set(incremental_sync, IncrementalSync),
+    ok = set(inlay_hints_enabled, InlayHintsEnabled),
     ok = set(
         indexing,
         maps:merge(

--- a/apps/els_lsp/priv/code_navigation/src/inlay_hint.erl
+++ b/apps/els_lsp/priv/code_navigation/src/inlay_hint.erl
@@ -1,0 +1,26 @@
+-module(inlay_hint).
+-export([test/0]).
+
+-record(foo, {}).
+
+test() ->
+    a(1, 2),
+    b(1, 2),
+    c(1),
+    d(1, 2),
+    lists:append([], []).
+
+a(Hej, Hoj) ->
+    Hej + Hoj.
+
+b(x, y) ->
+    0;
+b(A, _B) ->
+    A.
+
+c(#foo{}) ->
+    ok.
+
+d([1,2,3] = Foo,
+  Bar = #{hej := 123}) ->
+    ok.

--- a/apps/els_lsp/src/els_arg.erl
+++ b/apps/els_lsp/src/els_arg.erl
@@ -1,0 +1,25 @@
+-module(els_arg).
+-export([name/1]).
+-export([name/2]).
+-export([index/1]).
+-export_type([arg/0]).
+
+-type arg() :: #{
+    index := pos_integer(),
+    name := string() | undefined,
+    range => els_poi:poi_range()
+}.
+
+-spec name(arg()) -> string().
+name(Arg) ->
+    name("Arg", Arg).
+
+-spec name(string(), arg()) -> string().
+name(Prefix, #{index := N, name := undefined}) ->
+    Prefix ++ integer_to_list(N);
+name(_Prefix, #{name := Name}) ->
+    Name.
+
+-spec index(arg()) -> string().
+index(#{index := Index}) ->
+    integer_to_list(Index).

--- a/apps/els_lsp/src/els_code_actions.erl
+++ b/apps/els_lsp/src/els_code_actions.erl
@@ -264,7 +264,7 @@ format_args(Document, Arity, Range) ->
     ],
     case Matches of
         [#{data := #{args := Args0}} | _] ->
-            string:join([A || {_N, A} <- Args0], ", ");
+            string:join([els_arg:name(A) || A <- Args0], ", ");
         [] ->
             string:join(lists:duplicate(Arity, "_"), ", ")
     end.

--- a/apps/els_lsp/src/els_code_lens_provider.erl
+++ b/apps/els_lsp/src/els_code_lens_provider.erl
@@ -42,11 +42,7 @@ run_lenses_job(Uri) ->
             end,
         entries => [Document],
         title => <<"Lenses">>,
-        on_complete =>
-            fun(Lenses) ->
-                els_server ! {result, Lenses, self()},
-                ok
-            end
+        on_complete => fun els_server:register_result/1
     },
     {ok, Pid} = els_background_job:new(Config),
     Pid.

--- a/apps/els_lsp/src/els_diagnostics_provider.erl
+++ b/apps/els_lsp/src/els_diagnostics_provider.erl
@@ -37,8 +37,7 @@ handle_request({run_diagnostics, Params}) ->
 %%==============================================================================
 -spec notify([els_diagnostics:diagnostic()], pid()) -> ok.
 notify(Diagnostics, Job) ->
-    els_server ! {diagnostics, Diagnostics, Job},
-    ok.
+    els_server:register_diagonstics(Diagnostics, Job).
 
 -spec publish(uri(), [els_diagnostics:diagnostic()]) -> ok.
 publish(Uri, Diagnostics) ->

--- a/apps/els_lsp/src/els_docs.erl
+++ b/apps/els_lsp/src/els_docs.erl
@@ -541,9 +541,9 @@ format_edoc(Desc) when is_map(Desc) ->
     FormattedDoc = els_utils:to_list(docsh_edoc:format_edoc(Doc, #{})),
     [{text, FormattedDoc}].
 
--spec macro_signature(els_poi:poi_id(), [{integer(), string()}]) -> unicode:charlist().
+-spec macro_signature(els_poi:poi_id(), els_parser:args()) -> unicode:charlist().
 macro_signature({Name, _Arity}, Args) ->
-    [atom_to_list(Name), "(", lists:join(", ", [A || {_N, A} <- Args]), ")"];
+    [atom_to_list(Name), "(", lists:join(", ", [els_arg:name(A) || A <- Args]), ")"];
 macro_signature(Name, none) ->
     atom_to_list(Name).
 

--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -30,6 +30,7 @@
     new/4,
     pois/1,
     pois/2,
+    pois_in_range/3,
     get_element_at_pos/3,
     uri/1,
     functions_at_pos/3,
@@ -210,6 +211,21 @@ pois(#{pois := POIs}) ->
 -spec pois(item(), [els_poi:poi_kind()]) -> [els_poi:poi()].
 pois(Item, Kinds) ->
     [POI || #{kind := K} = POI <- pois(Item), lists:member(K, Kinds)].
+
+%% @doc Returns the list of POIs of the given types in the given range
+%%      for the current document
+-spec pois_in_range(
+    item(),
+    [els_poi:poi_kind()],
+    els_poi:poi_range()
+) -> [els_poi:poi()].
+pois_in_range(Item, Kinds, Range) ->
+    [
+        POI
+     || #{kind := K, range := R} = POI <- pois(Item),
+        lists:member(K, Kinds),
+        els_range:in(R, Range)
+    ].
 
 -spec get_element_at_pos(item(), non_neg_integer(), non_neg_integer()) ->
     [els_poi:poi()].

--- a/apps/els_lsp/src/els_general_provider.erl
+++ b/apps/els_lsp/src/els_general_provider.erl
@@ -133,7 +133,8 @@ available_providers() ->
         "code-lens",
         "rename",
         "call-hierarchy",
-        "semantic-tokens"
+        "semantic-tokens",
+        "inlay-hint"
     ].
 
 %% @doc Give the list of all providers enabled by default.
@@ -197,6 +198,8 @@ server_capabilities() ->
             renameProvider =>
                 els_rename_provider:options(),
             callHierarchyProvider => true,
+            inlayHintProvider =>
+                els_inlay_hint_provider:options(),
             semanticTokensProvider =>
                 #{
                     legend =>
@@ -306,4 +309,5 @@ provider_id(executeCommandProvider) -> "execute-command";
 provider_id(codeLensProvider) -> "code-lens";
 provider_id(renameProvider) -> "rename";
 provider_id(callHierarchyProvider) -> "call-hierarchy";
-provider_id(semanticTokensProvider) -> "semantic-tokens".
+provider_id(semanticTokensProvider) -> "semantic-tokens";
+provider_id(inlayHintProvider) -> "inlay-hint".

--- a/apps/els_lsp/src/els_hover_provider.erl
+++ b/apps/els_lsp/src/els_hover_provider.erl
@@ -47,11 +47,7 @@ run_hover_job(Uri, Line, Character) ->
         task => fun get_docs/2,
         entries => [{Uri, POIs}],
         title => <<"Hover">>,
-        on_complete =>
-            fun(HoverResp) ->
-                els_server ! {result, HoverResp, self()},
-                ok
-            end
+        on_complete => fun els_server:register_result/1
     },
     {ok, Pid} = els_background_job:new(Config),
     Pid.

--- a/apps/els_lsp/src/els_inlay_hint_provider.erl
+++ b/apps/els_lsp/src/els_inlay_hint_provider.erl
@@ -1,0 +1,119 @@
+-module(els_inlay_hint_provider).
+
+-behaviour(els_provider).
+
+-export([
+    handle_request/1,
+    options/0
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include("els_lsp.hrl").
+-include_lib("els_core/include/els_core.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%%==============================================================================
+%% els_provider functions
+%%==============================================================================
+-spec handle_request(any()) -> {async, uri(), pid()}.
+handle_request({inlay_hint, Params}) ->
+    #{
+        <<"range">> := Range,
+        <<"textDocument">> := #{<<"uri">> := Uri}
+    } = Params,
+    ?LOG_DEBUG(
+        "Inlay hint provider was called with params: ~p",
+        [Params]
+    ),
+    PoiRange = els_range:to_poi_range(Range),
+    {ok, Job} = run_inlay_hints_job(Uri, PoiRange),
+    {async, Uri, Job}.
+
+-spec options() -> boolean().
+options() ->
+    els_config:get(inlay_hints_enabled).
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+-spec run_inlay_hints_job(uri(), els_poi:poi_range()) -> {ok, pid()}.
+run_inlay_hints_job(Uri, Range) ->
+    Config = #{
+        task => fun get_inlay_hints/2,
+        entries => [{Uri, Range}],
+        title => <<"Inlay Hints">>,
+        on_complete => fun els_server:register_result/1
+    },
+    els_background_job:new(Config).
+
+-spec get_inlay_hints({uri(), els_poi:poi_range()}, any()) ->
+    [inlay_hint()].
+get_inlay_hints({Uri, Range}, _) ->
+    %% Wait for indexing job to finish, so that we have the updated document
+    wait_for_indexing_job(Uri),
+    %% Read the document to get the latest version
+    {ok, [Document]} = els_dt_document:lookup(Uri),
+    %% Fetch all application POIs that are in the given range
+    AppPOIs = els_dt_document:pois_in_range(Document, [application], Range),
+    [
+        arg_hint(ArgRange, ArgName)
+     || #{data := #{args := CallArgs}} = POI <- AppPOIs,
+        #{index := N, name := Name, range := ArgRange} <- CallArgs,
+        #{data := #{args := DefArgs}} <- [definition(Uri, POI)],
+        ArgName <- [arg_name(N, DefArgs)],
+        should_show_arg_hint(Name, ArgName)
+    ].
+
+-spec arg_hint(els_poi:poi_range(), string()) -> inlay_hint().
+arg_hint(#{from := {FromL, FromC}}, ArgName) ->
+    #{
+        position => #{line => FromL - 1, character => FromC - 1},
+        label => unicode:characters_to_binary(ArgName ++ ":"),
+        paddingRight => true,
+        kind => ?INLAY_HINT_KIND_PARAMETER
+    }.
+
+-spec should_show_arg_hint(string() | undefined, string() | undefined) ->
+    boolean().
+should_show_arg_hint(Name, Name) ->
+    false;
+should_show_arg_hint(_Name, undefined) ->
+    false;
+should_show_arg_hint(_Name, _DefArgName) ->
+    true.
+
+-spec wait_for_indexing_job(uri()) -> ok.
+wait_for_indexing_job(Uri) ->
+    %% Add delay to allowing indexing job to finish
+    timer:sleep(10),
+    JobTitles = els_background_job:list_titles(),
+    case lists:member(<<"Indexing ", Uri/binary>>, JobTitles) of
+        false ->
+            %% No indexing job is running, we're ready!
+            ok;
+        true ->
+            %% Indexing job is still running, retry until it finishes
+            wait_for_indexing_job(Uri)
+    end.
+
+-spec arg_name(non_neg_integer(), els_parser:args()) -> string() | undefined.
+arg_name(N, Args) ->
+    #{name := Name0} = lists:nth(N, Args),
+    case Name0 of
+        "_" ++ Name ->
+            Name;
+        Name ->
+            Name
+    end.
+
+-spec definition(uri(), els_poi:poi()) -> els_poi:poi() | error.
+definition(Uri, POI) ->
+    case els_code_navigation:goto_definition(Uri, POI) of
+        {ok, [{_Uri, DefPOI} | _]} ->
+            DefPOI;
+        Err ->
+            ?LOG_INFO("Error: ~p ~p", [Err, POI]),
+            error
+    end.

--- a/apps/els_lsp/src/els_methods.erl
+++ b/apps/els_lsp/src/els_methods.erl
@@ -37,6 +37,7 @@
     workspace_didchangewatchedfiles/2,
     workspace_symbol/2
 ]).
+-export([textdocument_inlayhint/2]).
 
 %%==============================================================================
 %% Includes
@@ -446,6 +447,16 @@ textdocument_preparerename(Params, State) ->
     {response, Response} =
         els_provider:handle_request(Provider, {prepare_rename, Params}),
     {response, Response, State}.
+
+%%==============================================================================
+%% textDocument/inlayHint
+%%=============================================================================
+-spec textdocument_inlayhint(params(), els_server:state()) -> result().
+textdocument_inlayhint(Params, State) ->
+    Provider = els_inlay_hint_provider,
+    {async, Uri, Job} =
+        els_provider:handle_request(Provider, {inlay_hint, Params}),
+    {async, Uri, Job, State}.
 
 %%==============================================================================
 %% textDocument/semanticTokens/full

--- a/apps/els_lsp/src/els_references_provider.erl
+++ b/apps/els_lsp/src/els_references_provider.erl
@@ -48,11 +48,7 @@ run_references_job(Uri, Line, Character) ->
         task => fun get_references/2,
         entries => [{Uri, Line, Character}],
         title => <<"References">>,
-        on_complete =>
-            fun(ReferencesResp) ->
-                els_server ! {result, ReferencesResp, self()},
-                ok
-            end
+        on_complete => fun els_server:register_result/1
     },
     {ok, Pid} = els_background_job:new(Config),
     Pid.

--- a/apps/els_lsp/src/els_server.erl
+++ b/apps/els_lsp/src/els_server.erl
@@ -29,7 +29,9 @@
     set_io_device/1,
     send_notification/2,
     send_request/2,
-    send_response/2
+    send_response/2,
+    register_result/1,
+    register_diagonstics/2
 ]).
 
 %% Testing
@@ -99,6 +101,16 @@ send_request(Method, Params) ->
 -spec send_response(pid(), any()) -> ok.
 send_response(Job, Result) ->
     gen_server:cast(?SERVER, {response, Job, Result}).
+
+-spec register_result(any()) -> ok.
+register_result(Resp) ->
+    els_server ! {result, Resp, self()},
+    ok.
+
+-spec register_diagonstics([els_diagnostics:diagnostic()], pid()) -> ok.
+register_diagonstics(Diagnostics, Job) ->
+    els_server ! {diagnostics, Diagnostics, Job},
+    ok.
 
 %%==============================================================================
 %% Testing

--- a/apps/els_lsp/src/els_signature_help_provider.erl
+++ b/apps/els_lsp/src/els_signature_help_provider.erl
@@ -171,7 +171,7 @@ signature_item(Module, #{data := #{args := Args}, id := {Function, Arity}}) ->
     #{
         documentation => els_markup_content:new(DocEntries),
         label => label(Function, Args),
-        parameters => [#{label => els_utils:to_binary(Name)} || {_Index, Name} <- Args]
+        parameters => [#{label => els_utils:to_binary(els_arg:name(Arg))} || Arg <- Args]
     }.
 
 -spec exported_function_pois(atom()) -> [els_poi:poi()].
@@ -196,9 +196,9 @@ exported_function_pois(Module) ->
             []
     end.
 
--spec label(atom(), [tuple()]) -> binary().
+-spec label(atom(), [els_arg:arg()]) -> binary().
 label(Function, Args0) ->
-    ArgList = ["(", string:join([Name || {_Index, Name} <- Args0], ", "), ")"],
+    ArgList = ["(", string:join([els_arg:name(Arg) || Arg <- Args0], ", "), ")"],
     els_utils:to_binary([atom_to_binary(Function, utf8) | ArgList]).
 
 -spec index_where(Predicate, list(), Default) -> non_neg_integer() | Default when

--- a/apps/els_lsp/test/els_call_hierarchy_SUITE.erl
+++ b/apps/els_lsp/test/els_call_hierarchy_SUITE.erl
@@ -71,7 +71,17 @@ incoming_calls(Config) ->
                 #{
                     data =>
                         #{
-                            args => [{1, "Arg1"}],
+                            args => [
+                                #{
+                                    index => 1,
+                                    name => "N",
+                                    range => #{
+                                        from => {9, 12},
+                                        to => {9, 13}
+                                    }
+                                }
+                            ],
+
                             wrapping_range => #{
                                 from => {7, 1},
                                 to => {17, 0}
@@ -121,7 +131,16 @@ incoming_calls(Config) ->
                                     #{
                                         data =>
                                             #{
-                                                args => [{1, "Arg1"}],
+                                                args => [
+                                                    #{
+                                                        index => 1,
+                                                        name => "N",
+                                                        range => #{
+                                                            from => {9, 12},
+                                                            to => {9, 13}
+                                                        }
+                                                    }
+                                                ],
                                                 wrapping_range =>
                                                     #{
                                                         from => {7, 1},
@@ -174,7 +193,16 @@ incoming_calls(Config) ->
                                     #{
                                         data =>
                                             #{
-                                                args => [{1, "Arg1"}],
+                                                args => [
+                                                    #{
+                                                        index => 1,
+                                                        name => "N",
+                                                        range => #{
+                                                            from => {9, 12},
+                                                            to => {9, 13}
+                                                        }
+                                                    }
+                                                ],
                                                 wrapping_range =>
                                                     #{
                                                         from => {7, 1},
@@ -232,7 +260,17 @@ incoming_calls(Config) ->
                 ]
         }
     ],
-    [?assert(lists:member(Call, Result)) || Call <- Calls],
+    lists:map(
+        fun(Call) ->
+            case lists:member(Call, Result) of
+                true ->
+                    ct:comment("Call found: ~p", [Call]);
+                false ->
+                    ct:fail("Call not found: ~p", [Call])
+            end
+        end,
+        Calls
+    ),
     ?assertEqual(length(Calls), length(Result)).
 
 -spec outgoing_calls(config()) -> ok.
@@ -245,7 +283,13 @@ outgoing_calls(Config) ->
             poi =>
                 #{
                     data => #{
-                        args => [{1, "Arg1"}],
+                        args => [
+                            #{
+                                index => 1,
+                                name => "N",
+                                range => #{from => {9, 12}, to => {9, 13}}
+                            }
+                        ],
                         wrapping_range => #{
                             from => {7, 1},
                             to => {17, 0}
@@ -292,7 +336,13 @@ outgoing_calls(Config) ->
                     #{
                         data =>
                             #{
-                                args => [{1, "Arg1"}],
+                                args => [
+                                    #{
+                                        index => 1,
+                                        name => "N",
+                                        range => #{from => {9, 12}, to => {9, 13}}
+                                    }
+                                ],
                                 wrapping_range => #{
                                     from => {7, 1},
                                     to => {17, 0}
@@ -340,7 +390,13 @@ outgoing_calls(Config) ->
                     #{
                         data =>
                             #{
-                                args => [{1, "Arg1"}],
+                                args => [
+                                    #{
+                                        index => 1,
+                                        name => "N",
+                                        range => #{from => {9, 12}, to => {9, 13}}
+                                    }
+                                ],
                                 wrapping_range => #{
                                     from => {7, 1},
                                     to => {14, 0}

--- a/apps/els_lsp/test/els_inlay_hint_SUITE.erl
+++ b/apps/els_lsp/test/els_inlay_hint_SUITE.erl
@@ -1,0 +1,128 @@
+-module(els_inlay_hint_SUITE).
+
+%% CT Callbacks
+-export([
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2,
+    all/0
+]).
+
+%% Test cases
+-export([
+    basic/1
+]).
+
+%%==============================================================================
+%% Includes
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include("els_lsp.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% CT Callbacks
+%%==============================================================================
+-spec suite() -> [tuple()].
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+-spec all() -> [atom()].
+all() ->
+    els_test_utils:all(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+    els_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+    els_test_utils:end_per_suite(Config).
+
+-spec init_per_testcase(atom(), config()) -> config().
+init_per_testcase(TestCase, Config) ->
+    els_test_utils:init_per_testcase(TestCase, Config).
+
+-spec end_per_testcase(atom(), config()) -> ok.
+end_per_testcase(TestCase, Config) ->
+    els_test_utils:end_per_testcase(TestCase, Config),
+    ok.
+
+%%==============================================================================
+%% Testcases
+%%==============================================================================
+-spec basic(config()) -> ok.
+basic(Config) ->
+    Uri = ?config(inlay_hint_uri, Config),
+    Range = #{
+        start => #{line => 0, character => 0},
+        'end' => #{line => 999, character => 0}
+    },
+    #{result := Result} = els_client:inlay_hint(Uri, Range),
+    ?assertEqual(
+        [
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"L1:">>,
+                paddingRight => true,
+                position => #{character => 17, line => 10}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"L2:">>,
+                paddingRight => true,
+                position => #{character => 21, line => 10}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"Foo:">>,
+                paddingRight => true,
+                position => #{character => 6, line => 9}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"Bar:">>,
+                paddingRight => true,
+                position => #{character => 9, line => 9}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"Foo:">>,
+                paddingRight => true,
+                position => #{character => 6, line => 8}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"A:">>,
+                paddingRight => true,
+                position => #{character => 6, line => 7}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"B:">>,
+                paddingRight => true,
+                position => #{character => 9, line => 7}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"Hej:">>,
+                paddingRight => true,
+                position => #{character => 6, line => 6}
+            },
+            #{
+                kind => ?INLAY_HINT_KIND_PARAMETER,
+                label => <<"Hoj:">>,
+                paddingRight => true,
+                position => #{character => 9, line => 6}
+            }
+        ],
+        Result
+    ),
+    ok.


### PR DESCRIPTION
### Description
Argument names in function calls will now show up as inlay hints.

Inlay hints are disabled by default, enable by adding this to config:

    inlay_hints_enabled: true

Additional changes:
* Add functional API to submit job results to els_server (Fixes #1334)
* Improve completions by extracting argument names from spec.
* Improve completions by extracting argument names from all function clauses.
* Gracefully handle parsing of missing header file