### PR TITLE
nifs attribute completion

### DIFF
--- a/apps/els_core/src/els_poi.erl
+++ b/apps/els_core/src/els_poi.erl
@@ -45,6 +45,8 @@
     | include_lib
     | macro
     | module
+    | nifs
+    | nifs_entry
     | parse_transform
     | record
     | record_def_field

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -60,7 +60,8 @@ goto_definition(
 ) when
     Kind =:= application;
     Kind =:= implicit_fun;
-    Kind =:= export_entry
+    Kind =:= export_entry;
+    Kind =:= nifs_entry
 ->
     %% try to find local function first
     %% fall back to bif search if unsuccessful

--- a/apps/els_lsp/src/els_compiler_diagnostics.erl
+++ b/apps/els_lsp/src/els_compiler_diagnostics.erl
@@ -526,6 +526,10 @@ make_code(erl_lint, {bad_dialyzer_option, _Term}) ->
     <<"L1316">>;
 make_code(erl_lint, {format_error, {_Fmt, _Args}}) ->
     <<"L1317">>;
+make_code(erl_lint, {undefined_nif, {_F, _A}}) ->
+    <<"L1318">>;
+make_code(erl_link, no_load_nif) ->
+    <<"L1319">>;
 make_code(erl_lint, _Other) ->
     <<"L1399">>;
 %% stdlib-3.15.2/src/erl_scan.erl

--- a/apps/els_lsp/src/els_completion_provider.erl
+++ b/apps/els_lsp/src/els_completion_provider.erl
@@ -471,6 +471,7 @@ attributes(Document) ->
         snippet(attribute_include),
         snippet(attribute_include_lib),
         snippet(attribute_on_load),
+        snippet(attribute_nifs),
         snippet(attribute_opaque),
         snippet(attribute_record),
         snippet(attribute_type),
@@ -599,6 +600,11 @@ snippet(attribute_on_load) ->
     snippet(
         <<"-on_load().">>,
         <<"on_load(${1:Function}).">>
+    );
+snippet(attribute_nifs) ->
+    snippet(
+        <<"-nifs().">>,
+        <<"nifs([${1:}]).">>
     );
 snippet(attribute_export_type) ->
     snippet(<<"-export_type().">>, <<"export_type([${1:}]).">>);

--- a/apps/els_lsp/src/els_crossref_diagnostics.erl
+++ b/apps/els_lsp/src/els_crossref_diagnostics.erl
@@ -40,7 +40,8 @@ run(Uri) ->
                 application,
                 implicit_fun,
                 import_entry,
-                export_entry
+                export_entry,
+                nifs_entry
             ]),
             [make_diagnostic(POI) || POI <- POIs, not has_definition(POI, Document)]
     end.

--- a/apps/els_lsp/src/els_docs.erl
+++ b/apps/els_lsp/src/els_docs.erl
@@ -54,6 +54,7 @@ docs(Uri, #{kind := Kind, id := {F, A}}) when
     Kind =:= application;
     Kind =:= implicit_fun;
     Kind =:= export_entry;
+    Kind =:= nifs_entry;
     Kind =:= spec
 ->
     M = els_uri:module(Uri),

--- a/apps/els_lsp/src/els_document_highlight_provider.erl
+++ b/apps/els_lsp/src/els_document_highlight_provider.erl
@@ -110,7 +110,8 @@ kind_groups() ->
             application,
             implicit_fun,
             function,
-            export_entry
+            export_entry,
+            nifs_entry
         ],
         %% record
         [

--- a/apps/els_lsp/src/els_dt_references.erl
+++ b/apps/els_lsp/src/els_dt_references.erl
@@ -161,7 +161,8 @@ kind_to_category(Kind) when
     Kind =:= function;
     Kind =:= function_clause;
     Kind =:= import_entry;
-    Kind =:= implicit_fun
+    Kind =:= implicit_fun;
+    Kind =:= nifs_entry
 ->
     function;
 kind_to_category(Kind) when

--- a/apps/els_lsp/src/els_range.erl
+++ b/apps/els_lsp/src/els_range.erl
@@ -36,6 +36,7 @@ in(#{from := FromA, to := ToA}, #{from := FromB, to := ToB}) ->
     els_poi:poi_range().
 range({{_Line, _Column} = From, {_ToLine, _ToColumn} = To}, Name, _, _Data) when
     Name =:= export;
+    Name =:= nifs;
     Name =:= export_type;
     Name =:= spec
 ->

--- a/apps/els_lsp/src/els_references_provider.erl
+++ b/apps/els_lsp/src/els_references_provider.erl
@@ -83,7 +83,8 @@ find_references(Uri, #{
     Kind =:= implicit_fun;
     Kind =:= function;
     Kind =:= export_entry;
-    Kind =:= export_type_entry
+    Kind =:= export_type_entry;
+    Kind =:= nifs_entry
 ->
     Key =
         case Id of

--- a/apps/els_lsp/src/els_rename_provider.erl
+++ b/apps/els_lsp/src/els_rename_provider.erl
@@ -122,7 +122,8 @@ workspace_edits(Uri, [#{kind := Kind} = POI | _], NewName) when
     Kind =:= export_entry;
     Kind =:= import_entry;
     Kind =:= export_type_entry;
-    Kind =:= type_application
+    Kind =:= type_application;
+    Kind =:= nifs_entry
 ->
     case els_code_navigation:goto_definition(Uri, POI) of
         {ok, [{DefUri, DefPOI}]} ->
@@ -205,7 +206,8 @@ editable_range(#{kind := Kind, data := #{name_range := Range}}, function) when
     Kind =:= export_type_entry;
     Kind =:= import_entry;
     Kind =:= type_application;
-    Kind =:= type_definition
+    Kind =:= type_definition,
+    Kind =:= nifs_entry
 ->
     %% application POI of a local call and
     %% type_application POI of a built-in type don't have name_range data
@@ -267,7 +269,8 @@ changes(Uri, #{kind := function, id := {F, A}}, NewName) ->
      || P <- els_dt_document:pois(Doc, [
             export_entry,
             function_clause,
-            spec
+            spec,
+            nifs_entry
         ]),
         IsMatch(P)
     ],

--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -224,6 +224,12 @@ attributes(Config) ->
             insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET,
             kind => ?COMPLETION_ITEM_KIND_SNIPPET,
             label => <<"-module(completion_attributes).">>
+        },
+        #{
+            insertText => <<"nifs([${1:}]).">>,
+            insertTextFormat => ?INSERT_TEXT_FORMAT_SNIPPET,
+            kind => ?COMPLETION_ITEM_KIND_SNIPPET,
+            label => <<"-nifs().">>
         }
     ],
     #{result := Completions} =


### PR DESCRIPTION
### Description

Adds completion for [-nifs attribute](https://www.erlang.org/doc/reference_manual/modules#pre-defined-module-attributes) officially supported from OTP25

EDIT: dont merge yet, I have to fix completion inside "-nifs" attribute to behave similarly as inside "-export"