### PR TITLE
Avoid running get_words twice when opening new file

### DIFF
--- a/apps/els_lsp/src/els_dt_document.erl
+++ b/apps/els_lsp/src/els_dt_document.erl
@@ -304,12 +304,12 @@ find_candidates(Pattern, Kind) ->
 get_words(Text) ->
     case erl_scan:string(els_utils:to_list(Text)) of
         {ok, Tokens, _EndLocation} ->
-            tokens_to_words(Tokens, sets:new());
+            tokens_to_words(Tokens, sets:new([{version, 2}]));
         {error, ErrorInfo, ErrorLocation} ->
             ?LOG_WARNING("Errors while get_words [info=~p] [location=~p]", [
                 ErrorInfo, ErrorLocation
             ]),
-            sets:new()
+            sets:new([{version, 2}])
     end.
 
 -spec tokens_to_words([erl_scan:token()], sets:set()) -> sets:set().

--- a/apps/els_lsp/src/els_text_synchronization.erl
+++ b/apps/els_lsp/src/els_text_synchronization.erl
@@ -55,7 +55,7 @@ did_open(Params) ->
     } = Params,
     Document = els_dt_document:new(Uri, Text, _Source = app, Version),
     els_dt_document:insert(Document),
-    els_indexing:deep_index(Document),
+    els_indexing:deep_index(Document, _UpdateWords = false),
     ok.
 
 -spec did_save(map()) -> ok.
@@ -129,7 +129,7 @@ reload_from_disk(Uri) ->
 background_index(#{uri := Uri} = Document) ->
     Config = #{
         task => fun(Doc, _State) ->
-            els_indexing:deep_index(Doc),
+            els_indexing:deep_index(Doc, _UpdateWords = true),
             ok
         end,
         entries => [Document],


### PR DESCRIPTION
### Description

Small fix to make a small performance improvement when opening a file the first time.
Avoids running get_words twice from did_open, and also makes the set created in get_words use version 2 which is a bit more efficient, supported from OTP24.

On a big file like erlfmt_parse.erl on my computer the time spent went from about 960ms to ~850ms.
