### PR TITLE
Extract argument names from specs

### DIFF
--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -569,12 +569,16 @@ attribute(Tree) ->
 get_spec_args(Tree) ->
     %% Just fetching from the first spec clause for simplicity
     [SpecArg | _] = erl_syntax:list_elements(Tree),
-    case erl_syntax:type(SpecArg) of
+    do_get_spec_args(SpecArg).
+
+-spec do_get_spec_args(tree()) -> args().
+do_get_spec_args(Tree) ->
+    case erl_syntax:type(Tree) of
         constrained_function_type ->
-            %% too complicated to handle now
-            [];
+            Body = erl_syntax:constrained_function_type_body(Tree),
+            do_get_spec_args(Body);
         function_type ->
-            TypeArgs = erl_syntax:function_type_arguments(SpecArg),
+            TypeArgs = erl_syntax:function_type_arguments(Tree),
             args_from_subtrees(TypeArgs);
         _OtherType ->
             []

--- a/apps/els_lsp/test/els_parser_SUITE.erl
+++ b/apps/els_lsp/test/els_parser_SUITE.erl
@@ -40,7 +40,8 @@
     latin1_source_code/1,
     record_comment/1,
     pragma_noformat/1,
-    implicit_fun/1
+    implicit_fun/1,
+    spec_args/1
 ]).
 
 %%==============================================================================
@@ -563,10 +564,25 @@ implicit_fun(_Config) ->
     ),
     ok.
 
+-spec spec_args(config()) -> ok.
+spec_args(_Config) ->
+    ?assertMatch(
+        [#{id := {f, 1}, data := #{args := [#{name := "Foo"}]}}],
+        parse_find_pois("-spec f(Foo :: any()) -> any()).", spec)
+    ),
+    ?assertMatch(
+        [#{id := {f, 1}, data := #{args := [#{name := "Foo"}]}}],
+        parse_find_pois("-spec f(Foo) -> any() when Foo :: any().", spec)
+    ),
+    ok.
+
 %%==============================================================================
 %% Helper functions
 %%==============================================================================
--spec parse_find_pois(string(), els_poi:poi_kind()) -> [els_poi:poi()].
+-spec parse_find_pois(string() | binary(), els_poi:poi_kind()) ->
+    [els_poi:poi()].
+parse_find_pois(Text, Kind) when is_list(Text) ->
+    parse_find_pois(unicode:characters_to_binary(Text), Kind);
 parse_find_pois(Text, Kind) ->
     {ok, POIs} = els_parser:parse(Text),
     SortedPOIs = els_poi:sort(POIs),


### PR DESCRIPTION
### Description

Partial support for this was already added in the inlay hints PR.

Now we also support extracting argument names from specs of this format:

```
-spec member(Elem, List) -> boolean() when
      Elem :: T,
      List :: [T],
      T :: term().
```

Fixes #1362 .
