### PR TITLE
Add inlay hints to show if a function is exported

### DIFF
--- a/apps/els_lsp/test/els_inlay_hint_SUITE.erl
+++ b/apps/els_lsp/test/els_inlay_hint_SUITE.erl
@@ -158,6 +158,12 @@ basic(Config) ->
                 position => #{line => 6, character => 9},
                 kind => ?INLAY_HINT_KIND_PARAMETER,
                 paddingRight => true
+            },
+            #{
+                label => <<"exp">>,
+                position => #{line => 5, character => 0},
+                kind => ?INLAY_HINT_KIND_TYPE,
+                paddingRight => true
             }
         ],
         Result


### PR DESCRIPTION
Each function clause of an exported function is now prefixed by an inlay hint "exp".
