### PR TITLE
Go to definition can now handle lines where parsing fails

### DIFF
--- a/apps/els_core/src/els_text.erl
+++ b/apps/els_core/src/els_text.erl
@@ -11,6 +11,7 @@
     range/3,
     split_at_line/2,
     tokens/1,
+    tokens/2,
     apply_edits/2
 ]).
 -export([strip_comments/1]).
@@ -70,6 +71,27 @@ tokens(Text) ->
         {ok, Tokens, _} -> Tokens;
         {error, _, _} -> []
     end.
+
+-spec tokens(text(), {integer(), integer()}) -> [any()].
+tokens(Text, Pos) ->
+    case erl_scan:string(els_utils:to_list(Text), Pos) of
+        {ok, Tokens, _} ->
+            [unpack_anno(T) || T <- Tokens];
+        {error, _, _} ->
+            []
+    end.
+
+-spec unpack_anno(erl_scan:token()) ->
+    {Category :: atom(), Pos :: {integer(), integer()}, Symbol :: any()}
+    | {Category :: atom(), Pos :: {integer(), integer()}}.
+unpack_anno({Category, Anno, Symbol}) ->
+    Line = erl_anno:line(Anno),
+    Column = erl_anno:column(Anno),
+    {Category, {Line, Column}, Symbol};
+unpack_anno({Category, Anno}) ->
+    Line = erl_anno:line(Anno),
+    Column = erl_anno:column(Anno),
+    {Category, {Line, Column}}.
 
 %% @doc Extract the last token from the given text.
 -spec last_token(text()) -> token() | {error, empty}.

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -144,7 +144,9 @@ goto_definition(Uri, #{kind := callback, id := Id}) ->
 goto_definition(_Filename, _) ->
     {error, not_found}.
 
--spec is_imported_bif(uri(), atom(), non_neg_integer()) -> boolean().
+-spec is_imported_bif(uri(), atom(), non_neg_integer() | any_arity) -> boolean().
+is_imported_bif(_Uri, _F, any_arity) ->
+    false;
 is_imported_bif(_Uri, F, A) ->
     OldBif = erl_internal:old_bif(F, A),
     Bif = erl_internal:bif(F, A),


### PR DESCRIPTION
Use tokens to generate POIs on lines where parsing fails. 
Currently handling call(), module:call(), ?MACRO, #record, atom.