### PR TITLE
Make formatting use in-memory text instead of file content.

### DIFF
--- a/apps/els_lsp/test/els_formatter_SUITE.erl
+++ b/apps/els_lsp/test/els_formatter_SUITE.erl
@@ -73,6 +73,7 @@ format_doc(Config) ->
     try
         file:set_cwd(RootPath),
         Uri = ?config(format_input_uri, Config),
+        ok = els_config:set(formatting, #{}),
         #{result := Result} = els_client:document_formatting(Uri, 8, true),
         ?assertEqual(
             [


### PR DESCRIPTION
### Description

This will make document formatting use the unsaved state of the file.

Fixes #1419  .