### PR TITLE
Fuzzy goto

### DIFF
--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -17,7 +17,7 @@
 %% Includes
 %%==============================================================================
 -include("els_lsp.hrl").
-
+-include_lib("kernel/include/logger.hrl").
 %%==============================================================================
 %% Type definitions
 %%==============================================================================
@@ -204,12 +204,20 @@ find_in_document([Uri | Uris0], Document, Kind, Data, AlreadyVisited) ->
     Defs = [POI || #{id := Id} = POI <- POIs, Id =:= Data],
     {AllDefs, MultipleDefs} =
         case Data of
-            {_, any_arity} when Kind =:= function ->
+            {_, any_arity} when
+                Kind =:= function;
+                Kind =:= define;
+                Kind =:= type_definition
+            ->
+                ?LOG_INFO("uri: ~p", [Uri]),
+                ?LOG_INFO("find in document any arity! ~p ~p", [Kind, Data]),
                 %% Including defs with any arity
                 AnyArity = [
                     POI
-                 || #{id := {F, _}} = POI <- POIs, Kind =:= function, Data =:= {F, any_arity}
+                 || #{id := {F, _}} = POI <- POIs,
+                    Data =:= {F, any_arity}
                 ],
+                ?LOG_INFO("any arity: ~p", [AnyArity]),
                 {AnyArity, true};
             _ ->
                 {Defs, false}

--- a/apps/els_lsp/src/els_code_navigation.erl
+++ b/apps/els_lsp/src/els_code_navigation.erl
@@ -17,7 +17,7 @@
 %% Includes
 %%==============================================================================
 -include("els_lsp.hrl").
--include_lib("kernel/include/logger.hrl").
+
 %%==============================================================================
 %% Type definitions
 %%==============================================================================
@@ -209,15 +209,11 @@ find_in_document([Uri | Uris0], Document, Kind, Data, AlreadyVisited) ->
                 Kind =:= define;
                 Kind =:= type_definition
             ->
-                ?LOG_INFO("uri: ~p", [Uri]),
-                ?LOG_INFO("find in document any arity! ~p ~p", [Kind, Data]),
                 %% Including defs with any arity
                 AnyArity = [
                     POI
-                 || #{id := {F, _}} = POI <- POIs,
-                    Data =:= {F, any_arity}
+                 || #{id := {F, _}} = POI <- POIs, Data =:= {F, any_arity}
                 ],
-                ?LOG_INFO("any arity: ~p", [AnyArity]),
                 {AnyArity, true};
             _ ->
                 {Defs, false}
@@ -240,7 +236,8 @@ find_in_document([Uri | Uris0], Document, Kind, Data, AlreadyVisited) ->
             case MultipleDefs of
                 true ->
                     %% This will be the case only when the user tries to
-                    %% navigate to the definition of an atom
+                    %% navigate to the definition of an atom or a
+                    %% function/type/macro of wrong arity.
                     [{Uri, POI} || POI <- SortedDefs];
                 false ->
                     %% In the general case, we return only one def


### PR DESCRIPTION
### Description

If we don't have a precise match, try to find a close match for goto definition, e.g. if we have a(q,w,e) but only a/4 defined jump there.

Fixes #1250 .
