### PR TITLE
Supports parsing macro expansion as a function branch

### DIFF
--- a/apps/els_lsp/src/els_parser.erl
+++ b/apps/els_lsp/src/els_parser.erl
@@ -797,7 +797,13 @@ analyze_function(FunName, Clauses0) ->
 
 -spec function_args(tree()) -> {arity(), els_arg:args()}.
 function_args(Clause) ->
-    Patterns = erl_syntax:clause_patterns(Clause),
+    Patterns =
+        case Clause of
+            {_, macro, _, _} ->
+                erl_syntax:macro_arguments(Clause);
+            _ ->
+                erl_syntax:clause_patterns(Clause)
+        end,
     Arity = length(Patterns),
     Args = args_from_subtrees(Patterns),
     {Arity, Args}.


### PR DESCRIPTION
example:

macro:
` 
-define(UNHANDLE_CASE(INFO),
    do_handle_cast({cts_cmd, CallBack, Args}) ->
        common_cmd:commandCallBack, Args})
).

`

function:
`
do_handle_cast({quit_family, RoleID}) ->
    ok;

?UNHANDLE_CASE(Msg).
`
