### PR TITLE
els_completion_SUITE/exported_types: add io_server to OTP 27

### DIFF
--- a/apps/els_lsp/test/els_completion_SUITE.erl
+++ b/apps/els_lsp/test/els_completion_SUITE.erl
@@ -711,6 +711,7 @@ exported_types(Config) ->
             <<"filename_all">>,
             <<"io_device">>
         ] ++
+            [<<"io_server">> || OtpRelease >= 27] ++
             [<<"location">> || OtpRelease >= 26] ++
             [
                 <<"mode">>,


### PR DESCRIPTION
### Description

When trying to build against OTP 27 in nixpkgs, I discovered this failing test case. This patch fixes our build, and succeeds in GitHub Actions against my fork. Why this isn't failing in the main repo CI, I couldn't determine.