### PR TITLE
crossref error for cannot find function export

### DIFF
--- a/apps/els_core/src/els_text.erl
+++ b/apps/els_core/src/els_text.erl
@@ -200,5 +200,5 @@ line_starts(Text) ->
 -spec pos([{integer(), any()}], {line_num(), column_num()}) ->
     pos_integer().
 pos(LineStarts, {LineNum, ColumnNum}) ->
-    {LinePos, _} = lists:nth(LineNum, LineStarts),
+    {LinePos, _} = lists:nth(min(length(LineStarts), LineNum), LineStarts),
     LinePos + ColumnNum.

--- a/apps/els_lsp/src/els_indexing.erl
+++ b/apps/els_lsp/src/els_indexing.erl
@@ -134,10 +134,25 @@ index_signature(M, Text, #{id := {F, A}, range := Range, data := #{args := Args}
         args => Args
     }).
 
+-spec is_export_all([els_poi:poi()]) -> boolean().
+is_export_all([]) ->
+    false;
+is_export_all([#{kind := compile}, #{id := export_all} | _]) ->
+    true;
+is_export_all([_ | T]) ->
+    is_export_all(T).
+
 -spec index_functions(atom(), uri(), [els_poi:poi()], version()) -> ok.
 index_functions(M, Uri, POIs, Version) ->
     ok = els_dt_functions:versioned_delete_by_uri(Uri, Version),
-    [index_function(M, POI, Version) || #{kind := function} = POI <- POIs],
+    Fkind =
+        case is_export_all(POIs) of
+            true ->
+                function;
+            false ->
+                export_entry
+        end,
+    [index_function(M, POI, Version) || #{kind := Kind} = POI <- POIs, Kind =:= Fkind],
     ok.
 
 -spec index_function(atom(), els_poi:poi(), version()) -> ok.


### PR DESCRIPTION
### Description

If you call a function that is not exported, crossref provides an error message


