### PR TITLE
Fix document index on Windows platform (#1411)

### DIFF
--- a/apps/els_core/src/els_uri.erl
+++ b/apps/els_core/src/els_uri.erl
@@ -85,7 +85,7 @@ uri(Path) ->
                 {H, uri_join(T)};
             {true, _} ->
                 % Strip the trailing slash from the first component
-                H1 = string:slice(Head, 0, 2),
+                H1 = percent_encoding(string:slice(Head, 0, 2)),
                 {<<>>, uri_join([H1 | Tail])}
         end,
 
@@ -96,6 +96,15 @@ uri(Path) ->
             path => [$/, Path1]
         })
     ).
+
+-spec percent_encoding(iodata()) -> iodata().
+-if(?OTP_RELEASE >= 25).
+percent_encoding(Data) ->
+    uri_string:quote(Data).
+-else.
+percent_encoding(Data) ->
+    http_uri:encode(Data).
+-endif.
 
 -spec uri_join([path()]) -> iolist().
 uri_join(List) ->


### PR DESCRIPTION
### Description

On Windows platform, the index of the module is saved as like "file:///d:/..." initially. After modify the file, re-indexing will use the URI percent encoding like "file:///d%3A/..." that cause the module cannot find the right URI by index.

Fixes #1411 .
